### PR TITLE
Tiny refactor: commandRequiresAuthentication

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -395,8 +395,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @return bool
    */
   protected function commandRequiresAuthentication(InputInterface $input): bool {
-    // In fact some other commands such as `api:list` don't require auth, but it's easier and safer to assume they do.
-    return $input->getFirstArgument() !== 'auth:login';
+    // Assume commands require authentication unless they opt out by overriding this method.
+    return TRUE;
   }
 
   /**


### PR DESCRIPTION
I was confused reviewing https://github.com/acquia/cli/pull/355 because I recalled exempting commands from authentication via the base `commandRequiresAuthentication` method. Since `auth:login` already overrides `commandRequiresAuthentication` it should return TRUE by default, and point people to overriding it as the correct way to exempt commands.

https://github.com/acquia/cli/blob/40085f651405f7af6bcfed057ab2c715892014c7/src/Command/Auth/AuthLoginCommand.php#L39-L41