### PR TITLE
Fix #218: Self-update errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,16 @@ composer install
 
 Be sure to validate and test your code locally using the provided Composer test scripts (`composer test`) before opening a PR.
 
+### Testing the `update` command
+
+Any changes to the `acli update` command should be manually tested using the following steps:
+
+1. Replace `@package_version@` on this line with `v1.0.0-rc4` or any older version string: https://github.com/acquia/cli/blob/v1.0.0-rc5/bin/acli#L87
+2. Clear and rebuild your Symfony cache: `./bin/acli cache:clear && ./bin/acli`
+4. Install Box if you haven't already: `composer box-install`
+5. Compile phar: `composer box-compile`
+6. Now test: `./build/acli.phar update --allow-unstable`
+
 ## Updating Acquia Cloud API spec
 
 Acquia CLI stores a local copy of the Acquia Cloud API spec in the `assets` directory. To update the Acquia Cloud API spec, run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Any changes to the `acli update` command should be manually tested using the fol
 
 1. Replace `@package_version@` on this line with `v1.0.0-rc4` or any older version string: https://github.com/acquia/cli/blob/v1.0.0-rc5/bin/acli#L87
 2. Clear and rebuild your Symfony cache: `./bin/acli cache:clear && ./bin/acli`
-4. Install Box if you haven't already: `composer box-install`
+4. Install Box if you haven't already: `composer box-install && composer dump-env prod`
 5. Compile phar: `composer box-compile`
 6. Now test: `./build/acli.phar update --allow-unstable`
 

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -71,15 +71,14 @@ class UpdateCommand extends CommandBase {
         $new = $updater->getNewVersion();
         $old = $updater->getOldVersion();
         $output->writeln("<info>Updated from $old to $new</info>");
-        // This is a bit of a hack. But, we suppress errors to avoid any type of error based on post replace
-        // code execution. @see https://github.com/acquia/cli/issues/169
-        // phpcs:ignore
-        error_reporting(0);
+        // Exit immediately to avoid loading additional classes.
+        // @see https://github.com/acquia/cli/issues/218
+        exit(0);
       }
       else {
         $output->writeln('<comment>No update needed.</comment>');
+        return 0;
       }
-      return 0;
     } catch (Exception $e) {
       $output->writeln("<error>{$e->getMessage()}</error>");
       return 1;


### PR DESCRIPTION
Fix #218 

This error occurs when any class is lazy-loaded after the update runs. The simplest solution is to immediately terminate the script after an update.

An alternative solution would be to preload telemetry classes so that telemetry reports during successful self-update commands. But that gets a little hairy: we risk this bug recurring if we introduce any new classes and forget to preload them as well.