### PR TITLE
DX-2657: Remove coveralls config

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-pro
-repo_token: 5HYPjYqlqRoZT1XdnW7zeWLVO6e5PvJ5z


### PR DESCRIPTION
Motivation
----------
I don't think this file is necessary to run Coveralls via Travis CI.

Proposed changes
---------
Remove the file.

Testing steps
---------
Just make sure Coveralls still runs and reports on this PR.
