### PR TITLE
DT-1606: Fix browser not found on Linux.

### DIFF
--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -39,7 +39,7 @@ class LocalMachineHelper {
    * @return bool
    */
   public function commandExists($command): bool {
-    $os_command = OsInfo::isWindows() ? ['where', $command] : ['command', '-v', $command];
+    $os_command = OsInfo::isWindows() ? ['where', $command] : ['which', $command];
         // phpcs:ignore
         return $this->execute($os_command, NULL, NULL, FALSE)->isSuccessful();
   }


### PR DESCRIPTION
This one is a little tricky.

We try to use `command -v` to find commands on *nix. `command` is a shell built-in. By default, Symfony Process runs commands using `exec`, which itself is a builtin and basically runs outside the context of any shell, and thus does _not_ allow you to run other builtins such as `command`. That's why this was failing.

Our choices then are:

1. Switch to using a non-builtin command such as `which` to find commands. That's what I've done here. This means that commands _will not_ be found if they are e.g. shell aliases or built-ins. I think that's appropriate, since when Symfony _actually_ runs the given command, it will be via `exec` and thus will not be able to find aliases or built-ins at runtime either.
2) Switch to running processes via `fromShellCommandline()`. This is just a hunch, I haven't tried to see if it will work. This would support the running of built-ins and aliases via Symfony Process, but I have no idea what the side effects might be, so I'm hesitant to switch.