### PR TITLE
DX-2482 | Fix to clear client query filter

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -931,6 +931,9 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
     $this->logger->debug("Found application matching $drush_site. Searching environments...");
 
+    // Remove the host=@*.$drush_site query as it would persist for future requests.
+    $acquia_cloud_client->clearQuery();
+
     return $customer_application;
   }
 

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -108,6 +108,7 @@ class ApiCommandTest extends CommandTestBase {
     $this->mockApplicationRequest();
     $this->command = $this->getApiCommandByName('api:applications:find');
     $alias = 'devcloud2';
+    $this->clientProphecy->clearQuery()->shouldBeCalled();
 
     $this->executeCommand(['applicationUuid' => $alias], [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?


### PR DESCRIPTION
Motivation
----------
The filter query for `getApplicationFromAlias` carries through to future client requests in the same execution. It should be removed before proceeding.

Proposed changes
---------
This adds a `clearQuery()` to the script after retrieving the application information

Alternatives considered
---------
Build a separate client connection (too cumbersome)?

Testing steps
---------
```
bin/acli api:applications:database-list <app_name>
```

returns this error before the patch
```
{
    "error": "invalid_filter",
    "message": "Invalid filtering option supplied hosting. Supported filters are: name"
}
``` 
and returns a list of databases for the application after.