### PR TITLE
Fix travis test failures due to missing ssh-agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ jobs:
 
 before_install:
   - composer selfupdate
+  # Tests for the SSH key commands rely on ssh-agent running.
+  - eval "$(ssh-agent -s)"
 
 install:
   # Load composer dependencies.


### PR DESCRIPTION
When we made the repo public, Travis CI [stopped injecting SSH keys](https://docs.travis-ci.com/user/private-dependencies/#user-key) into the build container. This in turn caused the ssh-agent not to start, so we need to [start it ourselves](https://github.com/travis-ci/travis-ci/issues/3652).