### PR TITLE
Set user agent string

### DIFF
--- a/src/Command/Api/ApiCommandBase.php
+++ b/src/Command/Api/ApiCommandBase.php
@@ -48,6 +48,7 @@ class ApiCommandBase extends CommandBase {
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
+   * @throws \Exception
    */
   protected function initialize(InputInterface $input, OutputInterface $output) {
     parent::initialize($input, $output);
@@ -87,6 +88,8 @@ class ApiCommandBase extends CommandBase {
     }
 
     $path = $this->getRequestPath($input);
+    $user_agent = sprintf("acli/%s", $this->getApplication()->getVersion());
+    $acquia_cloud_client->addOption('headers', ['User-Agent' => $user_agent]);
     $response = $acquia_cloud_client->request($this->method, $path);
     // @todo Add syntax highlighting to json output.
     $contents = json_encode($response, JSON_PRETTY_PRINT);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -182,6 +182,7 @@ abstract class TestBase extends TestCase {
     $this->cloudDatastore = new JsonFileStore($this->cloudConfigFilepath, 1);
     $this->amplitudeProphecy = $this->prophet->prophesize(Amplitude::class);
     $this->clientProphecy = $this->prophet->prophesize(Client::class);
+    $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN'])->shouldBeCalled();
     $this->localMachineHelper = new LocalMachineHelper($this->input, $output, $logger);
     $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
     $this->clientServiceProphecy->getClient()->willReturn($this->clientProphecy->reveal());

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -182,7 +182,7 @@ abstract class TestBase extends TestCase {
     $this->cloudDatastore = new JsonFileStore($this->cloudConfigFilepath, 1);
     $this->amplitudeProphecy = $this->prophet->prophesize(Amplitude::class);
     $this->clientProphecy = $this->prophet->prophesize(Client::class);
-    $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN']);
+    $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN'])->willReturn();
     $this->localMachineHelper = new LocalMachineHelper($this->input, $output, $logger);
     $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
     $this->clientServiceProphecy->getClient()->willReturn($this->clientProphecy->reveal());

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -182,7 +182,7 @@ abstract class TestBase extends TestCase {
     $this->cloudDatastore = new JsonFileStore($this->cloudConfigFilepath, 1);
     $this->amplitudeProphecy = $this->prophet->prophesize(Amplitude::class);
     $this->clientProphecy = $this->prophet->prophesize(Client::class);
-    $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN'])->shouldBeCalled();
+    $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN']);
     $this->localMachineHelper = new LocalMachineHelper($this->input, $output, $logger);
     $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
     $this->clientServiceProphecy->getClient()->willReturn($this->clientProphecy->reveal());


### PR DESCRIPTION
I've confirmed this shows up in Sumo Logic as "acli/@package_version@" (with a real version for a phar release)

Also talking about setting a default user agent for the SDK: https://github.com/typhonius/acquia-php-sdk-v2/issues/73