### PR TITLE
Fix spurious errors in local tests.

### DIFF
--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -16,7 +16,7 @@ abstract class SshKeyCommandBase extends CommandBase {
    */
   protected function findLocalSshKeys(): array {
     $finder = $this->getApplication()->getLocalMachineHelper()->getFinder();
-    $finder->files()->in($this->getApplication()->getSshKeysDir())->name('*.pub');
+    $finder->files()->in($this->getApplication()->getSshKeysDir())->name('*.pub')->ignoreUnreadableDirs();
     return iterator_to_array($finder);
   }
 


### PR DESCRIPTION
Tests will fail if the `/tmp` directory contains unreadable files, as often happens locally. We should just ignore them.