### PR TITLE
Fix test namespaces

### DIFF
--- a/tests/phpunit/src/Commands/CommandBaseTest.php
+++ b/tests/phpunit/src/Commands/CommandBaseTest.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Cli\Tests\Commands;
 
-use Acquia\Cli\Command\ClearCacheCommand;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ide\IdeListCommand;
 use Acquia\Cli\Command\LinkCommand;

--- a/tests/phpunit/src/Misc/ApiSpecTest.php
+++ b/tests/phpunit/src/Misc/ApiSpecTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acquia\Cli\Tests;
+namespace Acquia\Cli\Tests\Misc;
 
 use PHPUnit\Framework\TestCase;
 use Webmozart\PathUtil\Path;

--- a/tests/phpunit/src/Misc/LandoInfoTest.php
+++ b/tests/phpunit/src/Misc/LandoInfoTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Acquia\Cli\Tests;
+namespace Acquia\Cli\Tests\Misc;
 
 use Acquia\Cli\Command\ClearCacheCommand;
+use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 
 /**

--- a/tests/phpunit/src/Misc/LocalMachineHelperTest.php
+++ b/tests/phpunit/src/Misc/LocalMachineHelperTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Acquia\Cli\Tests;
+namespace Acquia\Cli\Tests\Misc;
+
+use Acquia\Cli\Tests\TestBase;
 
 /**
  * Class LocalMachineHelperTest.


### PR DESCRIPTION
Motivation
----------
Running `composer install` generates warnings:
> Class Acquia\Cli\Tests\ApiSpecTest located in ./tests/phpunit/src/Misc/ApiSpecTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Acquia\Cli\Tests\LocalMachineHelperTest located in ./tests/phpunit/src/Misc/LocalMachineHelperTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Acquia\Cli\Tests\LandoInfoTest located in ./tests/phpunit/src/Misc/LandoInfoTest.php does not comply with psr-4 autoloading standard. Skipping.

Proposed changes
---------
Fix the namespaces
