### PR TITLE
Cache Composer for Windows tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 cache:
   directories:
     - "$HOME/.composer/cache"
+    - "%LOCALAPPDATA%\Composer"
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ php:
 cache:
   directories:
     - "$HOME/.composer/cache"
-    - "%LOCALAPPDATA%\Composer"
+    - "$HOME/AppData/Local/Temp/chocolatey"
+    - "$HOME/AppData/Local/Composer"
 
 services:
   - mysql


### PR DESCRIPTION
Motivation
----------
Our tests take an extra minute or two to run on Windows due to Composer packages not being cached.

Proposed changes
---------
Hopefully speed up tests by caching these files on Windows like we do for Linux.

Testing steps
---------
This can't be tested until it's merged, since Travis CI won't modify a cache except as part of the master branch. I'll follow-up after merging to make sure it works.