### PR TITLE
Fixes #316: SSH key wizard often returns duplicated info on screen.

### DIFF
--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -273,8 +273,8 @@ EOT
         $process = $this->sshHelper->executeCommand($environment, ['ls'], FALSE);
         if ($process->isSuccessful()) {
           LoopHelper::finishSpinner($spinner);
-          $output->writeln("\n<info>Your SSH key is ready for use!</info>\n");
           $loop->stop();
+          $output->writeln("\n<info>Your SSH key is ready for use!</info>\n");
         }
         else {
           $this->logger->debug($process->getOutput() . $process->getErrorOutput());


### PR DESCRIPTION
This is a total guess. No idea if it actually fixes the issue.