### PR TITLE
DT-1612: Acquia CLI failing to upload SSH public key to Acquia Cloud

### DIFF
--- a/src/Command/Ssh/SshKeyUploadCommand.php
+++ b/src/Command/Ssh/SshKeyUploadCommand.php
@@ -99,12 +99,12 @@ class SshKeyUploadCommand extends SshKeyCommandBase {
 
     // Add a spinner.
     if ($this->useSpinner()) {
-      $spinner = new Spinner();
+      $spinner = new Spinner($this->output, 4);
       $loop->addPeriodicTimer($spinner->interval(),
         static function () use ($spinner) {
-          $spinner->spin();
+          $spinner->advance();
         });
-      $spinner->begin();
+      $spinner->start();
     }
 
     // Poll Cloud every 5 seconds.
@@ -129,7 +129,7 @@ class SshKeyUploadCommand extends SshKeyCommandBase {
     $loop->run();
 
     if ($this->useSpinner()) {
-      $spinner->end();
+      $spinner->finish();
     }
   }
 


### PR DESCRIPTION
Fixes 4 PHP fatal errors

```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Acquia\Ads\Output\Spinner\Spinner::__construct(), 0 passed in /home/anavarre/Git/acquia/cli/src/Command/Ssh/SshKeyUploadCommand.php on line 102 and at least 1 expected in /home/anavarre/Git/acquia/cli/src/Output/Spinner/Spinner.php:102
```

```
PHP Fatal error:  Uncaught Error: Call to undefined method Acquia\Ads\Output\Spinner\Spinner::begin() in /home/anavarre/Git/acquia/cli/src/Command/Ssh/SshKeyUploadCommand.php:107
```

```
PHP Fatal error:  Uncaught Error: Call to undefined method Acquia\Ads\Output\Spinner\Spinner::spin() in /home/anavarre/Git/acquia/cli/src/Command/Ssh/SshKeyUploadCommand.php:105
```

```
PHP Fatal error:  Uncaught Error: Call to undefined method Acquia\Ads\Output\Spinner\Spinner::end() in /home/anavarre/Git/acquia/cli/src/Command/Ssh/SshKeyUploadCommand.php:132
```

New output isn't great because there's no message, but at least it works.

```
$ acli ssh-key:upload
Choose a local SSH key to upload to Acquia Cloud:
  [0] id_rsa.pub
  [1] yubikey-ssh.pub
  [2] sshtest.pub
 > 2
Please enter a Acquia Cloud label for this SSH key: sshtest8
Uploaded sshtest.pub to Acquia Cloud with label sshtest8
    ⠛ %message%

Your SSH key is ready for use.
    ✔ %message%
```