### PR TITLE
Cannot run on Windows

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -3,7 +3,6 @@ parameters:
   env(ACLI_REPO_ROOT): "%kernel.project_dir%"
   app.data_dir: "%env(HOME)%/.acquia"
   app.repo_root: "%env(ACLI_REPO_ROOT)%"
-  app.ssh_dir: "%env(HOME)%/.ssh"
   app.acli_config_filename: 'acquia-cli.json'
   app.cloud_config_filename: 'cloud_api.conf'
   app.acli_config_filepath: "%app.data_dir%/%app.acli_config_filename%"
@@ -18,7 +17,6 @@ services:
       $acliConfigFilename: '%app.acli_config_filename%'
       # This should be root directory of the repository where acli is being invoked (not the root of acli itself).
       $repoRoot: "%app.repo_root%"
-      $sshDir: "%app.ssh_dir%"
       Webmozart\KeyValueStore\JsonFileStore $datastoreCloud: '@datastore.cloud'
       Webmozart\KeyValueStore\JsonFileStore $datastoreAcli: '@datastore.acli'
     public: true

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -115,8 +115,7 @@ class ApiCommandHelper {
     string $repoRoot,
     ClientService $cloudApiClientService,
     LogstreamManager $logstreamManager,
-    SshHelper $sshHelper,
-    string $sshDir
+    SshHelper $sshHelper
   ) {
     $this->cloudConfigFilepath = $cloudConfigFilepath;
     $this->localMachineHelper = $localMachineHelper;
@@ -129,7 +128,7 @@ class ApiCommandHelper {
     $this->cloudApiClientService = $cloudApiClientService;
     $this->logstreamManager = $logstreamManager;
     $this->sshHelper = $sshHelper;
-    $this->sshDir = $sshDir;
+    $this->sshDir = $localMachineHelper->getSshDir();
   }
 
   /**
@@ -482,7 +481,7 @@ class ApiCommandHelper {
         $command_name = 'api:' . $schema['x-cli-name'];
         $command = new ApiCommandBase($this->cloudConfigFilepath, $this->localMachineHelper, $this->datastoreCloud,
           $this->acliDatastore, $this->telemetryHelper, $this->amplitude, $this->acliConfigFilename, $this->repoRoot,
-          $this->cloudApiClientService, $this->logstreamManager, $this->sshHelper, $this->sshDir);
+          $this->cloudApiClientService, $this->logstreamManager, $this->sshHelper);
         $command->setName($command_name);
         $command->setDescription($schema['summary']);
         $command->setMethod($method);

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -154,8 +154,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     string $repoRoot,
     ClientService $cloudApiClientService,
     LogstreamManager $logstreamManager,
-    SshHelper $sshHelper,
-    string $sshDir
+    SshHelper $sshHelper
   ) {
     $this->cloudConfigFilepath = $cloudConfigFilepath;
     $this->localMachineHelper = $localMachineHelper;
@@ -168,7 +167,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->cloudApiClientService = $cloudApiClientService;
     $this->logstreamManager = $logstreamManager;
     $this->sshHelper = $sshHelper;
-    $this->sshDir = $sshDir;
+    $this->sshDir = $localMachineHelper->getSshDir();
     parent::__construct();
   }
 

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -25,7 +25,6 @@ class LocalMachineHelper {
   private $input;
   private $isTty = NULL;
   private $homeDir;
-  private $sshDir;
 
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
@@ -37,7 +36,6 @@ class LocalMachineHelper {
     $this->output = $output;
     $this->setLogger($logger);
     $this->homeDir = $this->doGetHomeDir();
-    $this->sshDir = $this->doGetSshDir();
   }
 
   /**
@@ -230,14 +228,6 @@ class LocalMachineHelper {
     $this->homeDir = $homeDir;
   }
 
-  public function setSshDir(string $sshDir): void {
-    $this->sshDir = $sshDir;
-  }
-
-  public function getSshDir(): string {
-    return $this->sshDir;
-  }
-
   /**
    * Returns the appropriate home directory.
    *
@@ -262,7 +252,7 @@ class LocalMachineHelper {
     return $home;
   }
 
-  private function doGetSshDir(): string {
+  public function getSshDir(): string {
     return $this->getHomeDir() . '/.ssh';
   }
 

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -24,6 +24,8 @@ class LocalMachineHelper {
   private $output;
   private $input;
   private $isTty = NULL;
+  private $homeDir;
+  private $sshDir;
 
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
@@ -34,6 +36,8 @@ class LocalMachineHelper {
     $this->input = $input;
     $this->output = $output;
     $this->setLogger($logger);
+    $this->homeDir = $this->doGetHomeDir();
+    $this->sshDir = $this->doGetSshDir();
   }
 
   /**
@@ -198,7 +202,7 @@ class LocalMachineHelper {
    * @return string
    */
   private function fixFilename($filename): string {
-    return str_replace('~', self::getHomeDir(), $filename);
+    return str_replace('~', $this->getHomeDir(), $filename);
   }
 
   /**
@@ -216,6 +220,22 @@ class LocalMachineHelper {
     return $process;
   }
 
+  public function getHomeDir(): string {
+    return $this->homeDir;
+  }
+
+  public function setHomeDir(string $homeDir): void {
+    $this->homeDir = $homeDir;
+  }
+
+  public function setSshDir(string $sshDir): void {
+    $this->sshDir = $sshDir;
+  }
+
+  public function getSshDir(): string {
+    return $this->sshDir;
+  }
+
   /**
    * Returns the appropriate home directory.
    *
@@ -225,7 +245,7 @@ class LocalMachineHelper {
    * @author Ed Reel <@uberhacker>
    * @url https://github.com/uberhacker/tpm
    */
-  public static function getHomeDir(): string {
+  private function doGetHomeDir(): string {
     $home = getenv('HOME');
     if (!$home) {
       $system = '';
@@ -238,6 +258,10 @@ class LocalMachineHelper {
     }
 
     return $home;
+  }
+
+  private function doGetSshDir(): string {
+    return $this->getHomeDir() . '/.ssh';
   }
 
   /**

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -194,8 +194,7 @@ class ApiCommandTest extends CommandTestBase {
       $this->projectFixtureDir,
       $this->clientServiceProphecy->reveal(),
       $this->logStreamManagerProphecy->reveal(),
-      $this->sshHelper,
-      $this->sshDir
+      $this->sshHelper
     );
     $api_commands = $api_command_helper->getApiCommands();
     foreach ($api_commands as $api_command) {

--- a/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
@@ -22,8 +22,7 @@ class ApiListCommandTest extends CommandTestBase {
       $this->projectFixtureDir,
       $this->clientServiceProphecy->reveal(),
       $this->logStreamManagerProphecy->reveal(),
-      $this->sshHelper,
-      $this->sshDir
+      $this->sshHelper
     );
     $this->application->addCommands($api_command_helper->getApiCommands());
   }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyCreateCommandTest.php
@@ -26,7 +26,7 @@ class SshKeyCreateCommandTest extends CommandTestBase {
    */
   public function testCreate(): void {
     $ssh_key_filename = 'id_rsa_acli_test';
-    $ssh_key_filepath = Path::join($this->sshDir, '/' . $ssh_key_filename);
+    $ssh_key_filepath = Path::join($this->sshDir, $ssh_key_filename);
     $this->fs->remove($ssh_key_filepath);
 
     $inputs = [

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -61,7 +61,7 @@ class SshKeyUploadCommandTest extends CommandTestBase
       // Label
       'Test'
     ];
-    $filepath = Path::join(sys_get_temp_dir(), 'notarealfile');
+    $filepath = Path::join($this->sshDir, 'notarealfile');
     $args = ['--filepath' => $filepath];
     try {
       $this->executeCommand($args, $inputs);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -174,7 +174,7 @@ abstract class TestBase extends TestCase {
     $this->projectFixtureDir = $this->fixtureDir . '/project';
     $this->acliRepoRoot = $this->projectFixtureDir;
     $this->dataDir = $this->fixtureDir . '/.acquia';
-    $this->sshDir = sys_get_temp_dir();
+    $this->sshDir = $this->fixtureDir . '/.ssh';
     $this->acliConfigFilename = 'acquia-cli.json';
     $this->cloudConfigFilepath = $this->dataDir . '/cloud_api.conf';
     $this->acliConfigFilepath = $this->dataDir . '/' . $this->acliConfigFilename;
@@ -185,7 +185,6 @@ abstract class TestBase extends TestCase {
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN']);
     $this->localMachineHelper = new LocalMachineHelper($this->input, $output, $logger);
     $this->localMachineHelper->setHomeDir($this->fixtureDir);
-    $this->localMachineHelper->setSshDir($this->sshDir);
     $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
     $this->clientServiceProphecy->getClient()->willReturn($this->clientProphecy->reveal());
     $this->telemetryHelper = new TelemetryHelper($this->input, $output, $this->clientServiceProphecy->reveal(), $this->acliDatastore, $this->cloudDatastore);
@@ -370,9 +369,9 @@ abstract class TestBase extends TestCase {
    */
   protected function createLocalSshKey($contents): string {
     $finder = new Finder();
-    $finder->files()->in(sys_get_temp_dir())->name('*.pub')->ignoreUnreadableDirs();
+    $finder->files()->in($this->sshDir)->name('*.pub')->ignoreUnreadableDirs();
     $this->fs->remove($finder->files());
-    $private_key_filepath = $this->fs->tempnam(sys_get_temp_dir(), 'acli');
+    $private_key_filepath = $this->fs->tempnam($this->sshDir, 'acli');
     $this->fs->touch($private_key_filepath);
     $public_key_filepath = $private_key_filepath . '.pub';
     $this->fs->dumpFile($public_key_filepath, $contents);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -184,6 +184,8 @@ abstract class TestBase extends TestCase {
     $this->clientProphecy = $this->prophet->prophesize(Client::class);
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN'])->willReturn();
     $this->localMachineHelper = new LocalMachineHelper($this->input, $output, $logger);
+    $this->localMachineHelper->setHomeDir($this->fixtureDir);
+    $this->localMachineHelper->setSshDir($this->sshDir);
     $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
     $this->clientServiceProphecy->getClient()->willReturn($this->clientProphecy->reveal());
     $this->telemetryHelper = new TelemetryHelper($this->input, $output, $this->clientServiceProphecy->reveal(), $this->acliDatastore, $this->cloudDatastore);


### PR DESCRIPTION
This is just a start. It converts the sshDir, but we need to convert nearly _all_ of the parameters (anything that depends on `$_ENV['HOME']`). I'm not sure how to feel about this approach. Reducing the number of service parameters / dependencies injected is good I think. Feels weird to kill all parameter though.

The reason this is so complicated: we use the home directory in our parameters to set other things like the data and ssh dirs, but HOME isn't set on Windows, it's some other variable. You can't use expressions in parameters, they have to be static, so we can't dynamically set the home directory.

I think we'll need to strip out most of the parameters and convert them into methods on the LocalMachineHelper, and then pass the LocalMachineHelper as a service and call its methods to get the values instead of getting them as parameters.

Alternatively, we might be able to bind these paths instead of setting them as parameters. That would involve a lot less refactoring. But the static methods can't be tested as easily, we'd need new tests.