### PR TITLE
Fix #111: Detect repo root correctly.

### DIFF
--- a/bin/acli
+++ b/bin/acli
@@ -22,6 +22,7 @@ use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
@@ -74,6 +75,11 @@ if (in_array($input->getFirstArgument(), ['cache:clear', 'cc'])) {
 $kernel->boot();
 $container = $kernel->getContainer();
 putenv("ACLI_REPO_ROOT=" . find_repo_root());
+// Register custom progress bar format.
+ProgressBar::setFormatDefinition(
+  'message',
+  "%current%/%max% [%bar%] <info>%percent:3s%%</info> -- %elapsed:6s%/%estimated:-6s%\n %message%"
+);
 /** @var Application $application */
 $application = $container->get(Application::class);
 $application->setName('Acquia CLI');

--- a/bin/acli
+++ b/bin/acli
@@ -73,6 +73,7 @@ if (in_array($input->getFirstArgument(), ['cache:clear', 'cc'])) {
 
 $kernel->boot();
 $container = $kernel->getContainer();
+putenv("ACLI_REPO_ROOT=" . find_repo_root());
 /** @var Application $application */
 $application = $container->get(Application::class);
 $application->setName('Acquia CLI');
@@ -93,3 +94,80 @@ $dispatcher->addListener(ConsoleEvents::ERROR, function (ConsoleErrorEvent $even
 $application->setDispatcher($dispatcher);
 
 $application->run();
+
+/**
+ * Finds the root directory for the repository.
+ *
+ * @return null|string
+ *   Root.
+ */
+function find_repo_root() {
+  $possible_repo_roots = [
+    getcwd(),
+  ];
+  // Check for PWD - some local environments will not have this key.
+  if (isset($_SERVER['PWD']) && !in_array($_SERVER['PWD'], $possible_repo_roots, TRUE)) {
+    array_unshift($possible_repo_roots, $_SERVER['PWD']);
+  }
+  foreach ($possible_repo_roots as $possible_repo_root) {
+    if ($repo_root = find_directory_containing_files($possible_repo_root, ['docroot/index.php'])) {
+      return realpath($repo_root);
+    }
+  }
+
+  return NULL;
+}
+
+/**
+ * Traverses file system upwards in search of a given file.
+ *
+ * Begins searching for $file in $working_directory and climbs up directories
+ * $max_height times, repeating search.
+ *
+ * @param string $working_directory
+ *   Working directory.
+ * @param array $files
+ *   Files.
+ * @param int $max_height
+ *   Max Height.
+ *
+ * @return bool|string
+ *   FALSE if file was not found. Otherwise, the directory path containing the
+ *   file.
+ */
+function find_directory_containing_files($working_directory, array $files, $max_height = 10) {
+  // Find the root directory of the git repository containing BLT.
+  // We traverse the file tree upwards $max_height times until we find
+  // vendor/bin/blt.
+  $file_path = $working_directory;
+  for ($i = 0; $i <= $max_height; $i++) {
+    if (files_exist($file_path, $files)) {
+      return $file_path;
+    }
+
+    $file_path = dirname($file_path) . '';
+  }
+
+  return FALSE;
+}
+
+/**
+ * Determines if an array of files exist in a particular directory.
+ *
+ * @param string $dir
+ *   Dir.
+ * @param array $files
+ *   Files.
+ *
+ * @return bool
+ *   Exists.
+ */
+function files_exist($dir, array $files) {
+  foreach ($files as $file) {
+    if (file_exists(Path::join($dir, $file))) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}

--- a/config/services.yml
+++ b/config/services.yml
@@ -1,6 +1,6 @@
 ---
 parameters:
-  env(ACLI_DATA_DIR): "%env(HOME)%"
+  env(ACLI_REPO_ROOT): "%kernel.project_dir%"
   app.data_dir: "%env(HOME)%/.acquia"
   app.repo_root: "%env(ACLI_REPO_ROOT)%"
   app.ssh_dir: "%env(HOME)%/.ssh"

--- a/config/services.yml
+++ b/config/services.yml
@@ -2,6 +2,7 @@
 parameters:
   env(ACLI_DATA_DIR): "%env(HOME)%"
   app.data_dir: "%env(HOME)%/.acquia"
+  app.repo_root: "%env(ACLI_REPO_ROOT)%"
   app.ssh_dir: "%env(HOME)%/.ssh"
   app.acli_config_filename: 'acquia-cli.json'
   app.cloud_config_filename: 'cloud_api.conf'
@@ -16,7 +17,8 @@ services:
     bind:
       $cloudConfigFilepath: '%app.cloud_config_filepath%'
       $acliConfigFilename: '%app.acli_config_filename%'
-      $repoRoot: "%kernel.project_dir%"
+      # This should be root directory of the repository where acli is being invoked (not the root of acli itself).
+      $repoRoot: "%app.repo_root%"
       $sshDir: "%app.ssh_dir%"
       Webmozart\KeyValueStore\JsonFileStore $datastoreCloud: '@datastore.cloud'
       Webmozart\KeyValueStore\JsonFileStore $datastoreAcli: '@datastore.acli'


### PR DESCRIPTION
After getting a release out, we should refactor find_repo_root to be a static method, maybe on LocalMachineHelper, and add unit tests.

Also then set it using an Expression in services.yml rather than via the acli bin.

Generally, we need to get stuff out of the acli bin so we can test it. Almost all of the instability following the DI conversion is due to stuff in there.