### PR TITLE
DX-1605: Add usage examples

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -28,6 +28,7 @@ use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\NullOutput;
@@ -303,6 +304,26 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->amplitude->queueEvent('Ran command', $event_properties);
 
     return $exit_code;
+  }
+
+  /**
+   * Add argument and usage examples for applicationUuid.
+   */
+  protected function acceptApplicationUuid() {
+    $this->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The Cloud Platform application UUID or alias.')
+    ->addUsage(self::getDefaultName() . ' [<applicationAlias>]')
+    ->addUsage(self::getDefaultName() . ' myapp')
+    ->addUsage(self::getDefaultName() . ' abcd1234-1111-2222-3333-0e02b2c3d470');
+  }
+
+  /**
+   * Add argument and usage examples for environmentId.
+   */
+  protected function acceptEnvironmentId() {
+    $this->addArgument('environmentId', InputArgument::OPTIONAL, 'The Cloud Platform environment ID or alias.')
+    ->addUsage(self::getDefaultName() . ' [<environmentAlias>]')
+    ->addUsage(self::getDefaultName() . ' myapp.dev')
+    ->addUsage(self::getDefaultName() . ' 12345-abcd1234-1111-2222-3333-0e02b2c3d470');
   }
 
   /**

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Cli\Command\Ide;
 
-use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Helpers\LoopHelper;
 use Acquia\Cli\Output\Checklist;
 use AcquiaCloudApi\Endpoints\Ides;
@@ -11,9 +10,7 @@ use AcquiaCloudApi\Response\OperationResponse;
 use Exception;
 use GuzzleHttp\Client;
 use React\EventLoop\Factory;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
@@ -38,8 +35,8 @@ class IdeCreateCommand extends IdeCommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Create a Cloud IDE for development')
-      ->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The UUID or alias of the associated Cloud Platform Application');
+    $this->setDescription('Create a Cloud IDE for development');
+    $this->acceptApplicationUuid();
   }
 
   /**

--- a/src/Command/Ide/IdeDeleteCommand.php
+++ b/src/Command/Ide/IdeDeleteCommand.php
@@ -3,9 +3,7 @@
 namespace Acquia\Cli\Command\Ide;
 
 use AcquiaCloudApi\Endpoints\Ides;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -22,9 +20,9 @@ class IdeDeleteCommand extends IdeCommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Delete a Cloud IDE')
-      ->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The UUID or alias of the associated Cloud Platform Application');
-      // @todo Add option to accept an ide UUID.
+    $this->setDescription('Delete a Cloud IDE');
+    $this->acceptApplicationUuid();
+    // @todo Add option to accept an ide UUID.
   }
 
   /**

--- a/src/Command/Ide/IdeListCommand.php
+++ b/src/Command/Ide/IdeListCommand.php
@@ -2,13 +2,10 @@
 
 namespace Acquia\Cli\Command\Ide;
 
-use Acquia\Cli\Command\CommandBase;
 use AcquiaCloudApi\Endpoints\Ides;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -22,8 +19,8 @@ class IdeListCommand extends IdeCommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('List available Cloud IDEs')
-      ->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The UUID or alias of the associated Cloud Platform Application');
+    $this->setDescription('List available Cloud IDEs');
+    $this->acceptApplicationUuid();
   }
 
   /**

--- a/src/Command/Ide/IdeOpenCommand.php
+++ b/src/Command/Ide/IdeOpenCommand.php
@@ -4,9 +4,7 @@ namespace Acquia\Cli\Command\Ide;
 
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Endpoints\Ides;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -21,8 +19,8 @@ class IdeOpenCommand extends IdeCommandBase {
    */
   protected function configure() {
     $this->setDescription('Open a Cloud IDE in your browser')
-      ->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The UUID or alias of the associated Cloud Platform Application')
       ->setHidden(AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
+      $this->acceptApplicationUuid;
     // @todo Add option to accept an ide UUID.
   }
 

--- a/src/Command/Ide/IdeOpenCommand.php
+++ b/src/Command/Ide/IdeOpenCommand.php
@@ -20,7 +20,7 @@ class IdeOpenCommand extends IdeCommandBase {
   protected function configure() {
     $this->setDescription('Open a Cloud IDE in your browser')
       ->setHidden(AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
-      $this->acceptApplicationUuid;
+    $this->acceptApplicationUuid();
     // @todo Add option to accept an ide UUID.
   }
 

--- a/src/Command/LinkCommand.php
+++ b/src/Command/LinkCommand.php
@@ -3,7 +3,6 @@
 namespace Acquia\Cli\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -36,7 +35,7 @@ class LinkCommand extends CommandBase {
       $output->writeln('This repository is already linked to Cloud application <options=bold>' . $cloud_application->name . '</>. Run <options=bold>acli unlink</> to unlink it.');
       return 1;
     }
-    $cloud_application_uuid = $this->determineCloudApplication(TRUE);
+    $this->determineCloudApplication(TRUE);
 
     return 0;
   }

--- a/src/Command/LinkCommand.php
+++ b/src/Command/LinkCommand.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Cli\Command;
 
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,8 +17,8 @@ class LinkCommand extends CommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Associate your project with a Cloud Platform application')
-      ->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The UUID or alias of the associated Cloud Platform Application');
+    $this->setDescription('Associate your project with a Cloud Platform application');
+    $this->acceptApplicationUuid();
   }
 
   /**

--- a/src/Command/LogTailCommand.php
+++ b/src/Command/LogTailCommand.php
@@ -20,8 +20,8 @@ class LogTailCommand extends CommandBase {
    */
   protected function configure() {
     $this->setDescription('Tail the logs from your environments')
-      ->setAliases(['tail'])
-      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The Cloud environment UUID or alias.');
+      ->setAliases(['tail']);
+    $this->acceptEnvironmentId();
   }
 
   /**

--- a/src/Command/LogTailCommand.php
+++ b/src/Command/LogTailCommand.php
@@ -3,9 +3,7 @@
 namespace Acquia\Cli\Command;
 
 use AcquiaCloudApi\Endpoints\Logs;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -23,8 +23,8 @@ class AliasListCommand extends CommandBase {
    */
   protected function configure() {
     $this->setDescription('List all aliases for the Cloud Platform environments')
-      ->setAliases(['aliases', 'sa'])
-      ->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The UUID or alias of the associated Cloud Platform Application');
+      ->setAliases(['aliases', 'sa']);
+    $this->acceptApplicationUuid();
   }
 
   /**


### PR DESCRIPTION
Motivation
----------
Most commands have no usage examples except for those automatically generated by Symfony for each argument. It's not clear to users, for instance, that they can use either an application UUID or sitegroup alias for any command with an app UUID argument.

Proposed changes
---------
Instead of manually adding app / environment ID arguments and usage examples to every command individually, encapsulate these in a common method. See before and after examples for the two commands refactored so far:
![link](https://user-images.githubusercontent.com/1984514/96048595-ab954080-0e2b-11eb-84ba-fc0ed6be49b1.png)
![logtail](https://user-images.githubusercontent.com/1984514/96048603-adf79a80-0e2b-11eb-93c4-7ca21d6e3293.png)

Alternatives considered
---------
Write the usage example for each command individually. That's a lot of unnecessary repetition.

Testing steps
---------
Run `acli help link` or `acli help log:tail`.

@grasmash @anavarre are you okay with this general approach? If so I'll finish refactoring the rest of the commands.