### PR TITLE
Clarify xdebug usage

### DIFF
--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -36,7 +36,7 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Toggle xDebug on or off in the current IDE')
+    $this->setDescription('Toggle Xdebug on or off in the current IDE')
       ->setAliases(['xdebug'])
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
   }
@@ -118,11 +118,12 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    *   The contents of php.ini.
    */
   protected function enableXDebug($destination_file, $contents): void {
-    $this->logger->notice("Enabling xdebug in $destination_file...");
+    $this->logger->notice("Enabling Xdebug PHP extension in $destination_file...");
     // Note that this replaces 1 or more ";" characters.
     $new_contents = preg_replace('/(;)+(zend_extension=xdebug\.so)/', '$2', $contents);
     file_put_contents($destination_file, $new_contents);
-    $this->output->writeln("<info>xDebug enabled.</info>");
+    $this->output->writeln("<info>Xdebug PHP extension enabled.</info>")
+    $this->output->writeln("You must also enable Xdebug listening in your code editor to begin a debugging session.");
   }
 
   /**
@@ -133,10 +134,10 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    *   The contents of php.ini.
    */
   protected function disableXDebug($destination_file, $contents) {
-    $this->logger->notice("Disabling xdebug in $destination_file...");
+    $this->logger->notice("Disabling Xdebug PHP extension in $destination_file...");
     $new_contents = preg_replace('/(;)*(zend_extension=xdebug\.so)/', ';$2', $contents);
     file_put_contents($destination_file, $new_contents);
-    $this->output->writeln("<info>xDebug disabled.</info>");
+    $this->output->writeln("<info>Xdebug PHP extension disabled.</info>");
   }
 
 }

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -122,7 +122,7 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
     // Note that this replaces 1 or more ";" characters.
     $new_contents = preg_replace('/(;)+(zend_extension=xdebug\.so)/', '$2', $contents);
     file_put_contents($destination_file, $new_contents);
-    $this->output->writeln("<info>Xdebug PHP extension enabled.</info>")
+    $this->output->writeln("<info>Xdebug PHP extension enabled.</info>");
     $this->output->writeln("You must also enable Xdebug listening in your code editor to begin a debugging session.");
   }
 

--- a/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
@@ -65,7 +65,7 @@ class IdeXdebugToggleCommandTest extends IdeRequiredTestBase {
     $this->assertFileExists($this->xdebugFilePath);
     $this->assertStringContainsString('zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath));
     $this->assertStringNotContainsString(';zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath));
-    $this->assertStringContainsString("Enabling Xdebug in {$this->xdebugFilePath}...", $this->getDisplay());
+    $this->assertStringContainsString("Enabling Xdebug PHP extension in {$this->xdebugFilePath}...", $this->getDisplay());
   }
 
   /**
@@ -78,7 +78,7 @@ class IdeXdebugToggleCommandTest extends IdeRequiredTestBase {
     $this->executeCommand([], []);
     $this->assertFileExists($this->xdebugFilePath);
     $this->assertStringContainsString(';zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath));
-    $this->assertStringContainsString("Disabling Xdebug in {$this->xdebugFilePath}...", $this->getDisplay());
+    $this->assertStringContainsString("Disabling Xdebug PHP extension in {$this->xdebugFilePath}...", $this->getDisplay());
   }
 
 }

--- a/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
@@ -65,7 +65,7 @@ class IdeXdebugToggleCommandTest extends IdeRequiredTestBase {
     $this->assertFileExists($this->xdebugFilePath);
     $this->assertStringContainsString('zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath));
     $this->assertStringNotContainsString(';zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath));
-    $this->assertStringContainsString("Enabling xdebug in {$this->xdebugFilePath}...", $this->getDisplay());
+    $this->assertStringContainsString("Enabling Xdebug in {$this->xdebugFilePath}...", $this->getDisplay());
   }
 
   /**
@@ -78,7 +78,7 @@ class IdeXdebugToggleCommandTest extends IdeRequiredTestBase {
     $this->executeCommand([], []);
     $this->assertFileExists($this->xdebugFilePath);
     $this->assertStringContainsString(';zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath));
-    $this->assertStringContainsString("Disabling xdebug in {$this->xdebugFilePath}...", $this->getDisplay());
+    $this->assertStringContainsString("Disabling Xdebug in {$this->xdebugFilePath}...", $this->getDisplay());
   }
 
 }


### PR DESCRIPTION
Motivation
----------
@wimleers expressed some confusion that Xdebug wasn't automatically listening after running this command. Documentation is the easiest short-term solution.

Proposed changes
---------
Notify customers they must also enable listening in the IDE.

Alternatives considered
---------
Automatically enable listening. Here be dragons though ("I tried to run Composer and it hung indefinitely...")

Testing steps
---------

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli ide:xdebug` and see the help text.
