### PR TITLE
DX-2533: Added confirmation question prompt and default responses

### DIFF
--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -104,7 +104,11 @@ class AuthLoginCommand extends CommandBase {
       $this->validateApiKey($api_secret);
     }
     else {
-      $api_secret = $this->io->askHidden('Please enter your API Secret', \Closure::fromCallable([$this, 'validateApiKey']));
+      $question = new Question('<question>Please enter your API Secret:</question> ');
+      $question->setHidden($this->localMachineHelper->useTty());
+      $question->setHiddenFallback(TRUE);
+      $question->setValidator(\Closure::fromCallable([$this, 'validateApiKey']));
+      $api_secret = $this->questionHelper->ask($input, $output, $question);
     }
 
     return $api_secret;

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -7,7 +7,6 @@ use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
@@ -69,9 +68,7 @@ class AuthLoginCommand extends CommandBase {
       $this->validateApiKey($api_key);
     }
     else {
-      $question = new Question('<question>Please enter your API Key:</question> ');
-      $question->setValidator(\Closure::fromCallable([$this, 'validateApiKey']));
-      $api_key = $this->questionHelper->ask($input, $output, $question);
+      $api_key = $this->io->ask('Please enter your API Key', NULL, \Closure::fromCallable([$this, 'validateApiKey']));
     }
 
     return $api_key;
