### PR TITLE
Updated help text for remote:ssh

### DIFF
--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -25,7 +25,7 @@ class DrushCommand extends SSHBaseCommand {
       ->setHelp('Pleases pay close attention to the argument syntax! Note the usage of <options=bold>--</> to separate the drush command arguments and options.')
       ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
       ->addArgument('drush_command', InputArgument::IS_ARRAY, 'Drush command')
-      ->addUsage('<site>.<env> -- <command>')
+      ->addUsage('<app>.<env> -- <command>')
       ->addUsage('myapp.dev -- uli 1')
       ->addUsage('myapp.dev -- status --fields=db-status');
   }

--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -20,10 +20,10 @@ class SshCommand extends SshBaseCommand {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Open a new SSH connection to a Cloud Platform environment')
+    $this->setDescription('Open a new SSH session to a Cloud Platform environment')
       ->setAliases(['ssh'])
       ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
-      ->addUsage(" <app>.<env> -- <command> Runs the Drush command <command> remotely on <site>'s <env> environment.");
+      ->addUsage("<app>.<env>");
   }
 
   /**


### PR DESCRIPTION
And a small fix for remote:drush for consistency

Motivation
----------
SSH Help text implies that you can pass a command, however the command is only meant for opening an interactive session

Also, remote:drush uses the incorrect terminology `<site>.<env>` which is inconsistent.

Proposed changes
---------
Just help text on two commands

Testing steps
---------
Run `help remote:ssh` and make sure it makes sense
Run `help remote:drush` and make sure it doesn't mention `<site>`.