### PR TITLE
Do not require authentication for ide:share command

### DIFF
--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -23,6 +23,16 @@ class IdeShareCommand extends CommandBase {
   private $shareCodeFilepaths;
 
   /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   *
+   * @return bool
+   */
+  protected function commandRequiresAuthentication(InputInterface $input): bool
+  {
+    return FALSE;
+  }
+
+  /**
    * {inheritdoc}.
    */
   protected function configure() {

--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -27,8 +27,7 @@ class IdeShareCommand extends CommandBase {
    *
    * @return bool
    */
-  protected function commandRequiresAuthentication(InputInterface $input): bool
-  {
+  protected function commandRequiresAuthentication(InputInterface $input): bool {
     return FALSE;
   }
 


### PR DESCRIPTION
Motivation
----------
Fixes #354

You should be able to share your IDE code without having to be authenticated against the Cloud Platform API. If you're in your IDE, it means you've already successfully authenticated against the Acquia SSO portal, so there's no inherent security risk to doing this.

Proposed changes
---------
Do not require `acli ide:share` to be authenticated against the Cloud Platform API

Alternatives considered
---------
Status quo

Testing steps
---------
How can we replicate the issue and verify that this PR fixes it?

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli ide:share` without being authenticated against the Cloud Platform API. You should see the share URL immediately.
