### PR TITLE
DX-1682: Download db backups via API rather than SSH

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -322,21 +322,6 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   /**
-   * @param $environment
-   * @param $remote_filepath
-   *
-   * @throws \Acquia\Cli\Exception\AcquiaCliException
-   */
-  protected function deleteRemoteDatabaseDump($environment, $remote_filepath): void {
-    $command = ['rm', $remote_filepath];
-    $process = $this->sshHelper->executeCommand($environment, $command, $this->output->isVerbose(), NULL);
-    if (!$process->isSuccessful()) {
-      throw new AcquiaCliException('Could not delete database dump on remote host: {message}',
-        ['message' => $process->getOutput()]);
-    }
-  }
-
-  /**
    * @return bool
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -19,7 +19,8 @@ class PullDatabaseCommand extends PullCommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Copy database from a Cloud Platform environment')
+    $this->setDescription('Import latest database backup from a Cloud Platform environment')
+      ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. You can generate an on-demand backup using api:environments:database-backup-create.')
       ->setAliases(['pull:db'])
       ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,

--- a/tests/fixtures/backups_response.json
+++ b/tests/fixtures/backups_response.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 1,
+    "database": "profserv2",
+    "type": "user",
+    "started_at": "something",
+    "completed_at": "something",
+    "flags": "",
+    "environment": "",
+    "_links": ""
+  }
+]

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\Output;
@@ -338,6 +339,36 @@ abstract class CommandTestBase extends TestBase {
       ->shouldBeCalled();
 
     return $databases_response;
+  }
+
+  /**
+   * @param object $environments_response
+   *
+   * @return object
+   */
+  protected function mockDatabaseBackupsResponse(
+    $environments_response,
+    $db_name
+  ) {
+    $databases_response = json_decode(file_get_contents(Path::join($this->fixtureDir, '/backups_response.json')));
+    $this->clientProphecy->request('get',
+      "/environments/{$environments_response->id}/databases/{$db_name}/backups")
+      ->willReturn($databases_response)
+      ->shouldBeCalled();
+
+    return $databases_response;
+  }
+
+  protected function mockDownloadBackupResponse(
+    $environments_response,
+    $db_name,
+    $backup_id
+  ) {
+    $stream = $this->prophet->prophesize(StreamInterface::class);
+    $this->clientProphecy->request('get',
+      "/environments/{$environments_response->id}/databases/{$db_name}/backups/{$backup_id}/actions/download")
+      ->willReturn($stream->reveal())
+      ->shouldBeCalled();
   }
 
 }

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -166,8 +166,7 @@ abstract class PullCommandTestBase extends CommandTestBase {
     $local_machine_helper
       ->execute([
         '/ide/drupal-setup.sh',
-      ])
-      ->shouldBeCalled();
+      ]);
   }
 
 }


### PR DESCRIPTION
This isn't quite complete (needs tests, code style cleanup) but it should be functional. I wanted to get it up before the long US weekend for initial feedback.

Instead of downloading db backups via MySQL dumps and SSH, this creates an on-demand backup via the Cloud API and then downloads the backup.

This is awesome because it's safer and allows more granular permissioning (no more SSH access to prod! 😬 ), but has two potential gotchas:
- It's a bit slower, because we have to wait for the notification api to tell us that the backup is ready.
- It's not deterministic, in that we have no way to ensure we are downloading the backup _we_ just created, since the notification API does not provide a backup ID. Instead, we just download the most recent backup on the assumption that it's ours.