### PR TITLE
DX-2994: Fix #366: Log exceptions

### DIFF
--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Yaml\Yaml;
 use Webmozart\KeyValueStore\JsonFileStore;
-use Zumba\Amplitude\Amplitude;
 
 /**
  *
@@ -66,11 +65,6 @@ class ApiCommandHelper {
    */
   protected $acliConfigFilepath;
 
-  /**
-   * @var \Zumba\Amplitude\Amplitude
-   */
-  protected $amplitude;
-
   protected $repoRoot;
 
   /**
@@ -101,7 +95,6 @@ class ApiCommandHelper {
    * @param \Webmozart\KeyValueStore\JsonFileStore $datastoreCloud
    * @param \Webmozart\KeyValueStore\JsonFileStore $datastoreAcli
    * @param \Acquia\Cli\Helpers\TelemetryHelper $telemetryHelper
-   * @param \Zumba\Amplitude\Amplitude $amplitude
    * @param string $acliConfigFilepath
    * @param string $repoRoot
    * @param \Acquia\Cli\Helpers\ClientService $cloudApiClientService
@@ -115,7 +108,6 @@ class ApiCommandHelper {
     JsonFileStore $datastoreCloud,
     YamlStore $datastoreAcli,
     TelemetryHelper $telemetryHelper,
-    Amplitude $amplitude,
     string $acliConfigFilepath,
     string $repoRoot,
     ClientService $cloudApiClientService,
@@ -128,7 +120,6 @@ class ApiCommandHelper {
     $this->datastoreCloud = $datastoreCloud;
     $this->acliDatastore = $datastoreAcli;
     $this->telemetryHelper = $telemetryHelper;
-    $this->amplitude = $amplitude;
     $this->acliConfigFilepath = $acliConfigFilepath;
     $this->repoRoot = $repoRoot;
     $this->cloudApiClientService = $cloudApiClientService;
@@ -480,7 +471,7 @@ class ApiCommandHelper {
 
         $command_name = 'api:' . $schema['x-cli-name'];
         $command = new ApiCommandBase($this->cloudConfigFilepath, $this->localMachineHelper, $this->datastoreCloud,
-          $this->acliDatastore, $this->telemetryHelper, $this->amplitude, $this->acliConfigFilepath, $this->repoRoot,
+          $this->acliDatastore, $this->telemetryHelper, $this->acliConfigFilepath, $this->repoRoot,
           $this->cloudApiClientService, $this->logstreamManager, $this->sshHelper, $this->sshDir);
         $command->setName($command_name);
         $command->setDescription($schema['summary']);

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -120,11 +120,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    */
   protected $acliConfigFilepath;
 
-  /**
-   * @var \Zumba\Amplitude\Amplitude
-   */
-  protected $amplitude;
-
   protected $repoRoot;
 
   /**
@@ -165,7 +160,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @param \Webmozart\KeyValueStore\JsonFileStore $datastoreCloud
    * @param \Acquia\Cli\DataStore\YamlStore $datastoreAcli
    * @param \Acquia\Cli\Helpers\TelemetryHelper $telemetryHelper
-   * @param \Zumba\Amplitude\Amplitude $amplitude
    * @param string $acliConfigFilepath
    * @param string $repoRoot
    * @param \Acquia\Cli\Helpers\ClientService $cloudApiClientService
@@ -179,7 +173,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     JsonFileStore $datastoreCloud,
     YamlStore $datastoreAcli,
     TelemetryHelper $telemetryHelper,
-    Amplitude $amplitude,
     string $acliConfigFilepath,
     string $repoRoot,
     ClientService $cloudApiClientService,
@@ -192,7 +185,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->datastoreCloud = $datastoreCloud;
     $this->datastoreAcli = $datastoreAcli;
     $this->telemetryHelper = $telemetryHelper;
-    $this->amplitude = $amplitude;
     $this->acliConfigFilepath = $acliConfigFilepath;
     $this->repoRoot = $repoRoot;
     $this->cloudApiClientService = $cloudApiClientService;
@@ -294,7 +286,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->output->writeln('Acquia CLI version: ' . $this->getApplication()->getVersion(), OutputInterface::VERBOSITY_DEBUG);
     $this->questionHelper = $this->getHelper('question');
     $this->checkAndPromptTelemetryPreference();
-    $this->telemetryHelper->initializeAmplitude($this->amplitude);
+    $this->telemetryHelper->initializeAmplitude();
 
     if ($this->commandRequiresAuthentication($this->input) && !self::isMachineAuthenticated($this->datastoreCloud)) {
       throw new AcquiaCliException('This machine is not yet authenticated with the Cloud Platform. Please run `acli auth:login`');
@@ -367,7 +359,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       'os_name' => OsInfo::os(),
       'os_version' => OsInfo::version(),
     ];
-    $this->amplitude->queueEvent('Ran command', $event_properties);
+    Amplitude::getInstance()->queueEvent('Ran command', $event_properties);
 
     return $exit_code;
   }

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -66,12 +66,11 @@ class TelemetryHelper {
   /**
    * Initializes Amplitude.
    *
-   * @param \Zumba\Amplitude\Amplitude $amplitude
-   *
    * @throws \Exception
    */
