### PR TITLE
Fix #403: Commands that invoke auth:login fail to pick up new credentials

### DIFF
--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -63,6 +63,7 @@ class AuthLoginCommand extends CommandBase {
     $this->writeApiCredentialsToDisk($api_key, $api_secret);
     // Client service needs to be reinitialized with new credentials in case
     // this is being run as a sub-command.
+    // @see https://github.com/acquia/cli/issues/403
     $this->cloudApiClientService->setConnector(new Connector(['key' => $api_key, 'secret' => $api_secret]));
     $output->writeln("<info>Saved credentials to <options=bold>{$this->cloudConfigFilepath}</></info>");
 

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\Command\Auth;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use AcquiaCloudApi\Connector\Connector;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -60,7 +61,9 @@ class AuthLoginCommand extends CommandBase {
     $api_key = $this->determineApiKey($input, $output);
     $api_secret = $this->determineApiSecret($input, $output);
     $this->writeApiCredentialsToDisk($api_key, $api_secret);
-
+    // Client service needs to be reinitialized with new credentials in case
+    // this is being run as a sub-command.
+    $this->cloudApiClientService->setConnector(new Connector(['key' => $api_key, 'secret' => $api_secret]));
     $output->writeln("<info>Saved credentials to <options=bold>{$this->cloudConfigFilepath}</></info>");
 
     return 0;

--- a/src/Helpers/ClientService.php
+++ b/src/Helpers/ClientService.php
@@ -19,6 +19,10 @@ class ClientService {
   private $connector;
 
   public function __construct(Connector $connector) {
+    $this->setConnector($connector);
+  }
+
+  public function setConnector(Connector $connector) {
     $this->connector = $connector;
   }
 


### PR DESCRIPTION
Motivation
----------
Fixes #403

Proposed changes
---------
auth:login should re-initialize the Typhonius Connector client service with the new credentials (otherwise it will use whatever was read at the start of the process)

This normally is not a problem since invoking one ACLI command in another is rare. `ide:wizard` is the only command I could find that invokes `auth:login`.

Testing steps
---------
How can we replicate the issue and verify that this PR fixes it?

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Clear your Acquia credentials
4. Run `ide:wizard`
