### PR TITLE
Fix #227: Errors refreshing ACSF site

### DIFF
--- a/src/Command/RefreshCommand.php
+++ b/src/Command/RefreshCommand.php
@@ -572,7 +572,7 @@ class RefreshCommand extends CommandBase {
   protected function getAcsfSites($cloud_environment): array {
     $sitegroup = self::getSiteGroupFromSshUrl($cloud_environment);
     $command = ['cat', "/var/www/site-php/$sitegroup.{$cloud_environment->name}/multisite-config.json"];
-    $process = $this->sshHelper->executeCommand($cloud_environment, $command);
+    $process = $this->sshHelper->executeCommand($cloud_environment, $command, FALSE);
     if ($process->isSuccessful()) {
       return json_decode($process->getOutput(), TRUE);
     }

--- a/tests/phpunit/src/Commands/RefreshCommandTest.php
+++ b/tests/phpunit/src/Commands/RefreshCommandTest.php
@@ -93,7 +93,7 @@ class RefreshCommandTest extends CommandTestBase {
         ))
       ->shouldBeCalled();
     $ssh_helper = $this->prophet->prophesize(SshHelper::class);
-    $ssh_helper->executeCommand(Argument::type('object'), ['cat', '/var/www/site-php/site.dev/multisite-config.json'])
+    $ssh_helper->executeCommand(Argument::type('object'), ['cat', '/var/www/site-php/site.dev/multisite-config.json'], FALSE)
       ->willReturn($acsf_multisite_fetch_process->reveal())
       ->shouldBeCalled();
     $process = $this->mockProcess();


### PR DESCRIPTION
Fixes #227  
--------

Motivation
----------
#227 describes an error when running `acli refresh` for ACSF sites. I believe this to be a regression caused by https://github.com/acquia/cli/pull/74 . This caused SSH command output to be printed to the screen, which apparently also prevents `$process->getOutput()` from capturing it.

Proposed changes
---------
Suppress SSH command output, so it can be captured programmatically. This is ideal for the human (who doesn't need to see a bunch of gobbledygook), and also fixes the error.

Alternatives considered
---------
- Change the default for [SshHelper::executeCommand()](https://github.com/acquia/cli/blob/v1.0.0-rc6/src/Helpers/SshHelper.php#L40) to _not_ print output. @joazvsoares @imnetworku do you have an opinion on this? Most places in the code that call `SshHelper::executeCommand()` set print_output to FALSE, should we make FALSE the default?
- Change the SSH process to both print and capture output. Might be useful at some point, but not right now.

Testing steps
---------
Run `acli refresh` on an ACSF application and verify that the error does not recur.