@@ -107,11 +104,7 @@ class AuthLoginCommand extends CommandBase {
       $this->validateApiKey($api_secret);
     }
     else {
-      $question = new Question('<question>Please enter your API Secret:</question> ');
-      $question->setHidden($this->localMachineHelper->useTty());
-      $question->setHiddenFallback(TRUE);
-      $question->setValidator(\Closure::fromCallable([$this, 'validateApiKey']));
-      $api_secret = $this->questionHelper->ask($input, $output, $question);
+      $api_secret = $this->io->askHidden('Please enter your API Secret', \Closure::fromCallable([$this, 'validateApiKey']));
     }
 
     return $api_secret;

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -7,7 +7,6 @@ use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -42,9 +41,7 @@ class AuthLoginCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output) {
     /** @var \Webmozart\KeyValueStore\JsonFileStore $cloud_datastore */
     if (CommandBase::isMachineAuthenticated($this->datastoreCloud)) {
-      $question = new ConfirmationQuestion('<question>Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?</question> ',
-        TRUE);
-      $answer = $this->questionHelper->ask($this->input, $this->output, $question);
+      $answer = $this->io->confirm('Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?');
       if (!$answer) {
         return 0;
       }
@@ -146,9 +143,7 @@ class AuthLoginCommand extends CommandBase {
       $this->output->writeln("You will need a Cloud Platform API token from <href=$token_url>$token_url</>");
 
       if (!AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
-        $question = new ConfirmationQuestion('<question>Do you want to open this page to generate a token now?</question> ',
-          TRUE);
-        if ($this->questionHelper->ask($input, $output, $question)) {
+        if ($this->io->confirm('Do you want to open this page to generate a token now?')) {
           $this->localMachineHelper->startBrowser($token_url);
         }
       }

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -7,6 +7,7 @@ use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -3,18 +3,8 @@
 namespace Acquia\Cli\Command\Auth;
 
 use Acquia\Cli\Command\CommandBase;
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
-use Closure;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Validator\Constraints\Length;
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Regex;
-use Symfony\Component\Validator\Exception\ValidatorException;
-use Symfony\Component\Validator\Validation;
 
 /**
  * Class AuthLogoutCommand.
@@ -50,9 +40,7 @@ class AuthLogoutCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output) {
     /** @var \Webmozart\KeyValueStore\JsonFileStore $cloud_datastore */
     if (CommandBase::isMachineAuthenticated($this->datastoreCloud)) {
-      $question = new ConfirmationQuestion('<question>Are you sure you\'d like to remove your Cloud Platform API login credentials from this machine?</question> ',
-        TRUE);
-      $answer = $this->questionHelper->ask($this->input, $this->output, $question);
+      $answer = $this->io->confirm('Are you sure you\'d like to remove your Cloud Platform API login credentials from this machine?');
       if (!$answer) {
         return 0;
       }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -66,6 +66,11 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected $output;
 
   /**
+   * @var \Symfony\Component\Console\Style\SymfonyStyle
+   */
+  protected $io;
+
+  /**
    * @var \Symfony\Component\Console\Helper\FormatterHelper*/
   protected $formatter;
 
@@ -214,6 +219,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected function initialize(InputInterface $input, OutputInterface $output) {
     $this->input = $input;
     $this->output = $output;
+    $this->io = new SymfonyStyle($input, $output);
     // Register custom progress bar format.
     ProgressBar::setFormatDefinition(
       'message',
@@ -585,8 +591,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     ): ?ApplicationResponse {
     if ($this->repoRoot) {
       $this->output->writeln("There is no Cloud Platform application linked to <options=bold>{$this->repoRoot}/.git</>.");
-      $io = new SymfonyStyle($this->input, $this->output);
-      $answer = $io->confirm('Would you like Acquia CLI to search for a Cloud application that matches your local git config?');
+      $answer = $this->io->confirm('Would you like Acquia CLI to search for a Cloud application that matches your local git config?');
       if ($answer) {
         $this->output->writeln('Searching for a matching Cloud application...');
         if ($git_config = $this->getGitConfig()) {
@@ -761,8 +766,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected function promptLinkApplication(
     ?ApplicationResponse $cloud_application
     ): bool {
-    $io = new SymfonyStyle($this->input, $this->output);
-    $answer = $io->confirm("Would you like to link the Cloud application <bg=cyan;options=bold>{$cloud_application->name}</> to this repository?");
+    $answer = $this->io->confirm("Would you like to link the Cloud application <bg=cyan;options=bold>{$cloud_application->name}</> to this repository?");
     if ($answer) {
       return $this->saveLocalConfigCloudAppUuid($cloud_application);
     }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -585,8 +585,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     ): ?ApplicationResponse {
     if ($this->repoRoot) {
       $this->output->writeln("There is no Cloud Platform application linked to <options=bold>{$this->repoRoot}/.git</>.");
-      $style = new SymfonyStyle($this->input, $this->output);
-      $answer = $style->confirm('Would you like Acquia CLI to search for a Cloud application that matches your local git config?');
+      $io = new SymfonyStyle($this->input, $this->output);
+      $answer = $io->confirm('Would you like Acquia CLI to search for a Cloud application that matches your local git config?');
       if ($answer) {
         $this->output->writeln('Searching for a matching Cloud application...');
         if ($git_config = $this->getGitConfig()) {
@@ -761,8 +761,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected function promptLinkApplication(
     ?ApplicationResponse $cloud_application
     ): bool {
-    $style = new SymfonyStyle($this->input, $this->output);
-    $answer = $style->confirm("Would you like to link the Cloud application <bg=cyan;options=bold>{$cloud_application->name}</> to this repository?");
+    $io = new SymfonyStyle($this->input, $this->output);
+    $answer = $io->confirm("Would you like to link the Cloud application <bg=cyan;options=bold>{$cloud_application->name}</> to this repository?");
     if ($answer) {
       return $this->saveLocalConfigCloudAppUuid($cloud_application);
     }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -33,7 +33,7 @@ use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -261,8 +261,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     if (!isset($send_telemetry) && $this->input->isInteractive()) {
       $this->output->writeln('We strive to give you the best tools for development.');
       $this->output->writeln('You can really help us improve by sharing anonymous performance and usage data.');
-      $question = new ConfirmationQuestion('<question>Would you like to share anonymous performance usage and data?</question> ', TRUE);
-      $pref = $this->questionHelper->ask($this->input, $this->output, $question);
+      $style = new SymfonyStyle($this->input, $this->output);
+      $pref = $style->confirm('Would you like to share anonymous performance usage and data?');
       $this->acliDatastore->set(DataStoreContract::SEND_TELEMETRY, $pref);
       if ($pref) {
         $this->output->writeln('Awesome! Thank you for helping!');
@@ -585,9 +585,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     ): ?ApplicationResponse {
     if ($this->repoRoot) {
       $this->output->writeln("There is no Cloud Platform application linked to <options=bold>{$this->repoRoot}/.git</>.");
-      $question = new ConfirmationQuestion('<question>Would you like Acquia CLI to search for a Cloud application that matches your local git config?</question> ');
-      $helper = $this->getHelper('question');
-      $answer = $helper->ask($this->input, $this->output, $question);
+      $style = new SymfonyStyle($this->input, $this->output);
+      $answer = $style->confirm('Would you like Acquia CLI to search for a Cloud application that matches your local git config?');
       if ($answer) {
         $this->output->writeln('Searching for a matching Cloud application...');
         if ($git_config = $this->getGitConfig()) {
@@ -762,9 +761,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected function promptLinkApplication(
     ?ApplicationResponse $cloud_application
     ): bool {
-    $question = new ConfirmationQuestion("<question>Would you like to link the Cloud application <bg=cyan;options=bold>{$cloud_application->name}</> to this repository</question>? ");
-    $helper = $this->getHelper('question');
-    $answer = $helper->ask($this->input, $this->output, $question);
+    $style = new SymfonyStyle($this->input, $this->output);
+    $answer = $style->confirm("Would you like to link the Cloud application <bg=cyan;options=bold>{$cloud_application->name}</> to this repository?");
     if ($answer) {
       return $this->saveLocalConfigCloudAppUuid($cloud_application);
     }

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Cli\Command\Ide;
 
-use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Helpers\LoopHelper;
 use Acquia\Cli\Output\Checklist;
 use AcquiaCloudApi\Endpoints\Ides;
@@ -13,9 +12,7 @@ use GuzzleHttp\Client;
 use React\EventLoop\Factory;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
 
 /**
  * Class IdeCreateCommand.
@@ -53,9 +50,7 @@ class IdeCreateCommand extends IdeCommandBase {
     $cloud_application_uuid = $this->determineCloudApplication();
     $this->checklist = new Checklist($output);
 
-    $question = new Question('<question>Please enter a label for your Cloud IDE:</question> ');
-    $helper = $this->getHelper('question');
-    $ide_label = $helper->ask($input, $output, $question);
+    $ide_label = $this->io->ask('Please enter a label for your Cloud IDE');
 
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $ides_resource = new Ides($acquia_cloud_client);

--- a/src/Command/Ide/IdeDeleteCommand.php
+++ b/src/Command/Ide/IdeDeleteCommand.php
@@ -5,9 +5,7 @@ namespace Acquia\Cli\Command\Ide;
 use AcquiaCloudApi\Endpoints\Ides;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Class CreateProjectCommand.
@@ -46,9 +44,7 @@ class IdeDeleteCommand extends IdeCommandBase {
     // Check to see if an SSH key for this IDE exists on Cloud.
     $cloud_key = $this->findIdeSshKeyOnCloud($ide->uuid);
     if ($cloud_key) {
-      $question = new ConfirmationQuestion('<question>Would you like to delete the SSH key associated with this IDE from your Cloud Platform account?</question> ',
-        TRUE);
-      $answer = $this->questionHelper->ask($this->input, $this->output, $question);
+      $answer = $this->io->confirm('Would you like to delete the SSH key associated with this IDE from your Cloud Platform account?');
       if ($answer) {
         $this->deleteSshKeyFromCloud($cloud_key);
       }

--- a/src/Command/NewCommand.php
+++ b/src/Command/NewCommand.php
@@ -39,9 +39,7 @@ class NewCommand extends CommandBase {
       'acquia/drupal-recommended-project',
       'acquia/drupal-minimal-project',
     ];
-    $question = new ChoiceQuestion('<question>Which starting project would you like to use?</question>', $distros);
-    $helper = $this->getHelper('question');
-    $project = $helper->ask($this->input, $this->output, $question);
+    $project = $this->io->choice('Choose a starting project', $distros);
 
     if ($input->hasArgument('directory') && $input->getArgument('directory')) {
       $dir = Path::canonicalize($input->getArgument('directory'));

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -581,9 +580,7 @@ abstract class PullCommandBase extends CommandBase {
 
     $finder = $this->localMachineHelper->getFinder()->files()->in($this->dir)->ignoreDotFiles(FALSE);
     if (!$finder->hasResults()) {
-      $question = new ConfirmationQuestion('<question>Would you like to clone a project into the current directory?</question> ',
-        TRUE);
-      if ($this->questionHelper->ask($this->input, $this->output, $question)) {
+      if ($this->io->confirm('Would you like to clone a project into the current directory?')) {
         return TRUE;
       }
     }
@@ -689,12 +686,10 @@ abstract class PullCommandBase extends CommandBase {
   ): void {
     $current_php_version = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
     if ($chosen_environment->configuration->php->version !== $current_php_version && AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
-      $question = new ConfirmationQuestion("<question>Would you like to change the PHP version on this IDE to match the PHP version on the <bg=cyan;options=bold>{$chosen_environment->label} ({$chosen_environment->configuration->php->version})</> environment?</question> ",
-        FALSE);
-      $answer = $this->questionHelper->ask($this->input, $this->output, $question);
+      $answer = $this->io->confirm("Would you like to change the PHP version on this IDE to match the PHP version on the <bg=cyan;options=bold>{$chosen_environment->label} ({$chosen_environment->configuration->php->version})</> environment?", FALSE);
       if ($answer) {
         $command = $this->getApplication()->find('ide:php-version');
-        $exit_code = $command->run(new ArrayInput(['version' => $chosen_environment->configuration->php->version]),
+        $command->run(new ArrayInput(['version' => $chosen_environment->configuration->php->version]),
           $output);
       }
     }

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -12,7 +12,6 @@ use AcquiaCloudApi\Response\EnvironmentResponse;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ChoiceQuestion;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -383,12 +382,7 @@ abstract class PullCommandBase extends CommandBase {
     }
     // Re-key the array since we removed production.
     $application_environments = array_values($application_environments);
-    $question = new ChoiceQuestion(
-      '<question>Choose a Cloud Platform environment</question>:',
-      $choices
-    );
-    $helper = $this->getHelper('question');
-    $chosen_environment_label = $helper->ask($this->input, $this->output, $question);
+    $chosen_environment_label = $this->io->choice('Choose a Cloud Platform environment', $choices);
     $chosen_environment_index = array_search($chosen_environment_label, $choices, TRUE);
 
     return $application_environments[$chosen_environment_index];
@@ -428,13 +422,7 @@ abstract class PullCommandBase extends CommandBase {
       $choices[] = $database->name . $suffix;
     }
 
-    $question = new ChoiceQuestion(
-      '<question>Choose a database</question>:',
-      $choices,
-      $default_database_index
-    );
-    $helper = $this->getHelper('question');
-    $chosen_database_label = $helper->ask($this->input, $this->output, $question);
+    $chosen_database_label = $this->io->choice('Choose a database', $choices, $default_database_index);
     $chosen_database_index = array_search($chosen_database_label, $choices, TRUE);
 
     return $environment_databases[$chosen_database_index];
@@ -497,11 +485,7 @@ abstract class PullCommandBase extends CommandBase {
       $choices[] = $acsf_site['name'];
     }
 
-    $question = new ChoiceQuestion('<question>Choose a site</question>:', $choices);
-    $helper = $this->getHelper('question');
-    $choice = $helper->ask($this->input, $this->output, $question);
-
-    return $choice;
+    return $this->io->choice('Choose a site', $choices);
   }
 
   /**

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -8,7 +8,6 @@ use Acquia\Cli\Output\Checklist;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Class PushDatabaseCommand.
@@ -44,8 +43,7 @@ class PushDatabaseCommand extends PullCommandBase {
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $database = $this->determineSourceDatabase($acquia_cloud_client, $destination_environment);
 
-    $question = new ConfirmationQuestion("<question>Overwrite the <bg=cyan;options=bold>{$database->name}</> database on <bg=cyan;options=bold>{$destination_environment->name}</> with a copy of the database from the current machine?</question> ", TRUE);
-    $answer = $this->questionHelper->ask($this->input, $this->output, $question);
+    $answer = $this->io->confirm("Overwrite the <bg=cyan;options=bold>{$database->name}</> database on <bg=cyan;options=bold>{$destination_environment->name}</> with a copy of the database from the current machine?");
     if (!$answer) {
       return 0;
     }

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Class PushFilesCommand.
@@ -49,8 +48,7 @@ class PushFilesCommand extends PullCommandBase {
     else {
       $chosen_site = NULL;
     }
-    $question = new ConfirmationQuestion("<question>Overwrite the public files directory on <bg=cyan;options=bold>{$destination_environment->name}</> with a copy of the files from the current machine?</question> ", TRUE);
-    $answer = $this->questionHelper->ask($this->input, $this->output, $question);
+    $answer = $this->io->confirm("Overwrite the public files directory on <bg=cyan;options=bold>{$destination_environment->name}</> with a copy of the files from the current machine?");
     if (!$answer) {
       return 0;
     }

--- a/tests/phpunit/src/Commands/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/NewCommandTest.php
@@ -75,7 +75,7 @@ class NewCommandTest extends CommandTestBase {
 
     $this->command->localMachineHelper = $local_machine_helper->reveal();
     $inputs = [
-      // Which starting project would you like to use?
+      // Choose a starting project
       $project,
     ];
     $this->executeCommand([
@@ -83,7 +83,7 @@ class NewCommandTest extends CommandTestBase {
     ], $inputs);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString('Which starting project would you like to use?', $output);
+    $this->assertStringContainsString('Choose a starting project', $output);
     $this->assertStringContainsString($project, $output);
     $this->assertStringContainsString('New 💧Drupal project created in ' . $this->newProjectDir, $output);
 

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -47,7 +47,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('Choose a Cloud Platform environment:', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
-    $this->assertStringContainsString('Choose a database:', $output);
+    $this->assertStringContainsString('Choose a database', $output);
     $this->assertStringContainsString('jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)', $output);
     $this->assertStringContainsString('profserv2 (default)', $output);
   }

--- a/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
@@ -68,7 +68,7 @@ class PushDatabaseCommandTest extends CommandTestBase {
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
-    $this->assertStringContainsString('Choose a database:', $output);
+    $this->assertStringContainsString('Choose a database', $output);
     $this->assertStringContainsString('jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)', $output);
     $this->assertStringContainsString('profserv2 (default)', $output);
     $this->assertStringContainsString('Overwrite the jxr136 database on dev with a copy of the database from the current machine?', $output);


### PR DESCRIPTION
Motivation
----------
We received product feedback from @ba66e77 that the confirmation questions asked by Acquia CLI are confusing because they don't tell you what the available/default responses are (y/n/yes/no/whatever). For the record, Symfony basically interprets anything starting with a "y" as "yes", but being more explicit can't hurt.

Proposed changes
---------
Switch from the Symfony question helper to the higher-level style component, which automatically formats confirmation questions to include suggested and default responses.

This has the effect of changing how questions are formatted.

Before:
![before](https://user-images.githubusercontent.com/1984514/96044538-69690080-0e25-11eb-993b-16743af49a09.png)

After:
![after](https://user-images.githubusercontent.com/1984514/96044558-74bc2c00-0e25-11eb-8eb2-94bcf6a77b5e.png)

Alternatives considered
---------
Keep using the lower-level question helpers and manually modify each invocation to add y/n and defaults.

Testing steps
---------
Run any command that generates a confirmation question, such as `acli auth:login` when you haven't set telemetry preferences.

@grasmash @anavarre how do you feel about this change, before I go through and convert all the remaining cases, as well as the failing tests?