### PR TITLE
Print version for debugging

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -287,6 +287,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     // @todo This logger is not shared in the container! Fix that.
     $this->setLogger(new ConsoleLogger($output));
 
+    // Output and logging are initialized after this point.
+    $this->output->writeln('Acquia CLI version: ' . $this->getApplication()->getVersion(), OutputInterface::VERBOSITY_DEBUG);
     $this->questionHelper = $this->getHelper('question');
     $this->checkAndPromptTelemetryPreference();
     $this->telemetryHelper->initializeAmplitude($this->amplitude);


### PR DESCRIPTION
To aid in debugging issues like https://github.com/acquia/cli/issues/356 where we have debug logs, it would help to know the Acquia CLI version since people often fail to report it independently.