### PR TITLE
DT-1611: Fixed test namespaces.

### DIFF
--- a/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acquia\Ads\Tests\Ssh;
+namespace Acquia\Ads\Tests\Commands\Ssh;
 
 use Acquia\Ads\Command\Ssh\SshKeyDeleteCommand;
 use Acquia\Ads\Tests\CommandTestBase;

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acquia\Ads\Tests\Ssh;
+namespace Acquia\Ads\Tests\Commands\Ssh;
 
 use Acquia\Ads\Command\Ssh\SshKeyListCommand;
 use Acquia\Ads\Tests\CommandTestBase;

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acquia\Ads\Tests\Ssh;
+namespace Acquia\Ads\Tests\Commands\Ssh;
 
 use Acquia\Ads\Command\Ssh\SshKeyCreateCommand;
 use Acquia\Ads\Command\Ssh\SshKeyCreateUploadCommand;


### PR DESCRIPTION
@grasmash when you add new tests be sure to check that the namespace is correct, otherwise users get warnings on the next `composer install`. Unfortunately it's not easy to catch this with automated tests since there are so many other warnings on `composer install` related to Composer 2 deprecations.