-  public function initializeAmplitude(Amplitude $amplitude): void {
+  public function initializeAmplitude(): void {
     $send_telemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
+    $amplitude = Amplitude::getInstance();
     $amplitude->setOptOut($send_telemetry === FALSE);
 
     if ($send_telemetry === FALSE) {

--- a/symfony.lock
+++ b/symfony.lock
@@ -29,9 +29,6 @@
     "amphp/sync": {
         "version": "v1.4.0"
     },
-    "brainmaestro/composer-git-hooks": {
-        "version": "v2.8.3"
-    },
     "brick/math": {
         "version": "0.9.1"
     },

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -342,7 +342,6 @@ class ApiCommandTest extends CommandTestBase {
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->telemetryHelper,
-      $this->amplitudeProphecy->reveal(),
       $this->acliConfigFilename,
       $this->projectFixtureDir,
       $this->clientServiceProphecy->reveal(),

--- a/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
@@ -18,7 +18,6 @@ class ApiListCommandTest extends CommandTestBase {
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->telemetryHelper,
-      $this->amplitudeProphecy->reveal(),
       $this->acliConfigFilename,
       $this->projectFixtureDir,
       $this->clientServiceProphecy->reveal(),

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -6,8 +6,6 @@ use Acquia\Cli\Command\LinkCommand;
 use Acquia\Cli\Command\TelemetryCommand;
 use Acquia\Cli\Helpers\DataStoreContract;
 use Acquia\Cli\Tests\CommandTestBase;
-use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
-use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 use Webmozart\PathUtil\Path;
 
@@ -85,7 +83,6 @@ class TelemetryCommandTest extends CommandTestBase {
     $this->createMockConfigFile();
     $this->createMockAcliConfigFile('a47ac10b-58cc-4372-a567-0e02b2c3d470');
     $this->mockApplicationRequest();
-    $this->mockAmplitudeRequest();
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
 
@@ -100,53 +97,10 @@ class TelemetryCommandTest extends CommandTestBase {
   public function testAmplitudeDisabled(): void {
     $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => FALSE];
     $this->createMockConfigFile();
-    $this->amplitudeProphecy->setOptOut(TRUE)->shouldBeCalled();
-    $this->amplitudeProphecy->queueEvent('Ran command', Argument::type('array'))->shouldBeCalled();
     $this->executeCommand();
 
     $this->assertEquals(0, $this->getStatusCode());
     $this->prophet->checkPredictions();
-  }
-
-  public function testAmplitudeEnabled(): void {
-    $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => TRUE];
-    $this->createMockConfigFile();
-
-    $this->mockAmplitudeRequest();
-    $this->executeCommand();
-
-    $this->prophet->checkPredictions();
-    $this->assertEquals(0, $this->getStatusCode());
-  }
-
-  public function testMigrateLegacyTelemetryPreference(): void {
-    $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => NULL];
-    $this->createMockConfigFile();
-    $this->fs->remove($this->legacyAcliConfigFilepath);
-    $legacy_acli_config = ['send_telemetry' => TRUE];
-    $contents = json_encode($legacy_acli_config);
-    $this->fs->dumpFile($this->legacyAcliConfigFilepath, $contents);
-    $this->mockAmplitudeRequest();
-    $this->executeCommand();
-    $this->prophet->checkPredictions();
-    $this->assertEquals(0, $this->getStatusCode());
-    $this->fs->remove($this->legacyAcliConfigFilepath);
-  }
-
-  protected function mockAmplitudeRequest(): void {
-    $account = json_decode(file_get_contents(Path::join($this->fixtureDir, '/account.json')));
-    $this->clientProphecy->request('get', '/account')->willReturn($account)->shouldBeCalled();
-
-    $this->amplitudeProphecy->queueEvent('Ran command', Argument::type('array'))->shouldBeCalled();
-    $this->amplitudeProphecy->init(Argument::type('string'))->shouldBeCalled();
-    $this->amplitudeProphecy->setUserProperties(Argument::type('array'))->shouldBeCalled();
-    $this->amplitudeProphecy->setDeviceId(Argument::type('string'))->shouldBeCalled();
-    $this->amplitudeProphecy->setUserId(Argument::type('string'))->shouldBeCalled();
-    $this->amplitudeProphecy->setOptOut(FALSE)->shouldBeCalled();
-    $this->amplitudeProphecy->logQueuedEvents()->shouldBeCalled();
-    // Ensure problems with telemetry reporting are handled silently.
-    // This doesn't seem to actually trigger code coverage of the exception catch, why?
-    $this->amplitudeProphecy->setUserId()->willThrow(new IdentityProviderException('test', 1, 'test'));
   }
 
 }

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -103,4 +103,17 @@ class TelemetryCommandTest extends CommandTestBase {
     $this->prophet->checkPredictions();
   }
 
+  public function testMigrateLegacyTelemetryPreference(): void {
+    $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => NULL];
+    $this->createMockConfigFile();
+    $this->fs->remove($this->legacyAcliConfigFilepath);
+    $legacy_acli_config = ['send_telemetry' => FALSE];
+    $contents = json_encode($legacy_acli_config);
+    $this->fs->dumpFile($this->legacyAcliConfigFilepath, $contents);
+    $this->executeCommand();
+    $this->prophet->checkPredictions();
+    $this->assertEquals(0, $this->getStatusCode());
+    $this->fs->remove($this->legacyAcliConfigFilepath);
+  }
+
 }

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -35,7 +35,6 @@ use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
 use Webmozart\KeyValueStore\JsonFileStore;
 use Webmozart\PathUtil\Path;
-use Zumba\Amplitude\Amplitude;
 
 /**
  * Class CommandTestBase.
@@ -77,11 +76,6 @@ abstract class TestBase extends TestCase {
   protected $input;
 
   protected $output;
-
-  /**
-   * @var \Prophecy\Prophecy\ObjectProphecy|Amplitude
-   */
-  protected $amplitudeProphecy;
 
   /**
    * @var \Prophecy\Prophecy\ObjectProphecy|\AcquiaCloudApi\Connector\Client
@@ -187,7 +181,6 @@ abstract class TestBase extends TestCase {
     $this->acliConfigFilepath = $this->projectFixtureDir . '/' . $this->acliConfigFilename;
     $this->datastoreAcli = new YamlStore($this->acliConfigFilepath);
     $this->datastoreCloud = new JsonFileStore($this->cloudConfigFilepath, 1);
-    $this->amplitudeProphecy = $this->prophet->prophesize(Amplitude::class);
     $this->clientProphecy = $this->prophet->prophesize(Client::class);
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN', 'Accept' => 'application/json']);
     $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
@@ -287,7 +280,6 @@ abstract class TestBase extends TestCase {
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->telemetryHelper,
-      $this->amplitudeProphecy->reveal(),
       $this->acliConfigFilename,
       $this->acliRepoRoot,
       $this->clientServiceProphecy->reveal(),


### PR DESCRIPTION
Motivation
----------
Fixes #366

Proposed changes
---------
Use Amplitude consistently as a [singleton service](https://github.com/zumba/amplitude-php#zumba-amplitude-php) so that exceptions are reported correctly.

Alternatives considered
---------
Use Amplitude as an object or Symfony service, and pass it everywhere it's needed (including the exception). I don't know how to do this in a clean way.

Testing steps
---------
How can we replicate the issue and verify that this PR fixes it?

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Remove your API credentials
4. Run a command requiring authentication (`ide:create`) and verify that the exception thrown shows up in Amplitude

![screenshot-analytics amplitude com-2020 12 15-13_13_34](https://user-images.githubusercontent.com/1984514/102273571-6054e800-3ed7-11eb-9176-ad7f4034b7a2.png)
