### PR TITLE
Rename refresh command to pull. Create pull sub command stubs.

### DIFF
--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -41,4 +41,5 @@ class PullCodeCommand extends PullCommandBase {
   protected function execute(InputInterface $input, OutputInterface $output) {
 
   }
+
 }

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Acquia\Cli\Command\Pull;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class PullCodeCommand.
+ */
+class PullCodeCommand extends PullCommandBase {
+
+  protected static $defaultName = 'pull:code';
+
+  /**
+   * @var string
+   */
+  protected $dir;
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure() {
+    $this->setDescription('Copy code from a Cloud Platform environment')
+      ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
+      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
+        'The UUID of the associated Cloud Platform source environment')
+      ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,
+        'Do not run any additional scripts after code and database are copied. E.g., composer install , drush cache-rebuild, etc.');
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return int 0 if everything went fine, or an exit code
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+
+  }
+}

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Acquia\Cli\Command\Pull;
+
+use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\Cli\Output\Checklist;
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class RefreshCommand.
+ */
+class PullCommand extends PullCommandBase {
+
+  protected static $defaultName = 'pull';
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure() {
+    $this->setAliases(['refresh'])
+      ->setDescription('Copy code, database, and files from a Cloud Platform environment')
+      ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
+      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED, 'The UUID of the associated Cloud Platform source environment')
+      ->addOption('no-code', NULL, InputOption::VALUE_NONE, 'Do not refresh code from remote repository')
+      ->addOption('no-files', NULL, InputOption::VALUE_NONE, 'Do not refresh files')
+      ->addOption('no-databases', NULL, InputOption::VALUE_NONE, 'Do not refresh databases')
+      ->addOption(
+            'no-scripts',
+            NULL,
+            InputOption::VALUE_NONE,
+            'Do not run any additional scripts after code and database are copied. E.g., composer install , drush cache-rebuild, etc.'
+        )
+      ->addOption('scripts', NULL, InputOption::VALUE_NONE, 'Only execute additional scripts');
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return int 0 if everything went fine, or an exit code
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->determineDir($input);
+    if ($this->dir !== '/home/ide/project' && AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      throw new AcquiaCliException('Please run this command from the {dir} directory', ['dir' => '/home/ide/project']);
+    }
+
+    $clone = $this->determineCloneProject($output);
+    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    $chosen_environment = $this->determineEnvironment($input, $output, $acquia_cloud_client);
+    $checklist = new Checklist($output);
+    $output_callback = static function ($type, $buffer) use ($checklist, $output) {
+      if (!$output->isVerbose()) {
+        $checklist->updateProgressBar($buffer);
+      }
+      $output->writeln($buffer, OutputInterface::VERBOSITY_VERY_VERBOSE);
+    };
+
+    if (!$input->getOption('no-code')) {
+      if ($clone) {
+        $checklist->addItem('Cloning git repository from the Cloud Platform');
+        $this->cloneFromCloud($chosen_environment, $output_callback);
+        $checklist->completePreviousItem();
+      }
+      else {
+        $checklist->addItem('Pulling code from the Cloud Platform');
+        $this->pullCodeFromCloud($chosen_environment, $output_callback);
+        $checklist->completePreviousItem();
+      }
+    }
+
+    // Copy databases.
+    if (!$input->getOption('no-databases')) {
+      $database = $this->determineSourceDatabase($acquia_cloud_client, $chosen_environment);
+      $checklist->addItem('Importing Drupal database copy from the Cloud Platform');
+      $this->importRemoteDatabase($chosen_environment, $database, $output_callback);
+      $checklist->completePreviousItem();
+    }
+
+    // Copy files.
+    if (!$input->getOption('no-files')) {
+      $checklist->addItem('Copying Drupal\'s public files from the Cloud Platform');
+      $this->rsyncFilesFromCloud($chosen_environment, $output_callback);
+      $checklist->completePreviousItem();
+    }
+
+    if (!$input->getOption('no-scripts')) {
+      if (file_exists($this->dir . '/composer.json') && $this->localMachineHelper
+        ->commandExists('composer')) {
+        $checklist->addItem('Installing Composer dependencies');
+        $this->composerInstall($output_callback);
+        $checklist->completePreviousItem();
+      }
+
+      if ($this->drushHasActiveDatabaseConnection($output_callback)) {
+        // Drush rebuild caches.
+        $checklist->addItem('Clearing Drupal caches via Drush');
+        $this->drushRebuildCaches($output_callback);
+        $checklist->completePreviousItem();
+
+        // Drush sanitize.
+        $checklist->addItem('Sanitizing database via Drush');
+        $this->drushSqlSanitize($output_callback);
+        $checklist->completePreviousItem();
+      }
+    }
+
+    // Match IDE PHP version to source environment PHP version.
+    $this->matchIdePhpVersion($output, $chosen_environment);
+
+    return 0;
+  }
+
+}

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -15,13 +15,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class PullCommand extends PullCommandBase {
 
-  protected static $defaultName = 'pull';
+  protected static $defaultName = 'pull:all';
 
   /**
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setAliases(['refresh'])
+    $this->setAliases(['refresh', 'pull'])
       ->setDescription('Copy code, database, and files from a Cloud Platform environment')
       ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
       ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED, 'The UUID of the associated Cloud Platform source environment')

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Acquia\Cli\Command\Pull;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class PullFilesCommand.
+ */
+class PullDatabaseCommand extends PullCommandBase {
+
+  protected static $defaultName = 'pull:database';
+
+  /**
+   * @var string
+   */
+  protected $dir;
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure() {
+    $this->setDescription('Copy files from a Cloud Platform environment')
+      ->setAliases(['pull:db'])
+      ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
+      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
+        'The UUID of the associated Cloud Platform source environment');
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return int 0 if everything went fine, or an exit code
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+
+  }
+}

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -38,6 +38,7 @@ class PullDatabaseCommand extends PullCommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    
+
   }
