### PR TITLE
DX-3061: Generate multisite settings and files for pulls

### DIFF
--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -44,10 +44,7 @@ class PullCommand extends PullCommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    // Generate database settings and files now in case we need them later.
-    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
-      $this->ideDrupalSettingsRefresh();
-    }
+    parent::execute($input, $output);
 
     if (!$input->getOption('no-code')) {
       $this->pullCode($input, $output);

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -44,6 +44,11 @@ class PullCommand extends PullCommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
+    // Generate database settings and files now in case we need them later.
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      $this->ideDrupalSettingsRefresh();
+    }
+
     if (!$input->getOption('no-code')) {
       $this->pullCode($input, $output);
     }

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -56,6 +56,22 @@ abstract class PullCommandBase extends CommandBase {
    * @param \Symfony\Component\Console\Input\InputInterface $input
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    *
+   * @return int 0 if everything went fine, or an exit code
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    // Generate settings and files in case we need them later.
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      $this->ideDrupalSettingsRefresh();
+    }
+
+    return 0;
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -88,9 +88,6 @@ abstract class PullCommandBase extends CommandBase {
     $database = $this->determineSourceDatabase($acquia_cloud_client, $source_environment);
     $this->checklist->addItem('Importing Drupal database copy from the Cloud Platform');
     $this->importRemoteDatabase($source_environment, $database, $this->getOutputCallback($output, $this->checklist));
-    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
-      $this->createDbSettingsFile($source_environment, $database);
-    }
     $this->checklist->completePreviousItem();
   }
 
@@ -760,14 +757,10 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   /**
-   * @param \AcquiaCloudApi\Response\EnvironmentResponse $source_environment
+   * Setup files and directories for multisite applications.
    */
-  protected function createDbSettingsFile(EnvironmentResponse $source_environment, $database): void {
-    $sitegroup = self::getSiteGroupFromSshUrl($source_environment);
-    $default_path = "/var/www/site-php/$sitegroup/$sitegroup-settings.inc";
-    $db_name_path = "/var/www/site-php/$sitegroup/{$database->name}-settings.inc";
-    $this->localMachineHelper->getFilesystem()
-      ->copy($default_path, $db_name_path);
+  protected function ideDrupalSettingsRefresh() {
+    $this->localMachineHelper->execute(['/ide/drupal-setup.sh']);
   }
 
 }

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -35,6 +35,10 @@ class PullDatabaseCommand extends PullCommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
+    // Generate database settings now in case we need them later.
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      $this->ideDrupalSettingsRefresh();
+    }
     $this->pullDatabase($input, $output);
     if (!$input->getOption('no-scripts')) {
       $this->runDrushCacheClear($this->getOutputCallback($output, $this->checklist));

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -35,10 +35,7 @@ class PullDatabaseCommand extends PullCommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    // Generate database settings now in case we need them later.
-    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
-      $this->ideDrupalSettingsRefresh();
-    }
+    parent::execute($input, $output);
     $this->pullDatabase($input, $output);
     if (!$input->getOption('no-scripts')) {
       $this->runDrushCacheClear($this->getOutputCallback($output, $this->checklist));

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -33,10 +33,7 @@ class PullFilesCommand extends PullCommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    // Generate file directories now in case we need them later.
-    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
-      $this->ideDrupalSettingsRefresh();
-    }
+    parent::execute($input, $output);
     $this->pullFiles($input, $output);
 
     return 0;

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -33,6 +33,10 @@ class PullFilesCommand extends PullCommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
+    // Generate file directories now in case we need them later.
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      $this->ideDrupalSettingsRefresh();
+    }
     $this->pullFiles($input, $output);
 
     return 0;

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -157,4 +157,17 @@ abstract class PullCommandTestBase extends CommandTestBase {
       ->shouldBeCalled();
   }
 
+  /**
+   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
+   */
+  protected function mockDrupalSettingsRefresh(
+    ObjectProphecy $local_machine_helper
+  ): void {
+    $local_machine_helper
+      ->execute([
+        '/ide/drupal-setup.sh',
+      ])
+      ->shouldBeCalled();
+  }
+
 }

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -130,7 +130,9 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     // Set up file system.
     $local_machine_helper->getFilesystem()->willReturn($fs)->shouldBeCalled();
 
+    // Mock IDE filesystem.
     if ($mock_ide_fs) {
+      $this->mockDrupalSettingsRefresh($local_machine_helper);
       $this->mockSettingsFiles($fs);
     }
 
@@ -288,9 +290,6 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
   }
 
   protected function mockSettingsFiles($fs): void {
-    $fs->copy('/var/www/site-php/profserv2/profserv2-settings.inc', '/var/www/site-php/profserv2/profserv2-settings.inc')
-      ->willReturn()
-      ->shouldBeCalled();
     $fs->remove(Argument::type('string'))
       ->willReturn()
       ->shouldBeCalled();

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -116,6 +116,9 @@ class PullFilesCommandTest extends PullCommandTestBase {
 
   public function testInvalidCwd(): void {
     IdeRequiredTestBase::setCloudIdeEnvVars();
+    $local_machine_helper = $this->mockLocalMachineHelper();
+    $this->mockDrupalSettingsRefresh($local_machine_helper);
+    $this->command->localMachineHelper = $local_machine_helper->reveal();
     try {
       $this->executeCommand([], []);
     } catch (AcquiaCliException $exception) {


### PR DESCRIPTION
Motivation
----------
Acquia CLI generates a new per-site db settings file during `pull:db`. Cloud IDEs now have a server-side script that does this for _every_ site, plus sets up file directories. Acquia CLI should delegate to the Cloud IDE script instead of managing the settings itself.

Proposed changes
---------
- Run the IDE script rather than generating files individually
- Run the script as part of `pull:files` (previously only ran during `pull:db`)
- Make sure the script only runs once per command, and run it _before_ the rest of the command (previously it ran after), since at some point we might support multi-dbs and need those db in place before pulling them.

Alternatives considered
---------
There's probably a way to run this script singly as part of a pre-command or event hook instead of calling the script in each command separately, but I think this is fine for now.

Testing steps
---------
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli pull`, `acli pull:db`, or `acli pull:files` in an IDE environment attached to a multisite app
4. Verify that settings files corresponding to all sites are generated at `/var/www/site-php/<foo.bar>`
