### PR TITLE
DX-2334: Indicate when errors come from Cloud API

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -17,6 +17,10 @@ class ExceptionListener
       $event->setError(new AcquiaCliException('Your Cloud API credentials are invalid. Run acli auth:login to reset them.',
         [], $exitCode));
     }
+
+    if ($error instanceof \AcquiaCloudApi\Exception\ApiErrorException) {
+      $event->setError(new AcquiaCliException('Acquia Cloud Platform API returned an error: ' . $error->getMessage(), [], $exitCode));
+    }
   }
 
 }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\EventListener;
 
 use Acquia\Cli\Exception\AcquiaCliException;
+use AcquiaCloudApi\Exception\ApiErrorException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 
@@ -18,7 +19,7 @@ class ExceptionListener
         [], $exitCode));
     }
 
-    if ($error instanceof \AcquiaCloudApi\Exception\ApiErrorException) {
+    if ($error instanceof ApiErrorException) {
       $event->setError(new AcquiaCliException('Acquia Cloud Platform API returned an error: ' . $error->getMessage(), [], $exitCode));
     }
   }


### PR DESCRIPTION
Motivation
----------
When the Acquia Cloud SDK throws an exception because the API returned an error, it _looks_ like the error is coming from Acquia CLI. This leads to support requests directed to Acquia CLI that really should be directed to Cloud API.

Proposed changes
---------
Prepend the exception with more informative text. Before and after:
![Screenshot from 2020-09-23 16-54-27](https://user-images.githubusercontent.com/1984514/94085732-bd03a380-fdbd-11ea-884f-7d547abac4b4.png)
![Screenshot from 2020-09-23 16-52-42](https://user-images.githubusercontent.com/1984514/94085733-bd9c3a00-fdbd-11ea-9d3a-e7b2c579cd4f.png)

Alternatives considered
---------
Instead of modifying the exception we could:
- Add text outside of the exception instead of modifying it. This is less cluttered but perhaps also visible. and/or:
- Exit cleanly without throwing an exception at all (but still returning a non-zero exit code) so it's a little less scary.

Testing steps
---------
`./bin/acli ide:create --cloud-app-uuid 2ed281d4-9dec-4cc3-ac63-691c3ba002ca` (this is an invalid UUID)

@grasmash was concerned about corrupting the JSON output but I don't think that's relevant here, since this is an exception that wouldn't have returned clean JSON in the first place. Also let me know what you think about the coverage decrease. This is ugly to test because we'd have to mock the application and kernel, rather than a single command, and it would be largely redundant because we already have a test for the exception listener as a whole.