+
 }

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -23,7 +23,7 @@ class PullDatabaseCommand extends PullCommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Copy files from a Cloud Platform environment')
+    $this->setDescription('Copy database from a Cloud Platform environment')
       ->setAliases(['pull:db'])
       ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
       ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
@@ -38,6 +38,6 @@ class PullDatabaseCommand extends PullCommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-
+    
   }
 }

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Acquia\Cli\Command\Pull;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class PullFilesCommand.
+ */
+class PullFilesCommand extends PullCommandBase {
+
+  protected static $defaultName = 'pull:files';
+
+  /**
+   * @var string
+   */
+  protected $dir;
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure() {
+    $this->setDescription('Copy files from a Cloud Platform environment')
+      ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
+      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
+        'The UUID of the associated Cloud Platform source environment');
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return int 0 if everything went fine, or an exit code
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+
+  }
+}

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -39,4 +39,5 @@ class PullFilesCommand extends PullCommandBase {
   protected function execute(InputInterface $input, OutputInterface $output) {
 
   }
+
 }

--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -54,12 +54,12 @@ class AliasesDownloadCommand extends SshCommand {
     $this->localMachineHelper->getFilesystem()->mkdir($drush_aliases_dir);
     $this->localMachineHelper->getFilesystem()->chmod($drush_aliases_dir, 0700);
 
+    // @todo Upgrade to Drush 9 aliases and the open from sites subdir, not .drush!
     $archive = new PharData($drush_archive_filepath . '/.drush');
     $drushFiles = [];
     foreach (new RecursiveIteratorIterator($archive, RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
       $drushFiles[] = '.drush/' . $file->getFileName();
     }
-
     $archive->extractTo(dirname($drush_aliases_dir), $drushFiles, TRUE);
     $this->output->writeln(sprintf(
       'Cloud Platform Drush aliases installed into <options=bold>%s</>',

--- a/tests/phpunit/src/Commands/Pull/PullCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTest.php
@@ -1,15 +1,14 @@
 <?php
 
-namespace Acquia\Cli\Tests\Commands;
+namespace Acquia\Cli\Tests\Commands\Pull;
 
 use Acquia\Cli\Command\Ide\IdePhpVersionCommand;
-use Acquia\Cli\Command\RefreshCommand;
+use Acquia\Cli\Command\Pull\PullCommand;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Tests\Commands\Ide\IdeRequiredTestBase;
 use Acquia\Cli\Tests\CommandTestBase;
 use AcquiaCloudApi\Response\EnvironmentResponse;
-use PhpParser\Node\Arg;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Command\Command;
@@ -18,18 +17,18 @@ use Symfony\Component\Process\Process;
 use Webmozart\PathUtil\Path;
 
 /**
- * Class RefreshCommandTest.
+ * Class PullCommandTest.
  *
- * @property \Acquia\Cli\Command\RefreshCommand $command
+ * @property \Acquia\Cli\Command\Pull\PullCommand $command
  * @package Acquia\Cli\Tests\Commands
  */
-class RefreshCommandTest extends CommandTestBase {
+class PullCommandTest extends CommandTestBase {
 
   /**
    * {@inheritdoc}
    */
   protected function createCommand(): Command {
-    return $this->injectCommand(RefreshCommand::class);
+    return $this->injectCommand(PullCommand::class);
   }
 
   public function setUp($output = NULL): void {


### PR DESCRIPTION
No functional changes at all, just a rename of `refresh` to `pull:all` (with aliases to `refresh` and `pull`) and a few new non-functional stubs.

This does prep work for #201, which will introduce `push:*` commands.

![image](https://user-images.githubusercontent.com/539205/95661448-70c69c00-0afd-11eb-8a80-0dce9a781ae5.png)