### PR TITLE
DX-1780: Better message when no IDEs available

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -23,7 +23,7 @@ class ExceptionListener
     if ($error instanceof ApiErrorException) {
       switch ($errorMessage) {
         case "There are no available Cloud IDEs for this application.\n":
-          $newErrorMessage = $errorMessage . 'Delete an existing IDE (acli ide:delete) or submit a support ticket to purchase additional IDEs (https://support.acquia.com)';
+          $newErrorMessage = $errorMessage . "Delete an existing IDE (acli ide:delete) or contact your Account Manager or Acquia Sales to purchase additional IDEs.\n You may also submit a support ticket to ask for more information (https://insight.acquia.com/support/tickets/new?product=p:ride)";
           break;
         default:
           $newErrorMessage = 'Cloud Platform API returned an error: ' . $errorMessage;

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -13,14 +13,25 @@ class ExceptionListener
   public function onConsoleError(ConsoleErrorEvent $event) {
     $exitCode = $event->getExitCode();
     $error = $event->getError();
+    $errorMessage = $error->getMessage();
+
     // Make OAuth server errors more human-friendly.
     if ($error instanceof IdentityProviderException && $error->getMessage() === 'invalid_client') {
-      $event->setError(new AcquiaCliException('Your Cloud API credentials are invalid. Run acli auth:login to reset them.',
-        [], $exitCode));
+      $newErrorMessage = 'Your Cloud API credentials are invalid. Run acli auth:login to reset them.';
     }
 
     if ($error instanceof ApiErrorException) {
-      $event->setError(new AcquiaCliException('Acquia Cloud Platform API returned an error: ' . $error->getMessage(), [], $exitCode));
+      switch ($errorMessage) {
+        case "There are no available Cloud IDEs for this application.\n":
+          $newErrorMessage = $errorMessage . 'Delete an existing IDE (acli ide:delete) or submit a support ticket to purchase additional IDEs (https://support.acquia.com)';
+          break;
+        default:
+          $newErrorMessage = 'Acquia Cloud Platform API returned an error: ' . $errorMessage;
+      }
+    }
+
+    if (isset($newErrorMessage)) {
+      $event->setError(new AcquiaCliException($newErrorMessage, [], $exitCode));
     }
   }
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -17,7 +17,7 @@ class ExceptionListener
 
     // Make OAuth server errors more human-friendly.
     if ($error instanceof IdentityProviderException && $error->getMessage() === 'invalid_client') {
-      $newErrorMessage = 'Your Cloud API credentials are invalid. Run acli auth:login to reset them.';
+      $newErrorMessage = 'Your Cloud Platform API credentials are invalid. Run acli auth:login to reset them.';
     }
 
     if ($error instanceof ApiErrorException) {
@@ -26,7 +26,7 @@ class ExceptionListener
           $newErrorMessage = $errorMessage . 'Delete an existing IDE (acli ide:delete) or submit a support ticket to purchase additional IDEs (https://support.acquia.com)';
           break;
         default:
-          $newErrorMessage = 'Acquia Cloud Platform API returned an error: ' . $errorMessage;
+          $newErrorMessage = 'Cloud Platform API returned an error: ' . $errorMessage;
       }
     }
 

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -37,6 +37,6 @@ class ExceptionApplicationTest extends TestBase {
     $output = new BufferedOutput();
     $application->run($input, $output);
     $buffer = $output->fetch();
-    $this->assertStringContainsString('Your Cloud API credentials are invalid. Run acli auth:login to reset them.', $buffer);  }
+    $this->assertStringContainsString('Your Cloud Platform API credentials are invalid. Run acli auth:login to reset them.', $buffer);  }
 
 }

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -37,6 +37,7 @@ class ExceptionApplicationTest extends TestBase {
     $output = new BufferedOutput();
     $application->run($input, $output);
     $buffer = $output->fetch();
-    $this->assertStringContainsString('Your Cloud Platform API credentials are invalid. Run acli auth:login to reset them.', $buffer);  }
+    // This is sensitive to the display width of the test environment, so that's fun.
+    $this->assertStringContainsString('Your Cloud Platform API credentials are invalid.', $buffer);  }
 
 }


### PR DESCRIPTION
Motivation
----------
The Cloud API error message indicates when no IDEs are available, but doesn't indicate how to resolve this.

Proposed changes
---------
Suggest users delete an existing IDE or purchase more

Alternatives considered
---------
Fix the message upstream in Cloud API

Testing steps
---------
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli ide:create` on an application with no available IDEs.

<img width="902" alt="Screen Shot 2020-11-05 at 10 43 34 AM" src="https://user-images.githubusercontent.com/1984514/98283279-4cbb7680-1f54-11eb-852c-d2bbed107a33.png">
