### PR TITLE
DX-2641: Allow passing SSH commands

### DIFF
--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -20,11 +20,12 @@ class SshCommand extends SshBaseCommand {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Open a new SSH session to a Cloud Platform environment')
+    $this->setDescription('Use SSH to open a shell or run a command in a Cloud Platform environment')
       ->setAliases(['ssh'])
       ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
-      ->addArgument('ssh_command', InputArgument::OPTIONAL, 'Command to run via SSH (opens a shell by default)')
-      ->addUsage("<app>.<env>");
+      ->addArgument('ssh_command', InputArgument::OPTIONAL, 'Command to run via SSH (if not provided, opens a shell in the site directory)')
+      ->addUsage("myapp.dev # open a shell in the myapp.dev environment")
+      ->addUsage("myapp.dev ls # list files in the myapp.dev environment and return");
   }
 
   /**

--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -23,6 +23,7 @@ class SshCommand extends SshBaseCommand {
     $this->setDescription('Open a new SSH session to a Cloud Platform environment')
       ->setAliases(['ssh'])
       ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
+      ->addArgument('ssh_command', InputArgument::OPTIONAL, 'Command to run via SSH (opens a shell by default)')
       ->addUsage("<app>.<env>");
   }
 
@@ -39,8 +40,9 @@ class SshCommand extends SshBaseCommand {
     $environment = $this->getEnvironmentFromAliasArg($alias);
     $arguments = $input->getArguments();
     array_shift($arguments);
-    $arguments[] = 'cd /var/www/html/' . $alias . '; exec $SHELL -l';
-
+    if (empty($arguments['ssh_command'])) {
+      $arguments['ssh_command'] = 'cd /var/www/html/' . $alias . '; exec $SHELL -l';
+    }
     return $this->sshHelper->executeCommand($environment, $arguments, TRUE, NULL)->getExitCode();
   }
 


### PR DESCRIPTION
Motivation
----------
@eporama requested the ability to run custom commands via `remote:ssh`

Proposed changes
---------
Add the ability to pass custom commands. If no command is provided, default to the old behavior (open a shell).

Testing steps
---------
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli remote:ssh myapp.dev` to ensure the original behavior still works.
4. Run `acli remote:ssh myapp.dev -- ls -al` or any other command to see that it gets executed via SSH.
