### PR TITLE
Fix local tests (unreadable tmp dirs).

### DIFF
--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -19,7 +19,7 @@ abstract class SshKeyCommandBase extends CommandBase {
    */
   protected function findLocalSshKeys() {
     $finder = new Finder();
-    $finder->files()->in($this->getSshKeysDir())->name('*.pub');
+    $finder->files()->in($this->getSshKeysDir())->name('*.pub')->ignoreUnreadableDirs();
     $local_keys = iterator_to_array($finder);
 
     return $local_keys;

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -317,7 +317,7 @@ abstract class CommandTestBase extends TestCase {
    */
   protected function createLocalSshKey($contents): string {
     $finder = new Finder();
-    $finder->files()->in(sys_get_temp_dir())->name('*.pub');
+    $finder->files()->in(sys_get_temp_dir())->name('*.pub')->ignoreUnreadableDirs();
     $this->fs->remove($finder->files());
     $temp_file_name = $this->fs->tempnam(sys_get_temp_dir(), 'acli') . '.pub';
     $this->fs->dumpFile($temp_file_name, $contents);


### PR DESCRIPTION
Tests fail on my local because `/tmp` contains dirs that my user can't read, causing Finder to barf unless it's explicitly told to ignore these.