### PR TITLE
DX-3073: Disable update notifications in Cloud IDE

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1086,7 +1086,12 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     if ($this->getApplication()->getVersion() == '@package_version@') {
       return;
     }
+    // Bale in Cloud IDEs to avoid hitting Github API rate limits.
+    if (!AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      return;
+    }
     try {
+      // Bale in Cloud IDEs to avoid hitting Github API rate limits.
       if ($this->hasUpdate()) {
         $output->writeln("A newer version of Acquia CLI is available. Run <options=bold>acli self-update</> to update.");
       }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1091,7 +1091,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       return;
     }
     try {
-      // Bale in Cloud IDEs to avoid hitting Github API rate limits.
       if ($this->hasUpdate()) {
         $output->writeln("A newer version of Acquia CLI is available. Run <options=bold>acli self-update</> to update.");
       }


### PR DESCRIPTION
Motivation
----------
Because Cloud IDEs are behind a NAT and share external IPs, if a bunch of users all run `acli self-update` within a 60-minute interval it can hit Github API rate limits.

Proposed changes
---------
Disable update notifications so we aren't actively encouraging people to self-update at the same time when a new release comes out. They can still choose to self-update, or wait for the next platform release when ACLI is updated.

Alternatives considered
---------
Completely disable self-updates, or make the self-update command hidden in Cloud IDEs. I'd rather take a gentler approach to start.

Ideally we could provide a Github API key somehow, but consolidation/self-update doesn't support it.

