### PR TITLE
Improve telemetry test coverage.

### DIFF
--- a/bin/acli
+++ b/bin/acli
@@ -35,6 +35,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Webmozart\PathUtil\Path;
+use Zumba\Amplitude\Amplitude;
 
 $pharPath = Phar::running(TRUE);
 if ($pharPath) {
@@ -49,11 +50,12 @@ $input = new ArgvInput($_SERVER['argv']);
 $output = new ConsoleOutput();
 $logger = new ConsoleLogger($output);
 $repo_root = find_repo_root();
+$amplitude = Amplitude::getInstance();
 
 /**
  * Running Acquia CLI.
  */
-$application = new AcquiaCliApplication($logger, $input, $output, $repo_root, '@package_version@');
+$application = new AcquiaCliApplication($logger, $input, $output, $repo_root, $amplitude, '@package_version@');
 $application->addCommands([
   new AliasesDownloadCommand(),
   new AliasListCommand(),

--- a/src/AcquiaCliApplication.php
+++ b/src/AcquiaCliApplication.php
@@ -55,7 +55,7 @@ class AcquiaCliApplication extends Application implements LoggerAwareInterface {
   /**
    * @var \Zumba\Amplitude\Amplitude
    */
-  public $amplitude;
+  private $amplitude;
 
   /**
    * @var string
@@ -99,6 +99,7 @@ class AcquiaCliApplication extends Application implements LoggerAwareInterface {
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    * @param $repo_root
    *
+   * @param \Zumba\Amplitude\Amplitude $amplitude
    * @param string $version
    *
    * @param null $data_dir
@@ -110,6 +111,7 @@ class AcquiaCliApplication extends Application implements LoggerAwareInterface {
         InputInterface $input,
         OutputInterface $output,
         $repo_root,
+        $amplitude,
         string $version = 'UNKNOWN',
         $data_dir = NULL
     ) {
@@ -123,6 +125,7 @@ class AcquiaCliApplication extends Application implements LoggerAwareInterface {
     $this->dataDir = $data_dir ? $data_dir : $this->getLocalMachineHelper()->getHomeDir() . '/.acquia';
     $this->setDatastore(new JsonFileStore($this->getAcliConfigFilepath()));
     $this->setCloudApiDatastore(new JsonFileStore($this->getCloudConfigFilepath(), JsonFileStore::NO_SERIALIZE_STRINGS));
+    $this->amplitude = $amplitude;
     $this->initializeAmplitude();
 
     // Add API commands.
@@ -185,10 +188,11 @@ class AcquiaCliApplication extends Application implements LoggerAwareInterface {
    * Initializes Amplitude.
    */
   private function initializeAmplitude() {
-    $this->amplitude = Amplitude::getInstance();
-    $this->amplitude->init('956516c74386447a3148c2cc36013ac3')
-      ->setDeviceId(OsInfo::uuid())
-      ->setUserProperties($this->getTelemetryUserData());
+    $this->amplitude->init('956516c74386447a3148c2cc36013ac3');
+    // Method chaining breaks Prophecy?
+    // @see https://github.com/phpspec/prophecy/issues/25
+    $this->amplitude->setDeviceId(OsInfo::uuid());
+    $this->amplitude->setUserProperties($this->getTelemetryUserData());
     try {
       $this->amplitude->setUserId($this->getUserId());
     } catch (IdentityProviderException $e) {

--- a/tests/phpunit/src/AcquiaCliApplicationTest.php
+++ b/tests/phpunit/src/AcquiaCliApplicationTest.php
@@ -2,15 +2,21 @@
 
 namespace Acquia\Cli\Tests;
 
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Prophecy\Argument;
 use Zumba\Amplitude\Amplitude;
 
 class AcquiaCliApplicationTest extends TestBase {
 
   public function testRun(): void {
-    $amplitude = $this->prophet->prophesize(Amplitude::class);
-    $this->application->amplitude = $amplitude->reveal();
-    $amplitude->queueEvent('Ran command', Argument::type('array'))->shouldBeCalled();
+    $this->amplitudeProphecy->queueEvent('Ran command', Argument::type('array'))->shouldBeCalled();
+    $this->amplitudeProphecy->init('956516c74386447a3148c2cc36013ac3')->shouldBeCalled();
+    $this->amplitudeProphecy->setDeviceId(Argument::type('string'))->shouldBeCalled();
+    $this->amplitudeProphecy->setOptOut(TRUE)->shouldBeCalled();
+    $this->amplitudeProphecy->logQueuedEvents()->shouldBeCalled();
+    // Ensure problems with telemetry reporting are handled silently.
+    // This doesn't seem to actually trigger code coverage of the exception catch, why?
+    $this->amplitudeProphecy->setUserId()->willThrow(new IdentityProviderException('test', 1, 'test'));
     $exit_code = $this->application->run($this->input, $this->consoleOutput);
     $this->assertEquals(0, $exit_code);
     $this->prophet->checkPredictions();

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
+use Zumba\Amplitude\Amplitude;
 
 /**
  * Class CommandTestBase.
@@ -59,6 +60,8 @@ abstract class TestBase extends TestCase {
    */
   protected $input;
 
+  protected $amplitudeProphecy;
+
   /**
    * This method is called before each test.
    * @throws \Psr\Cache\InvalidArgumentException
@@ -76,7 +79,8 @@ abstract class TestBase extends TestCase {
     $this->fixtureDir = realpath(__DIR__ . '/../../fixtures');
     $this->projectFixtureDir = $this->fixtureDir . '/project';
     $repo_root = $this->projectFixtureDir;
-    $this->application = new AcquiaCliApplication($logger, $this->input, $output, $repo_root, 'UNKNOWN', $this->fixtureDir . '/.acquia');
+    $this->amplitudeProphecy = $this->prophet->prophesize(Amplitude::class);
+    $this->application = new AcquiaCliApplication($logger, $this->input, $output, $repo_root, $this->amplitudeProphecy->reveal(), 'UNKNOWN', $this->fixtureDir . '/.acquia');
     $this->removeMockConfigFiles();
     $this->createMockConfigFile();
 


### PR DESCRIPTION
Feedback welcome, complex tests with mocking aren't my strong suit. I don't think you can easily mock a static class like `Amplitude`, but we can treat it as a property and swap it out during tests that way. It's not full-on service injection but it gets the job done.