### PR TITLE
Replace --cloud-env-uuid option with environmentId arg.

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -295,7 +295,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
     $this->convertApplicationAliastoUuid($input);
     $this->fillMissingRequiredApplicationUuid($input, $output);
-    $this->convertEnvironmentAliasToUuid($input);
+    $this->convertEnvironmentAliasToUuid($input, 'environmentId');
+    $this->convertEnvironmentAliasToUuid($input, 'source');
     $this->checkForNewVersion($input, $output);
   }
 
@@ -1119,12 +1120,14 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
    *
+   * @param $argument_name
+   *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Psr\Cache\InvalidArgumentException
    */
-  protected function convertEnvironmentAliasToUuid(InputInterface $input): void {
-    if ($input->hasArgument('environmentId') && $input->getArgument('environmentId')) {
-      $env_uuid_argument = $input->getArgument('environmentId');
+  protected function convertEnvironmentAliasToUuid(InputInterface $input, $argument_name): void {
+    if ($input->hasArgument($argument_name) && $input->getArgument($argument_name)) {
+      $env_uuid_argument = $input->getArgument($argument_name);
       try {
         // Environment IDs take the form of [env-num]-[app-uuid].
         $uuid_parts = explode('-', $env_uuid_argument);
@@ -1139,9 +1142,9 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
           $alias = $this->normalizeAlias($alias);
           $alias = self::validateEnvironmentAlias($alias);
           $environment = $this->getEnvironmentFromAliasArg($alias);
-          $input->setArgument('environmentId', $environment->uuid);
+          $input->setArgument($argument_name, $environment->uuid);
         } catch (AcquiaCliException $exception) {
-          throw new AcquiaCliException("The {environmentId} must be a valid UUID or site alias.");
+          throw new AcquiaCliException("The {$argument_name} must be a valid UUID or site alias.");
         }
       }
     }

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -21,8 +21,7 @@ class PullCodeCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Copy code from a Cloud Platform environment')
       ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
-      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
-        'The UUID of the associated Cloud Platform source environment')
+      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,
         'Do not run any additional scripts after code is pulled. E.g., composer install , drush cache-rebuild, etc.')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -23,7 +23,7 @@ class PullCommand extends PullCommandBase {
     $this->setAliases(['refresh', 'pull'])
       ->setDescription('Copy code, database, and files from a Cloud Platform environment')
       ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
-      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED, 'The UUID of the associated Cloud Platform source environment')
+      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->addOption('no-code', NULL, InputOption::VALUE_NONE, 'Do not refresh code from remote repository')
       ->addOption('no-files', NULL, InputOption::VALUE_NONE, 'Do not refresh files')
       ->addOption('no-databases', NULL, InputOption::VALUE_NONE, 'Do not refresh databases')

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -613,8 +613,8 @@ abstract class PullCommandBase extends CommandBase {
       return $this->sourceEnvironment;
     }
 
-    if ($input->getOption('cloud-env-uuid')) {
-      $environment_id = $input->getOption('cloud-env-uuid');
+    if ($input->getArgument('environmentId')) {
+      $environment_id = $input->getArgument('environmentId');
       $chosen_environment = $this->getCloudEnvironment($environment_id);
     }
     else {

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Command\Pull;
 
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,8 +21,7 @@ class PullDatabaseCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Copy database from a Cloud Platform environment')
       ->setAliases(['pull:db'])
-      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
-        'The UUID of the associated Cloud Platform source environment')
+      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,
         'Do not run any additional scripts after the database is pulled. E.g., drush cache-rebuild, drush sql-sanitize, etc.')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -21,8 +21,7 @@ class PullFilesCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Copy files from a Cloud Platform environment')
       ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
-      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
-        'The UUID of the associated Cloud Platform source environment')
+      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -26,8 +26,7 @@ class PullScriptsCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Execute post pull scripts')
       ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
-      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
-        'The UUID of the associated Cloud Platform source environment')
+      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -6,6 +6,7 @@ use Acquia\Cli\Command\Pull\PullCommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -28,8 +29,7 @@ class PushDatabaseCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Push a database from your IDE to a Cloud Platform environment')
       ->setAliases(['push:db'])
-      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
-        'The UUID of the associated Cloud Platform source environment')
+      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -28,9 +28,8 @@ class PushFilesCommand extends PullCommandBase {
    */
   protected function configure() {
     $this->setDescription('Push Drupal files from your IDE to a Cloud Platform environment')
-      ->addOption('cloud-env-uuid', 'from', InputOption::VALUE_REQUIRED,
-        'The UUID of the associated Cloud Platform source environment')
       ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project with files to be pushed')
+      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
@@ -240,8 +240,8 @@ class PullCodeCommandTest extends PullCommandTestBase {
 
     $this->executeCommand([
       // @todo Execute ONLY match php aspect, not the code pull.
-      '--cloud-env-uuid' => $environment_response->id,
       'dir' => $dir,
+      'environmentId' => $environment_response->id,
       '--no-scripts' => TRUE,
     ], [
       // Please choose an Acquia environment:


### PR DESCRIPTION
Using the environmentId argument name allows users to use either an alias or a uuid.