### PR TITLE
Fix #247: Rename api:environments:update --version parameter

### DIFF
--- a/src/Command/Api/ApiCommandBase.php
+++ b/src/Command/Api/ApiCommandBase.php
@@ -7,14 +7,7 @@ use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Exception\ApiErrorException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Validator\Constraints\Length;
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Regex;
-use Symfony\Component\Validator\Constraints\Uuid;
-use Symfony\Component\Validator\Constraints\UuidValidator;
-use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Exception\ValidatorException;
-use Symfony\Component\Validator\Validation;
 
 /**
  * Class ApiCommandBase.

--- a/src/Command/Api/ApiCommandBase.php
+++ b/src/Command/Api/ApiCommandBase.php
@@ -91,6 +91,9 @@ class ApiCommandBase extends CommandBase {
     if ($this->postParams) {
       foreach ($this->postParams as $param_name) {
         $param = $this->getParamFromInput($input, $param_name);
+        if ($param_name == 'lang_version') {
+          $param_name = 'version';
+        }
         $acquia_cloud_client->addOption('form_params', [$param_name => $param]);
       }
     }

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -223,7 +223,7 @@ class ApiCommandHelper {
     if (array_key_exists('requestBody', $schema)) {
       [$body_input_definition, $request_body_param_usage_suffix] = $this->addApiCommandParametersForRequestBody($schema, $acquia_cloud_spec);
       /** @var \Symfony\Component\Console\Input\InputOption|InputArgument $parameter_definition */
-      foreach ($body_input_definition as $index => $parameter_definition) {
+      foreach ($body_input_definition as $parameter_definition) {
         $command->addPostParameter($parameter_definition->getName());
       }
       $usage .= $request_body_param_usage_suffix;

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -224,10 +224,6 @@ class ApiCommandHelper {
       [$body_input_definition, $request_body_param_usage_suffix] = $this->addApiCommandParametersForRequestBody($schema, $acquia_cloud_spec);
       /** @var \Symfony\Component\Console\Input\InputOption|InputArgument $parameter_definition */
       foreach ($body_input_definition as $index => $parameter_definition) {
-        // Remove API parameters that conflict with CLI parameters.
-        if ($parameter_definition->getName() == 'version') {
-          unset($body_input_definition[$index]);
-        }
         $command->addPostParameter($parameter_definition->getName());
       }
       $usage .= $request_body_param_usage_suffix;
@@ -269,6 +265,9 @@ class ApiCommandHelper {
     }
     foreach ($request_body_schema['properties'] as $prop_key => $param_definition) {
       $is_required = array_key_exists('required', $request_body_schema) && in_array($prop_key, $request_body_schema['required'], TRUE);
+      if ($prop_key == 'version') {
+        $prop_key = 'lang_version';
+      }
       if ($is_required) {
         $input_definition[] = new InputArgument(
           $prop_key,

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -223,7 +223,11 @@ class ApiCommandHelper {
     if (array_key_exists('requestBody', $schema)) {
       [$body_input_definition, $request_body_param_usage_suffix] = $this->addApiCommandParametersForRequestBody($schema, $acquia_cloud_spec);
       /** @var \Symfony\Component\Console\Input\InputOption|InputArgument $parameter_definition */
-      foreach ($body_input_definition as $parameter_definition) {
+      foreach ($body_input_definition as $index => $parameter_definition) {
+        // Remove API parameters that conflict with CLI parameters.
+        if ($parameter_definition->getName() == 'version') {
+          unset($body_input_definition[$index]);
+        }
         $command->addPostParameter($parameter_definition->getName());
       }
       $usage .= $request_body_param_usage_suffix;


### PR DESCRIPTION
Fixes #247 
--------

Motivation
----------
See #247. Running `acli help api:environments:update` results in an error because version is defined both via the CLI and API.

Proposed changes
---------
This renames the API `--version` to `--lang_version`.

Alternatives considered
---------
If this becomes a pattern with other parameters, we might want a full translation layer that renames conflicting parameters either automatically (if it detects a conflict) or statically (based on hardcoded mappings). Or at least use a constant utility class between the API command base and helper.

Testing steps
---------
- Run `acli cache:clear`
- Run `acli help api:environments:update`.
@eporama if you're comfortable running dev builds, you're welcome to test.