### PR TITLE
DT-1608: Unhelpful error using ide:open when no ide exists.

### DIFF
--- a/src/Command/Ide/IdeCommandBase.php
+++ b/src/Command/Ide/IdeCommandBase.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Command\Ide;
 
 use Acquia\Cli\Command\CommandBase;
+use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Endpoints\Ides;
 use AcquiaCloudApi\Response\IdeResponse;
 
@@ -15,7 +16,7 @@ abstract class IdeCommandBase extends CommandBase {
    * @param string $question_text
    * @param \AcquiaCloudApi\Endpoints\Ides $ides_resource
    *
-   * @return \AcquiaCloudApi\Response\IdeResponse|null
+   * @return \AcquiaCloudApi\Response\IdeResponse
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   protected function promptIdeChoice(
@@ -24,7 +25,12 @@ abstract class IdeCommandBase extends CommandBase {
     $cloud_application_uuid
   ): ?IdeResponse {
     $ides = iterator_to_array($ides_resource->getAll($cloud_application_uuid));
-    return $this->promptChooseFromObjects($ides, 'uuid', 'label', $question_text);
+    if (empty($ides)) {
+      throw new AcquiaCliException('No IDEs exist for this application.');
+    }
+    /** @var IdeResponse $ide_response */
+    $ide_response = $this->promptChooseFromObjects($ides, 'uuid', 'label', $question_text);
+    return $ide_response;
   }
 
 }


### PR DESCRIPTION
As a follow-up, we might want to improve the application prompt to only show applications that actually have IDEs available, and/or indicate the number of IDEs for each app. Although this will incur more network requests.

Regardless, the current approach is necessary in case an application with no IDEs is linked to the current directory.