### PR TITLE
DX-2794 | Increase timeout for IDE creation from 30 to 45 minutes

### DIFF
--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -102,7 +102,7 @@ class IdeCreateCommand extends IdeCommandBase {
         $this->logger->debug($e->getMessage());
       }
     });
-    LoopHelper::addTimeoutToLoop($loop, 30, $spinner, $this->output);
+    LoopHelper::addTimeoutToLoop($loop, 45, $spinner, $this->output);
 
     // Start the loop.
     try {


### PR DESCRIPTION
Motivation
----------
This solves user-end expectations `ide:create` for the server-side status-quo.

Proposed changes
---------
The timeout for IDE creation is now in line with the server-side API soon to be released.

Alternatives considered
---------
We're working on more structural fixes for the middle-long term.

Testing steps
---------
How can we replicate the issue and verify that this PR fixes it?

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. (add specific steps for this pr)
