### PR TITLE
DX-3045: Don't reuse AcquiaCloudApi client

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -56,7 +56,9 @@ services:
   AcquiaCloudApi\Connector\Client: ~
   AcquiaCloudApi\Connector\Connector:
     arguments:
-      $config: ['@=service("datastore.cloud").get("key")', '@=service("datastore.cloud").get("secret")']
+      $config:
+        key: '@=service("datastore.cloud").get("key")'
+        secret: '@=service("datastore.cloud").get("secret")'
   AcquiaCloudApi\Connector\ConnectorInterface:
     alias: AcquiaCloudApi\Connector\Connector
   AcquiaLogstream\LogstreamManager: ~

--- a/src/Helpers/ClientService.php
+++ b/src/Helpers/ClientService.php
@@ -4,32 +4,19 @@ namespace Acquia\Cli\Helpers;
 
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Connector\Connector;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 class ClientService {
 
-  private $acquiaCloudClient;
+  private $connector;
 
-  private $cloud_api_conf;
-
-  public function __construct(JsonFileStore $datastoreCloud) {
-    $this->cloud_api_conf = $datastoreCloud;
+  public function __construct(Connector $connector) {
+    $this->connector = $connector;
   }
 
   /**
    * @return \AcquiaCloudApi\Connector\Client
    */
   public function getClient(): Client {
-    if (isset($this->acquiaCloudClient)) {
-      return $this->acquiaCloudClient;
-    }
-
-    $config = [
-      'key' => $this->cloud_api_conf->get('key'),
-      'secret' => $this->cloud_api_conf->get('secret'),
-    ];
-    $this->acquiaCloudClient = Client::factory(new Connector($config));
-
-    return $this->acquiaCloudClient;
+    return Client::factory($this->connector);
   }
 }

--- a/src/Helpers/ClientService.php
+++ b/src/Helpers/ClientService.php
@@ -5,6 +5,15 @@ namespace Acquia\Cli\Helpers;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Connector\Connector;
 
+/**
+ * Factory producing Acquia Cloud Api clients.
+ *
+ * This class is only necessary as a testing shim, so that we can prophesize
+ * client queries. Consumers could otherwise just call
+ * Client::factory($connector) directly.
+ *
+ * @package Acquia\Cli\Helpers
+ */
 class ClientService {
 
   private $connector;


### PR DESCRIPTION
Motivation
----------
We re-use the Acquia Cloud API client across multiple requests, which probably isn't good because we directly modify the client query and options in commands. This means that queries/options from one Cloud API call could bleed into the next, even across different commands. We have seen odd behavior from the Cloud API client that could be attributable to this, though I don't know for sure.

Proposed changes
---------
- Use a Client factory pattern as recommended in the acquia-php-sdk-v2 docs instead of re-using a single client
- Fix autowiring so that we can greatly simplify the ClientService class

Alternatives considered
---------
We could probably get rid of the ClientService completely, but it's still useful to facilitate testing. If we got rid of it, then we'd use dependency injection to store $connector on the command base, and in every `Command::execute()` we'd call `Client::factory($this->connector);`. This would break testing because it prevents us from prophesizing the client calls (see how `TestBase::clientProphecy` is used for mocking)

Testing steps
---------
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Just make sure that commands that invoke the API (`ide:list`, `api:accounts:find`, etc) work as before
