### PR TITLE
Accept application and environment aliases.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "authors": [
     {
       "name": "Matthew Grasmick",
-      "email": "matt.grasmick@gmail.com"
+      "email": "matthew.grasmick@acquia.com"
     }
   ],
   "minimum-stability": "dev",

--- a/src/Command/Api/ApiCommandBase.php
+++ b/src/Command/Api/ApiCommandBase.php
@@ -3,12 +3,9 @@
 namespace Acquia\Cli\Command\Api;
 
 use Acquia\Cli\Command\CommandBase;
-use Acquia\Cli\Exception\AcquiaCliException;
-use AcquiaCloudApi\Endpoints\Environments;
 use AcquiaCloudApi\Exception\ApiErrorException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Validator\Exception\ValidatorException;
 
 /**
  * Class ApiCommandBase.
@@ -56,9 +53,6 @@ class ApiCommandBase extends CommandBase {
    */
   protected function initialize(InputInterface $input, OutputInterface $output) {
     parent::initialize($input, $output);
-    $this->convertApplicationAliastoUuid($input);
-    $this->fillMissingApplicationUuid($input, $output);
-    $this->convertEnvironmentAliasToUuid($input);
   }
 
   /**
@@ -215,50 +209,6 @@ class ApiCommandBase extends CommandBase {
       $param = $input->getOption($param_name);
     }
     return $param;
-  }
-
-  /**
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   *
-   * @throws \Exception
-   */
-  protected function fillMissingApplicationUuid(InputInterface $input, OutputInterface $output): void {
-    if ($input->hasArgument('applicationUuid') && !$input->getArgument('applicationUuid')) {
-      $output->writeln('Inferring Cloud Application UUID for this command since none was provided...', OutputInterface::VERBOSITY_VERBOSE);
-      if ($application_uuid = $this->determineCloudApplication()) {
-        $output->writeln("Set application uuid to <options=bold>$application_uuid</>", OutputInterface::VERBOSITY_VERBOSE);
-        $input->setArgument('applicationUuid', $application_uuid);
-      }
-    }
-  }
-
-  /**
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   *
-   * @throws \Acquia\Cli\Exception\AcquiaCliException
-   */
-  protected function convertEnvironmentAliasToUuid(InputInterface $input): void {
-    if ($input->hasArgument('environmentId') && $input->getArgument('environmentId')) {
-      $env_uuid_argument = $input->getArgument('environmentId');
-      try {
-        // Environment IDs take the form of [env-num]-[app-uuid].
-        $uuid_parts = explode('-', $env_uuid_argument);
-        $env_id = $uuid_parts[0];
-        unset($uuid_parts[0]);
-        $application_uuid = implode('-', $uuid_parts);
-        self::validateUuid($application_uuid);
-      } catch (ValidatorException $validator_exception) {
-        try {
-          // Since this isn't a valid environment ID, let's see if it's a valid alias.
-          $this->validateEnvironmentAlias($env_uuid_argument);
-          $environment = $this->getEnvironmentFromAliasArg($env_uuid_argument);
-          $input->setArgument('environmentId', $environment->uuid);
-        } catch (AcquiaCliException $exception) {
-          throw new AcquiaCliException("The {environmentId} must be a valid UUID or site alias.");
-        }
-      }
-    }
   }
 
   /**

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -223,7 +223,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
     $this->loadLocalProjectInfo();
     $this->convertApplicationAliastoUuid($input);
-    $this->fillMissingApplicationUuid($input, $output);
+    $this->fillMissingRequiredApplicationUuid($input, $output);
     $this->convertEnvironmentAliasToUuid($input);
     $this->checkForNewVersion($input, $output);
   }
@@ -1026,7 +1026,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    *
    * @throws \Exception
    */
