### PR TITLE
Fix #219: Enforce PHP version requirements

### DIFF
--- a/box.json
+++ b/box.json
@@ -16,6 +16,5 @@
     "output": "build/acli.phar",
     "git-version": "package_version",
     "exclude-composer-files": false,
-    "force-autodiscovery": true,
-    "check-requirements": false
+    "force-autodiscovery": true
 }

--- a/box.json.md
+++ b/box.json.md
@@ -4,7 +4,7 @@ box.json is largely based on the template provided here: https://github.com/humb
 
 This particular configuration is necessary to support Symfony Console. Specifically:
 - Must include composer files, since Symfony uses these to determine the root directory
-- Must force autodisovery and disable requirements checks, for good (but unknown) reasons
-- Must force include of config and var directories
+- Must force autodisovery, since Symfony won't be able to find service classes otherwise
+- Must force include of config and var directories, since Symfony uses these for cache and config
 
 See also: https://github.com/humbug/box/blob/master/doc/symfony.md


### PR DESCRIPTION
Fix #219

I don't know exactly why we disabled requirement checking originally. I think just because "that's what the Symfony template did".

I tested and this seems to work fine with requirements checking in place.

Note that previously you _could_ run _parts_ of ACLI with PHP 7.2 or without the php-json extension installed, and only certain commands would fail. Now you will not be able to run ACLI at all under those conditions.