### PR TITLE
Fix #234: self-update command aborts tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ jobs:
         - cmd.exe //c "RefreshEnv.cmd"
         # Emulate RefreshEnv to pick up new bin paths in Git Bash (the native Travis CI shell).
         - eval $(powershell -NonInteractive -Command 'write("export PATH=`"" + ([Environment]::GetEnvironmentVariable("PATH","Machine") + ";" + [Environment]::GetEnvironmentVariable("PATH","User")).replace("\","/").replace("C:","/c").replace(";",":") + ":`$PATH`"")')
-      # Coveralls results get polluted by Windows builds, disable reporting.
-      after_success: skip
     - stage: "Build packages for CLI"
       if: tag IS present
       install: composer install --no-dev --optimize-autoloader && composer box-install
@@ -65,6 +63,6 @@ install:
 
 script:
   - composer test
-
-after_success:
-  - ./vendor/bin/php-coveralls -vvv
+  # Run coveralls here instead of after_success because it should break the build if it fails to report.
+  # Disable Coveralls reporting on Windows, which pollutes results.
+  - if [ $TRAVIS_TEST_RESULT -eq 0 ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then composer coveralls; fi

--- a/bin/acli
+++ b/bin/acli
@@ -32,6 +32,8 @@ if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
 set_time_limit(0);
 
 $loader = require dirname(__DIR__).'/vendor/autoload.php';
+// We must pre-load this class to prevent self-update command from breaking.
+// @see https://github.com/acquia/cli/issues/234
 $loader->loadClass('Symfony\Component\Console\Event\ConsoleTerminateEvent');
 
 $input = new ArgvInput();

--- a/bin/acli
+++ b/bin/acli
@@ -19,7 +19,6 @@ namespace Acquia\Cli;
 use Acquia\Cli\Command\Api\ApiCommandHelper;
 use Acquia\Cli\Helpers\LocalMachineHelper;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
@@ -32,7 +31,8 @@ if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
 
 set_time_limit(0);
 
-require dirname(__DIR__).'/vendor/autoload.php';
+$loader = require dirname(__DIR__).'/vendor/autoload.php';
+$loader->loadClass('Symfony\Component\Console\Event\ConsoleTerminateEvent');
 
 $input = new ArgvInput();
 if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {

--- a/composer.json
+++ b/composer.json
@@ -118,6 +118,9 @@
       "@lint",
       "@cs",
       "@unit"
+    ],
+    "coveralls": [
+      "php-coveralls -vvv"
     ]
   }
 }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -248,6 +248,11 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    */
   public function run(InputInterface $input, OutputInterface $output) {
     $exit_code = parent::run($input, $output);
+    if ($exit_code === 0 && in_array($input->getFirstArgument(), ['self-update', 'update'])) {
+      // Exit immediately to avoid loading additional classes breaking updates.
+      // @see https://github.com/acquia/cli/issues/218
+      return $exit_code;
+    }
     $event_properties = [
       'exit_code' => $exit_code,
       'arguments' => $input->getArguments(),

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -71,14 +71,11 @@ class UpdateCommand extends CommandBase {
         $new = $updater->getNewVersion();
         $old = $updater->getOldVersion();
         $output->writeln("<info>Updated from $old to $new</info>");
-        // Exit immediately to avoid loading additional classes.
-        // @see https://github.com/acquia/cli/issues/218
-        exit(0);
       }
       else {
         $output->writeln('<comment>No update needed.</comment>');
-        return 0;
       }
+      return 0;
     } catch (Exception $e) {
       $output->writeln("<error>{$e->getMessage()}</error>");
       return 1;


### PR DESCRIPTION
Fix #234 

### Background
According to the [humbug/phar-updater docs](https://github.com/humbug/phar-updater#avoid-post-update-file-includes), we need to do one of two things to avoid post-update errors:
1. Exit immediately after updating
2. Pre-load any classes that might be used after updating

We chose to exit immediately in #220, which is simple and safe (for the end user) but unfortunately breaks PHPUnit tests.

### The fix
This PR takes the approach of exiting as soon as possible (though not immediately, since we can't force Symfony to quit any sooner than this), and pre-loading classes that we know Symfony needs before it exits. It's kind of ugly but unavoidable.

### Alternatives
The only other solutions I can think of, even uglier I think:
- Stop testing for successful self-updates
- Use a mockable class to exit the command instead of calling `exit` directly
- In the update command, detect when PHPUnit is running and don't exit in that case

### Manual testing
Follow the [process in CONTRIBUTING.md](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#testing-the-update-command)