### PR TITLE
DX-2557: Enable release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+name-template: '$RESOLVED_VERSION 🌈'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚨 Major changes'
+    label: 'breaking change'
+  - title: '🚀 Enhancements'
+    label: 'enhancement'
+  - title: '🐛 Bug Fixes'
+    label: 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'breaking change'
+  minor:
+    labels:
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+  default: patch
+template: |
+  ## What's new since $PREVIOUS_TAG
+
+  $CHANGES


### PR DESCRIPTION
Motivation
----------
Creating release notes consistently is a pain

Proposed changes
---------
Use https://github.com/release-drafter/release-drafter to automatically generate release notes based on PR labels:
- Breaking / major changes (major version increment)
- Enhancements (minor version increment)
- Bug fixes (patch version increment)

New releases will be kept in a draft state and constantly updated with new PRs until a human publishes them.

Alternatives considered
---------
We could split control of the issue type and severity. So have enhancement / bug labels in addition to major / minor / patch labels for direct control over versioning.

Testing steps
---------
I don't think this can be tested until it's merged 🤷 