### PR TITLE
DX-3307: Remove Travis CI caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 
 cache:
   directories:
-    - "$HOME/.composer/cache"
+    - "$HOME/.cache/composer"
     - "$HOME/AppData/Local/Composer"
 
 services:
@@ -68,3 +68,4 @@ script:
   # Run coveralls here instead of after_success because it should break the build if it fails to report.
   # Only run once per build so Coveralls doesn't get confused.
   - if [ $TRAVIS_TEST_RESULT -eq 0 ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_PHP_VERSION" = "7.4" ]; then composer coveralls; fi
+  - ls -al "$HOME/.cache"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ php:
   - 7.4
   - 8.0.0
 
-cache:
-  directories:
-    - "$HOME/.cache/composer"
-    - "$HOME/AppData/Local/Composer"
-
 services:
   - mysql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,4 +63,3 @@ script:
   # Run coveralls here instead of after_success because it should break the build if it fails to report.
   # Only run once per build so Coveralls doesn't get confused.
   - if [ $TRAVIS_TEST_RESULT -eq 0 ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_PHP_VERSION" = "7.4" ]; then composer coveralls; fi
-  - ls -al "$HOME/.cache"


### PR DESCRIPTION
An unfortunate follow-up to #402 . It turns out that all of our caching in Travis (across Linux and Windows) actually _slows down_ builds, paradoxically. Composer 2 is so efficient that caching doesn't benefit it much, and Travis burns a lot of CPU time unpacking and repacking the cache. So let's just stop caching and remove some complexity.

For comparison:
- With caching, total time 8 minutes: https://travis-ci.com/github/acquia/cli/builds/215155409
- Without caching, total time 7:41: https://travis-ci.com/github/acquia/cli/builds/215155701

You can verify whether the cache was used and see its effect by looking at the "composer install" build step. The times are basically identical between builds, but in the cached one you can see that it skips downloading packages.