### PR TITLE
Fix heisenbug in IDE create test

### DIFF
--- a/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
@@ -23,8 +23,9 @@ class IdeCreateCommandTest extends CommandTestBase {
    */
   public function testCreate(): void {
 
-    $this->mockApplicationsRequest();
+    $applications_response = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
+    $this->mockAllEnvironmentsRequest($applications_response);
 
     // Request to create IDE.
     $response = $this->getMockResponseFromSpec('/api/applications/{applicationUuid}/ides', 'post', '202');

--- a/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
@@ -23,9 +23,8 @@ class IdeCreateCommandTest extends CommandTestBase {
    */
   public function testCreate(): void {
 
-    $applications_response = $this->mockApplicationsRequest();
+    $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockAllEnvironmentsRequest($applications_response);
 
     // Request to create IDE.
     $response = $this->getMockResponseFromSpec('/api/applications/{applicationUuid}/ides', 'post', '202');
@@ -50,7 +49,7 @@ class IdeCreateCommandTest extends CommandTestBase {
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
       // Would you like to link the project at ... ?
-      'y',
+      'n',
       0,
       // Please select the application for which you'd like to create a new IDE
       0,

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -466,29 +466,6 @@ abstract class TestBase extends TestCase {
   }
 
   /**
-   * @param object $applications_response
-   *
-   * @return object
-   * @throws \Psr\Cache\InvalidArgumentException
-   */
-  public function mockAllEnvironmentsRequest(
-    $applications_response
-  ) {
-    // Request for Environments data. This isn't actually the endpoint we should
-    // be using, but we do it due to CXAPI-7209.
-    $response = $this->getMockResponseFromSpec('/environments/{environmentId}',
-      'get', '200');
-    foreach ($applications_response->{'_embedded'}->items as $application) {
-      $this->clientProphecy->request('get',
-        "/applications/{$application->uuid}/environments")
-        ->willReturn([$response])
-        ->shouldBeCalled();
-    }
-
-    return $response;
-  }
-
-  /**
    * @return object
    * @throws \Psr\Cache\InvalidArgumentException
    */

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -466,6 +466,29 @@ abstract class TestBase extends TestCase {
   }
 
   /**
+   * @param object $applications_response
+   *
+   * @return object
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function mockAllEnvironmentsRequest(
+    $applications_response
+  ) {
+    // Request for Environments data. This isn't actually the endpoint we should
+    // be using, but we do it due to CXAPI-7209.
+    $response = $this->getMockResponseFromSpec('/environments/{environmentId}',
+      'get', '200');
+    foreach ($applications_response->{'_embedded'}->items as $application) {
+      $this->clientProphecy->request('get',
+        "/applications/{$application->uuid}/environments")
+        ->willReturn([$response])
+        ->shouldBeCalled();
+    }
+
+    return $response;
+  }
+
+  /**
    * @return object
    * @throws \Psr\Cache\InvalidArgumentException
    */


### PR DESCRIPTION
Motivation
----------
Kept getting this error running tests locally:
> 1) Acquia\Cli\Tests\Commands\Ide\IdeCreateCommandTest::testCreate
array_map(): Expected parameter 2 to be an array, null given

Seemed to be a bit of a heisenbug, it would come and go on different machines. I've never seen it in Travis CI, not sure why. Maybe there's an actual network call happening here? :grimacing: 

Proposed changes
---------
Mock environment requests for all applications in this test. This is necessary because the command loops through all applications, but we only mock the first one:
- https://github.com/acquia/cli/blob/1.0.0/src/Command/CommandBase.php#L488
- https://github.com/acquia/cli/blob/1.0.0/tests/phpunit/src/TestBase.php#L440

Alternatives considered
---------
I have no idea why this only happens in this one test, or why it happens intermittently. Quite possibly I'm missing something.

Testing steps
---------
Run `composer test` on a machine where you've previously seen this bug.