### PR TITLE
Fix #242: Support multisite db refresh

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -825,9 +825,8 @@ abstract class PullCommandBase extends CommandBase {
 
   /**
    * @param \AcquiaCloudApi\Response\EnvironmentResponse $source_environment
-   * @param \AcquiaCloudApi\Response\DatabaseResponse $database
    */
-  protected function createDbSettingsFile(EnvironmentResponse $source_environment, DatabaseResponse $database): void {
+  protected function createDbSettingsFile(EnvironmentResponse $source_environment, $database): void {
     $sitegroup = self::getSiteGroupFromSshUrl($source_environment);
     $default_path = "/var/www/site-php/$sitegroup/$sitegroup-settings.inc";
     $db_name_path = "/var/www/site-php/$sitegroup/{$database->name}-settings.inc";

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -8,7 +8,6 @@ use Acquia\Cli\Output\Checklist;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Endpoints\Environments;
-use AcquiaCloudApi\Response\DatabaseResponse;
 use AcquiaCloudApi\Response\EnvironmentResponse;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -89,11 +89,9 @@ abstract class PullCommandBase extends CommandBase {
     $this->checklist->addItem('Importing Drupal database copy from the Cloud Platform');
     $this->importRemoteDatabase($source_environment, $database, $this->getOutputCallback($output, $this->checklist));
     $sitegroup = self::getSiteGroupFromSshUrl($source_environment);
-    $db_name = $this->getNameFromDatabaseResponse($database);
     $default_path = "/var/www/site-php/$sitegroup/$sitegroup-settings.inc";
-    $db_name_path = "/var/www/site-php/$sitegroup/$db_name-settings.inc";
+    $db_name_path = "/var/www/site-php/$sitegroup/{$database->name}-settings.inc";
     $this->localMachineHelper->execute(['cp', $default_path, $db_name_path]);
-
     $this->checklist->completePreviousItem();
   }
 

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -88,7 +88,7 @@ abstract class PullCommandBase extends CommandBase {
     $database = $this->determineSourceDatabase($acquia_cloud_client, $source_environment);
     $this->checklist->addItem('Importing Drupal database copy from the Cloud Platform');
     $this->importRemoteDatabase($source_environment, $database, $this->getOutputCallback($output, $this->checklist));
-    $sitegroup = self::getSiteGroupFromSshUrl($source_environment->sshUrl);
+    $sitegroup = self::getSiteGroupFromSshUrl($source_environment);
     $db_name = $this->getNameFromDatabaseResponse($database);
     $default_path = "/var/www/site-php/$sitegroup/$sitegroup-settings.inc";
     $db_name_path = "/var/www/site-php/$sitegroup/$db_name-settings.inc";

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -89,7 +89,9 @@ abstract class PullCommandBase extends CommandBase {
     $database = $this->determineSourceDatabase($acquia_cloud_client, $source_environment);
     $this->checklist->addItem('Importing Drupal database copy from the Cloud Platform');
     $this->importRemoteDatabase($source_environment, $database, $this->getOutputCallback($output, $this->checklist));
-    $this->createDbSettingsFile($source_environment, $database);
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      $this->createDbSettingsFile($source_environment, $database);
+    }
     $this->checklist->completePreviousItem();
   }
 

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -88,6 +88,12 @@ abstract class PullCommandBase extends CommandBase {
     $database = $this->determineSourceDatabase($acquia_cloud_client, $source_environment);
     $this->checklist->addItem('Importing Drupal database copy from the Cloud Platform');
     $this->importRemoteDatabase($source_environment, $database, $this->getOutputCallback($output, $this->checklist));
+    $sitegroup = self::getSiteGroupFromSshUrl($source_environment->sshUrl);
+    $db_name = $this->getNameFromDatabaseResponse($database);
+    $default_path = "/var/www/site-php/$sitegroup/$sitegroup-settings.inc";
+    $db_name_path = "/var/www/site-php/$sitegroup/$db_name-settings.inc";
+    $this->localMachineHelper->execute(['cp', $default_path, $db_name_path]);
+
     $this->checklist->completePreviousItem();
   }
 

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -172,7 +172,7 @@ abstract class CommandTestBase extends TestBase {
   }
 
   protected function getSourceGitConfigFixture() {
-    return Path::join($this->fixtureDir, 'git_config');;
+    return Path::join($this->fixtureDir, 'git_config');
   }
 
   /**

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -120,7 +120,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $local_machine_helper = $this->mockLocalMachineHelper();
     $fs = $this->prophet->prophesize(Filesystem::class);
     $fs->copy('/var/www/site-php/profserv2/profserv2-settings.inc', '/var/www/site-php/profserv2/profserv2-settings.inc')->willReturn();
-    $fs->remove('/tmp/acli-mysql-dump-dev-profserv201dev.sql.gz')->willReturn();
+    $fs->remove(Argument::type('string'))->willReturn();
     $local_machine_helper->getFilesystem()->willReturn($fs);
 
     // Database.

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -127,6 +127,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->mockExecuteMySqlCreateDb($local_machine_helper, $mysql_create_successful);
     $this->mockExecuteMySqlImport($local_machine_helper, $mysql_import_successful);
     $this->mockExecuteSshRemove($ssh_helper, $environments_response, TRUE);
+    $this->mockSettingsFileCopy($local_machine_helper);
 
     $this->command->localMachineHelper = $local_machine_helper->reveal();
     $this->command->sshHelper = $ssh_helper->reveal();
@@ -195,6 +196,16 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
         NULL, TRUE, NULL)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
+  }
+
+  protected function mockSettingsFileCopy(
+    ObjectProphecy $local_machine_helper
+  ): void {
+    $process = $this->mockProcess();
+    $local_machine_helper
+      ->execute(['cp', '/var/www/site-php/profserv2/profserv2-settings.inc', '/var/www/site-php/profserv2/profserv2-settings.inc'])
+    ->willReturn($process->reveal())
+    ->shouldBeCalled();
   }
 
   /**

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -117,11 +117,14 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $ssh_helper = $this->prophet->prophesize(SshHelper::class);
     $this->mockGetAcsfSites($ssh_helper);
 
+    // ACLI should copy settings files in an IDE environment, so mock the environment.
+    IdeRequiredTestBase::setCloudIdeEnvVars();
     $local_machine_helper = $this->mockLocalMachineHelper();
     $fs = $this->prophet->prophesize(Filesystem::class);
     $fs->copy('/var/www/site-php/profserv2/profserv2-settings.inc', '/var/www/site-php/profserv2/profserv2-settings.inc')->willReturn();
     $fs->remove(Argument::type('string'))->willReturn();
     $local_machine_helper->getFilesystem()->willReturn($fs);
+    IdeRequiredTestBase::unsetCloudIdeEnvVars();
 
     // Database.
     $this->mockCreateRemoteDatabaseDump($ssh_helper, $environments_response, $mysql_dump_successful);

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -51,7 +51,6 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
    * @throws \Exception
    */
   public function testPullDatabaseSettingsFiles(): void {
-    // ACLI should copy settings files in an IDE environment, so mock the environment.
     $this->setupPullDatabase(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE);
     $inputs = $this->getInputs();
     putenv('AH_SITE_ENVIRONMENT=IDE');

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -6,7 +6,6 @@ use Acquia\Cli\Command\Pull\PullDatabaseCommand;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Tests\Commands\Ide\IdeRequiredTestBase;
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Response\EnvironmentResponse;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -56,9 +55,9 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     // ACLI should copy settings files in an IDE environment, so mock the environment.
     $this->setupPullDatabase(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE);
     $inputs = $this->getInputs();
-    IdeRequiredTestBase::setCloudIdeEnvVars();
+    putenv('AH_SITE_ENVIRONMENT=IDE');
     $this->executeCommand(['--no-scripts' => TRUE], $inputs);
-    IdeRequiredTestBase::unsetCloudIdeEnvVars();
+    putenv('AH_SITE_ENVIRONMENT');
   }
 
   public function testPullDatabaseWithMySqlDumpError(): void {

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -5,7 +5,6 @@ namespace Acquia\Cli\Tests\Commands\Pull;
 use Acquia\Cli\Command\Pull\PullDatabaseCommand;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\SshHelper;
-use Acquia\Cli\Tests\Commands\Ide\IdeRequiredTestBase;
 use AcquiaCloudApi\Response\EnvironmentResponse;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -124,16 +123,14 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $ssh_helper = $this->prophet->prophesize(SshHelper::class);
     $this->mockGetAcsfSites($ssh_helper);
 
+    $fs = $this->prophet->prophesize(Filesystem::class);
     $local_machine_helper = $this->mockLocalMachineHelper();
-    // Always prophesize the fs?
+    // Set up file system.
+    $local_machine_helper->getFilesystem()->willReturn($fs)->shouldBeCalled();
+
     if ($mock_ide_fs) {
-      $fs = $this->mockSettingsFiles();
+      $this->mockSettingsFiles($fs);
     }
-    else {
-      $fs = $this->fs;
-    }
-    // Use shouldbecalled here and elsewhere.
-    $local_machine_helper->getFilesystem()->willReturn($fs);
 
     // Database.
     $this->mockCreateRemoteDatabaseDump($ssh_helper, $environments_response, $mysql_dump_successful);
@@ -288,15 +285,13 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     return $inputs;
   }
 
-  /**
-   * @return \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Filesystem\Filesystem
-   */
-  protected function mockSettingsFiles() {
-    $fs = $this->prophet->prophesize(Filesystem::class);
+  protected function mockSettingsFiles($fs): void {
     $fs->copy('/var/www/site-php/profserv2/profserv2-settings.inc', '/var/www/site-php/profserv2/profserv2-settings.inc')
-      ->willReturn();
-    $fs->remove(Argument::type('string'))->willReturn();
-    return $fs;
+      ->willReturn()
+      ->shouldBeCalled();
+    $fs->remove(Argument::type('string'))
+      ->willReturn()
+      ->shouldBeCalled();
   }
 
 }

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -2,22 +2,15 @@
 
 namespace Acquia\Cli\Tests\Commands\Pull;
 
-use Acquia\Cli\Command\Ide\IdePhpVersionCommand;
-use Acquia\Cli\Command\Pull\PullCodeCommand;
-use Acquia\Cli\Command\Pull\PullCommand;
 use Acquia\Cli\Command\Pull\PullDatabaseCommand;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Tests\Commands\Ide\IdeRequiredTestBase;
-use Acquia\Cli\Tests\CommandTestBase;
 use AcquiaCloudApi\Response\EnvironmentResponse;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Process\Process;
-use Webmozart\PathUtil\Path;
 
 /**
  * Class PullDatabaseCommandTest.

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -53,6 +53,9 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
   public function testPullDatabaseSettingsFiles(): void {
     $this->setupPullDatabase(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE);
     $inputs = $this->getInputs();
+    // @todo Use the IdeRequiredTestBase instead of setting AH_SITE_ENVIRONMENT.
+    // IdeRequiredTestBase sets other env vars (such as application ID) that
+    // seem to conflict with the rest of this test.
     putenv('AH_SITE_ENVIRONMENT=IDE');
     $this->executeCommand(['--no-scripts' => TRUE], $inputs);
     putenv('AH_SITE_ENVIRONMENT');


### PR DESCRIPTION
Motivation
----------
Fixes #242

Proposed changes
---------
Upon a DB pull, copy the default db settings file to match the name of the pulled db.

Alternatives considered
---------
Tons, see #242 

Testing steps
---------
`acli pull:db` on a multisite app, ensure that a new file is created at `/var/www/site-php/[sitegroup]`