### PR TITLE
Disable update notifications in development

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1076,7 +1076,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    */
   protected function checkForNewVersion(InputInterface $input, OutputInterface $output): void {
     // Running on API commands would corrupt JSON output.
-    if (strpos($input->getArgument('command'), 'api:')) {
+    if (strpos($input->getArgument('command'), 'api:') !== FALSE) {
       return;
     }
     // Bale for development builds.

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1075,9 +1075,16 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    */
   protected function checkForNewVersion(InputInterface $input, OutputInterface $output): void {
+    // Running on API commands would corrupt JSON output.
+    if (strpos($input->getArgument('command'), 'api:')) {
+      return;
+    }
+    // Bale for development builds.
+    if ($this->getApplication()->getVersion() == '@package_version@') {
+      return;
+    }
     try {
-      // Running on API commands would corrupt JSON output.
-      if (strpos($input->getArgument('command'), 'api:') === FALSE && $this->hasUpdate()) {
+      if ($this->hasUpdate()) {
         $output->writeln("A newer version of Acquia CLI is available. Run <options=bold>acli self-update</> to update.");
       }
     } catch (\Exception $e) {


### PR DESCRIPTION
When developing on ACLI you get an update notification on every command because of the placeholder version string.