-  protected function fillMissingApplicationUuid(InputInterface $input, OutputInterface $output): void {
+  protected function fillMissingRequiredApplicationUuid(InputInterface $input, OutputInterface $output): void {
     if ($input->hasArgument('applicationUuid') && !$input->getArgument('applicationUuid') && $this->getDefinition()->getArgument('applicationUuid')->isRequired()) {
       $output->writeln('Inferring Cloud Application UUID for this command since none was provided...', OutputInterface::VERBOSITY_VERBOSE);
       if ($application_uuid = $this->determineCloudApplication()) {
@@ -1048,13 +1048,9 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
         self::validateUuid($application_uuid_argument);
       } catch (ValidatorException $validator_exception) {
         // Since this isn't a valid UUID, let's see if it's a valid alias.
-        try {
-          $alias = $this->normalizeAlias($application_uuid_argument);
-          $customer_application = $this->getApplicationFromAlias($alias);
-          $input->setArgument('applicationUuid', $customer_application->uuid);
-        } catch (AcquiaCliException $exception) {
-          throw new AcquiaCliException("The {applicationUuid} must be a valid UUID or site alias.");
-        }
+        $alias = $this->normalizeAlias($application_uuid_argument);
+        $customer_application = $this->getApplicationFromAlias($alias);
+        $input->setArgument('applicationUuid', $customer_application->uuid);
       }
     }
   }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1027,7 +1027,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @throws \Exception
    */
   protected function fillMissingApplicationUuid(InputInterface $input, OutputInterface $output): void {
-    if ($input->hasArgument('applicationUuid') && !$input->getArgument('applicationUuid')) {
+    if ($input->hasArgument('applicationUuid') && !$input->getArgument('applicationUuid') && $this->getDefinition()->getArgument('applicationUuid')->isRequired()) {
       $output->writeln('Inferring Cloud Application UUID for this command since none was provided...', OutputInterface::VERBOSITY_VERBOSE);
       if ($application_uuid = $this->determineCloudApplication()) {
         $output->writeln("Set application uuid to <options=bold>$application_uuid</>", OutputInterface::VERBOSITY_VERBOSE);

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -608,7 +608,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $environment = $this->promptChooseEnvironment($acquia_cloud_client, $application_uuid);
 
     return $environment->uuid;
-
   }
 
   /**

--- a/src/Command/Ide/IdeCommandBase.php
+++ b/src/Command/Ide/IdeCommandBase.php
@@ -15,18 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class IdeCommandBase extends CommandBase {
 
   /**
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   *
-   * @throws \Acquia\Cli\Exception\AcquiaCliException
-   * @throws \Exception
-   */
-  protected function initialize(InputInterface $input, OutputInterface $output) {
-    parent::initialize($input, $output);
-    $this->convertApplicationAliastoUuid($input);
-  }
-
-  /**
    * @param string $question_text
    * @param \AcquiaCloudApi\Endpoints\Ides $ides_resource
    *

--- a/src/Command/LogTailCommand.php
+++ b/src/Command/LogTailCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Command;
 
 use AcquiaCloudApi\Endpoints\Logs;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,7 +21,7 @@ class LogTailCommand extends CommandBase {
   protected function configure() {
     $this->setDescription('Tail the logs from your environments')
       ->setAliases(['tail'])
-      ->addOption('cloud-env-uuid', 'uuid', InputOption::VALUE_REQUIRED, 'The UUID of the associated Cloud Platform environment');
+      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The Cloud environment UUID or alias.');
   }
 
   /**
@@ -31,13 +32,7 @@ class LogTailCommand extends CommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    if ($input->getOption('cloud-env-uuid')) {
-      $environment_id = $input->getOption('cloud-env-uuid');
-    }
-    else {
-      $application_uuid = $this->determineCloudApplication();
-      $environment_id = $this->determineCloudEnvironment($application_uuid);
-    }
+    $environment_id = $this->determineCloudEnvironment();
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $logs = $this->promptChooseLogs($acquia_cloud_client, $environment_id);
     $log_types = array_map(function ($log) {

--- a/src/Command/RefreshCommand.php
+++ b/src/Command/RefreshCommand.php
@@ -313,6 +313,7 @@ class RefreshCommand extends CommandBase {
   protected function importDatabaseDump($dump_filepath, $db_host, $db_user, $db_name, $db_password, $output_callback = NULL): void {
     // Unfortunately we need to make this a string to prevent the '|' characters from being escaped.
     // @see https://github.com/symfony/symfony/issues/10025.
+    // scp username@remote:/file/to/send /where/to/put
     $command = '';
     if ($this->localMachineHelper->commandExists('pv')) {
       $command .= 'pv ';

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -134,7 +134,7 @@ class ApiCommandTest extends CommandTestBase {
       $this->executeCommand(['applicationUuid' => $alias], []);
     }
     catch (AcquiaCliException $exception) {
-      $this->assertEquals('The {applicationUuid} must be a valid UUID or site alias.', $exception->getMessage());
+      $this->assertEquals('Application not found matching the alias ' . $alias, $exception->getMessage());
     }
     $this->prophet->checkPredictions();
   }
@@ -143,7 +143,6 @@ class ApiCommandTest extends CommandTestBase {
     $applications_response = $this->mockApplicationsRequest();
     $this->clientProphecy->addQuery('filter', 'hosting=@*devcloud2')->shouldBeCalled();
     $this->clientProphecy->clearQuery()->shouldBeCalled();
-    //$this->mockApplicationRequest();
     $this->mockEnvironmentsRequest($applications_response);
 
     $response = $this->getMockResponseFromSpec('/environments/{environmentId}', 'get', '200');

--- a/tests/phpunit/src/Commands/CommandBaseTest.php
+++ b/tests/phpunit/src/Commands/CommandBaseTest.php
@@ -80,9 +80,7 @@ class CommandBaseTest extends CommandTestBase {
    */
   public function testInvalidCloudAppUuidArg($uuid, $message): void {
     try {
-      $this->executeCommand([
-        'applicationUuid' => $uuid,
-      ], []);
+      CommandBase::validateUuid($uuid);
     }
     catch (ValidatorException $e) {
       $this->assertEquals($message, $e->getMessage());

--- a/tests/phpunit/src/Commands/LogTailCommandTest.php
+++ b/tests/phpunit/src/Commands/LogTailCommandTest.php
@@ -33,7 +33,7 @@ class LogTailCommandTest extends CommandTestBase {
     $this->mockEnvironmentsRequest($applications_response);
     $this->mockLogListRequest();
     $this->mockLogStreamRequest();
-    $inputs = [
+    $this->executeCommand([], [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
       'n',
       // Please select the application.
@@ -44,8 +44,7 @@ class LogTailCommandTest extends CommandTestBase {
       0,
       // Select log
       0
-    ];
-    $this->executeCommand([], $inputs);
+    ]);
 
     // Assert.
     $this->prophet->checkPredictions();
@@ -53,6 +52,27 @@ class LogTailCommandTest extends CommandTestBase {
     $this->assertStringContainsString('Please select a Cloud Platform application:', $output);
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('[1] Sample application 2', $output);
+    $this->assertStringContainsString('Apache access', $output);
+    $this->assertStringContainsString('Drupal request', $output);
+  }
+
+  /**
+   * Tests the 'log:tail' commands.
+   *
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function testLogTailCommandWithEnvArg(): void {
+    $this->mockLogListRequest();
+    $this->mockLogStreamRequest();
+    $this->executeCommand(
+      ['environmentId' => '24-a47ac10b-58cc-4372-a567-0e02b2c3d470'],
+      // Select log.
+      [0]
+    );
+
+    // Assert.
+    $this->prophet->checkPredictions();
+    $output = $this->getDisplay();
     $this->assertStringContainsString('Apache access', $output);
     $this->assertStringContainsString('Drupal request', $output);
   }


### PR DESCRIPTION
Functional changes:

* log:tail now accepts aliases like `@eemgrasmick.dev`
* link now accepts aliases like `@eemgrasmick.dev`
* ide:* commands now accept aliases with and without `@` prefix
* remote:aliases:list will now accept an alias for the applicationUuid argument