### PR TITLE
Fixed datastore bug.

### DIFF
--- a/src/Helpers/CloudApiDataStoreAwareTrait.php
+++ b/src/Helpers/CloudApiDataStoreAwareTrait.php
@@ -13,20 +13,20 @@ trait CloudApiDataStoreAwareTrait {
   /**
    * @var KeyValueStore
    */
-  protected $datastore;
+  protected $cloudApiDatastore;
 
   /**
    * @return KeyValueStore
    */
   public function getCloudApiDatastore() {
-    return $this->datastore;
+    return $this->cloudApiDatastore;
   }
 
   /**
    * @param KeyValueStore $datastore
    */
   public function setCloudApiDatastore(KeyValueStore $datastore): void {
-    $this->datastore = $datastore;
+    $this->cloudApiDatastore = $datastore;
   }
 
 }


### PR DESCRIPTION
The cloud datastore (`cloud_api.conf`) and ACLI datastore were clobbering each other because the traits had the same property name.