### PR TITLE
Fixes #339: Store multiple Acquia Cloud tokens in local file.

### DIFF
--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -63,7 +63,7 @@ class AuthLoginCommand extends CommandBase {
         'uuid' => 'create_new',
         'label' => 'Create a new API key',
       ];
-      $selected_key = $this->promptChooseFromObjects($keys, 'uuid', 'label', 'Choose which API key to use');
+      $selected_key = $this->promptChooseFromObjectsOrArrays($keys, 'uuid', 'label', 'Choose which API key to use');
       if ($selected_key['uuid'] !== 'create_new') {
         $this->datastoreCloud->set('acli_key', $selected_key['uuid']);
         $output->writeln("<info>Acquia CLI will use the API Key <options=bold>{$selected_key['label']}</></info>");

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -76,8 +76,8 @@ class AuthLoginCommand extends CommandBase {
     $this->promptOpenBrowserToCreateToken($input, $output);
     $api_key = $this->determineApiKey($input, $output);
     $api_secret = $this->determineApiSecret($input, $output);
-    $this->writeApiCredentialsToDisk($api_key, $api_secret);
     $this->reAuthenticate($api_key, $api_secret);
+    $this->writeApiCredentialsToDisk($api_key, $api_secret);
     $output->writeln("<info>Saved credentials to <options=bold>{$this->cloudConfigFilepath}</></info>");
 
     return 0;

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -61,7 +61,7 @@ class AuthLoginCommand extends CommandBase {
     if ($keys = $this->datastoreCloud->get('keys')) {
       $keys['create_new'] = [
         'uuid' => 'create_new',
-        'label' => '<comment>Create a new API key</comment>',
+        'label' => 'Create a new API key',
       ];
       $selected_key = $this->promptChooseFromObjects($keys, 'uuid', 'label', 'Choose which API key to use');
       if ($selected_key['uuid'] !== 'create_new') {

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -66,13 +66,13 @@ class AuthLoginCommand extends CommandBase {
       $selected_key = $this->promptChooseFromObjects($keys, 'uuid', 'label', 'Choose which API key to use');
       if ($selected_key['uuid'] !== 'create_new') {
         $this->datastoreCloud->set('acli_key', $selected_key['uuid']);
-        $output->writeln("<info>Acquia CLI will use the API Key<options=bold>{$selected_key['label']}</></info>");
+        $output->writeln("<info>Acquia CLI will use the API Key <options=bold>{$selected_key['label']}</></info>");
         // Client service needs to be reinitialized with new credentials in case
         // this is being run as a sub-command.
         // @see https://github.com/acquia/cli/issues/403
         $this->cloudApiClientService->setConnector(new Connector([
-          'key' => $answer,
-          'secret' => $this->datastoreCloud->get('keys')[$answer]['secret'],
+          'key' => $selected_key['uuid'],
+          'secret' => $this->datastoreCloud->get('keys')[$selected_key['uuid']]['secret'],
         ]));
         return 0;
       }

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -56,8 +56,29 @@ class AuthLoginCommand extends CommandBase {
         return 0;
       }
     }
-    $this->promptOpenBrowserToCreateToken($input, $output);
 
+    // If keys already are saved locally, prompt to select.
+    if ($keys = $this->datastoreCloud->get('keys')) {
+      $keys['create_new'] = [
+        'uuid' => 'create_new',
+        'label' => '<comment>Create a new API key</comment>',
+      ];
+      $selected_key = $this->promptChooseFromObjects($keys, 'uuid', 'label', 'Choose which API key to use');
+      if ($selected_key['uuid'] !== 'create_new') {
+        $this->datastoreCloud->set('acli_key', $selected_key['uuid']);
+        $output->writeln("<info>Acquia CLI will use the API Key<options=bold>{$selected_key['label']}</></info>");
+        // Client service needs to be reinitialized with new credentials in case
+        // this is being run as a sub-command.
+        // @see https://github.com/acquia/cli/issues/403
+        $this->cloudApiClientService->setConnector(new Connector([
+          'key' => $answer,
+          'secret' => $this->datastoreCloud->get('keys')[$answer]['secret'],
+        ]));
+        return 0;
+      }
+    }
+
+    $this->promptOpenBrowserToCreateToken($input, $output);
     $api_key = $this->determineApiKey($input, $output);
     $api_secret = $this->determineApiSecret($input, $output);
     $this->writeApiCredentialsToDisk($api_key, $api_secret);
@@ -134,9 +155,16 @@ class AuthLoginCommand extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function writeApiCredentialsToDisk($api_key, $api_secret): void {
-    $this->datastoreCloud->set('key', $api_key);
-    $this->datastoreCloud->set('secret', $api_secret);
+  protected function writeApiCredentialsToDisk(string $api_key, string $api_secret): void {
+    $token_info = $this->cloudApiClientService->getClient()->request('get', "/account/tokens/{$api_key}");
+    $keys = $this->datastoreCloud->get('keys');
+    $keys[$api_key] = [
+      'label' => $token_info->label,
+      'uuid' => $api_key,
+      'secret' => $api_secret,
+    ];
+    $this->datastoreCloud->set('keys', $keys);
+    $this->datastoreCloud->set('acli_key', $api_key);
   }
 
   /**

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -45,7 +45,7 @@ class AuthLogoutCommand extends CommandBase {
         return 0;
       }
     }
-    $this->datastoreCloud->set('acli_key', NULL);
+    $this->datastoreCloud->remove('acli_key');
 
     $output->writeln("Unset the Acquia Cloud API key for Acquia CLI in <options=bold>{$this->cloudConfigFilepath}</></info>");
 

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -40,15 +40,14 @@ class AuthLogoutCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output) {
     /** @var \Webmozart\KeyValueStore\JsonFileStore $cloud_datastore */
     if (CommandBase::isMachineAuthenticated($this->datastoreCloud)) {
-      $answer = $this->io->confirm('Are you sure you\'d like to remove your Cloud Platform API login credentials from this machine?');
+      $answer = $this->io->confirm('Are you sure you\'d like to unset the Acquia Cloud API key for Acquia CLI?');
       if (!$answer) {
         return 0;
       }
     }
-    $this->datastoreCloud->set('key', NULL);
-    $this->datastoreCloud->set('secret', NULL);
+    $this->datastoreCloud->set('acli_key', NULL);
 
-    $output->writeln("Removed Cloud API credentials from <options=bold>{$this->cloudConfigFilepath}</></info>");
+    $output->writeln("Unset the Acquia Cloud API key for Acquia CLI in <options=bold>{$this->cloudConfigFilepath}</></info>");
 
     return 0;
   }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1381,7 +1381,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
         'secret' => $this->datastoreCloud->get('secret'),
       ];
       $this->datastoreCloud->set('keys', $keys);
-      $this->datastoreCloud->get('acli_key', $uuid);
+      $this->datastoreCloud->set('acli_key', $uuid);
     }
   }
 

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1356,7 +1356,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * Migrate from storing preference in acquia-cli.json.
    */
-  protected function migrateLegacySendTelemetryPreference() {
+  protected function migrateLegacySendTelemetryPreference(): void {
     $legacy_acli_config_filepath = $this->localMachineHelper->getLocalFilepath(Path::join(dirname($this->cloudConfigFilepath),
       'acquia-cli.json'));
     if ($this->localMachineHelper->getFilesystem()->exists($legacy_acli_config_filepath)) {

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -487,7 +487,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * The list is generated from an array of objects. The objects much have at least one unique property and one
    * property that can be used as a human readable label.
    *
-   * @param object[]|array $items An array of objects.
+   * @param object[]|array $items An array of objects or arrays.
    * @param string $unique_property The property of the $item that will be used to identify the object.
    * @param string $label_property
    * @param string $question_text
@@ -498,9 +498,12 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    */
   public function promptChooseFromObjects($items, $unique_property, $label_property, $question_text, $multiselect = FALSE) {
     $list = [];
-    foreach ($items as $item) {
-      $item_array = (array) $item;
-      $list[$item_array[$unique_property]] = trim($item_array[$label_property]);
+    $items_array = [];
+    foreach ($items as $key => $item) {
+      $items_array[$key] = (array) $item;
+    }
+    foreach ($items_array as $item) {
+      $list[$item[$unique_property]] = trim($item[$label_property]);
     }
     $labels = array_values($list);
     $question = new ChoiceQuestion($question_text, $labels);
@@ -509,9 +512,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $choice_id = $helper->ask($this->input, $this->output, $question);
     if (!$multiselect) {
       $identifier = array_search($choice_id, $list, TRUE);
-      foreach ($items as $item) {
-        $item_array = (array) $item;
-        if ($item_array[$unique_property] === $identifier) {
+      foreach ($items_array as $item) {
+        if ($item[$unique_property] === $identifier) {
           return $item;
         }
       }
@@ -520,7 +522,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       $chosen = [];
       foreach ($choice_id as $choice) {
         $identifier = array_search($choice, $list, TRUE);
-        foreach ($items as $item) {
+        foreach ($items_array as $item) {
           if ($item[$unique_property] === $identifier) {
             $chosen[] = $item;
           }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -309,7 +309,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     if ($cloud_datastore === NULL) {
       return FALSE;
     }
-
+    // Continue to honor legacy method of authentication.
     if ($cloud_datastore->get('key') && $cloud_datastore->get('secret')) {
       return TRUE;
     }

--- a/src/Command/Ide/IdeCommandBase.php
+++ b/src/Command/Ide/IdeCommandBase.php
@@ -24,7 +24,7 @@ abstract class IdeCommandBase extends CommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   protected function promptIdeChoice(
-    $question_text,
+    string $question_text,
     Ides $ides_resource,
     $cloud_application_uuid
   ): ?IdeResponse {
@@ -33,7 +33,7 @@ abstract class IdeCommandBase extends CommandBase {
       throw new AcquiaCliException('No IDEs exist for this application.');
     }
     /** @var IdeResponse $ide_response */
-    $ide_response = $this->promptChooseFromObjects($ides, 'uuid', 'label', $question_text);
+    $ide_response = $this->promptChooseFromObjectsOrArrays($ides, 'uuid', 'label', $question_text);
     return $ide_response;
   }
 

--- a/src/Command/Ssh/SshKeyDeleteCommand.php
+++ b/src/Command/Ssh/SshKeyDeleteCommand.php
@@ -53,7 +53,7 @@ class SshKeyDeleteCommand extends CommandBase {
     }
 
     $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
-    $cloud_key = $this->promptChooseFromObjects(
+    $cloud_key = $this->promptChooseFromObjectsOrArrays(
       $cloud_keys,
       'uuid',
       'label',

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -290,7 +290,7 @@ class ApiCommandTest extends CommandTestBase {
   public function providerTestApiCommandDefinitionRequestBody(): array {
     return [
       ['api:accounts:ssh-key-create', 'post', 'api:accounts:ssh-key-create "mykey" "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChwPHzTTDKDpSbpa2+d22LcbQmsw92eLsUK3Fmei1fiGDkd34NsYCN8m7lsi3NbvdMS83CtPQPWiCveYPzFs1/hHc4PYj8opD2CNnr5iWVVbyaulCYHCgVv4aB/ojcexg8q483A4xJeF15TiCr/gu34rK6ucTvC/tn/rCwJBudczvEwt0klqYwv8Cl/ytaQboSuem5KgSjO3lMrb6CWtfSNhE43ZOw+UBFBqxIninN868vGMkIv9VY34Pwj54rPn/ItQd6Ef4B0KHHaGmzK0vfP+AK7FxNMoHnj3iYT33KZNqtDozdn5tYyH/bThPebEtgqUn+/w5l6wZIC/8zzvls/127ngHk+jNa0PlNyS2TxhPUK4NaPHIEnnrlp07JEYC4ImcBjaYCWAdcTcUkcJjwZQkN4bGmyO9cjICH98SdLD/HxqzTHeaYDbAX/Hu9HfaBb5dXLWsjw3Xc6hoVnUUZbMQyfgb0KgxDLh92eNGxJkpZiL0VDNOWCxDWsNpzwhLNkLqCvI6lyxiLaUzvJAk6dPaRhExmCbU1lDO2eR0FdSwC1TEhJOT9eDIK1r2hztZKs2oa5FNFfB/IFHVWasVFC9N2h/r/egB5zsRxC9MqBLRBq95NBxaRSFng6ML5WZSw41Qi4C/JWVm89rdj2WqScDHYyAdwyyppWU4T5c9Fmw== example@example.com"'],
-      ['api:environments:domains-clear-varnish', 'post', 'api:environments:domains-clear-varnish 12-d314739e-296f-11e9-b210-d663bd873d93 --domains="domain1.example.com" --domains="domain2.example.com"'],
+      ['api:environments:domains-clear-varnish', 'postestApiCommandErrorResponset', 'api:environments:domains-clear-varnish 12-d314739e-296f-11e9-b210-d663bd873d93 --domains="domain1.example.com" --domains="domain2.example.com"'],
     ];
   }
 

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -290,7 +290,7 @@ class ApiCommandTest extends CommandTestBase {
   public function providerTestApiCommandDefinitionRequestBody(): array {
     return [
       ['api:accounts:ssh-key-create', 'post', 'api:accounts:ssh-key-create "mykey" "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChwPHzTTDKDpSbpa2+d22LcbQmsw92eLsUK3Fmei1fiGDkd34NsYCN8m7lsi3NbvdMS83CtPQPWiCveYPzFs1/hHc4PYj8opD2CNnr5iWVVbyaulCYHCgVv4aB/ojcexg8q483A4xJeF15TiCr/gu34rK6ucTvC/tn/rCwJBudczvEwt0klqYwv8Cl/ytaQboSuem5KgSjO3lMrb6CWtfSNhE43ZOw+UBFBqxIninN868vGMkIv9VY34Pwj54rPn/ItQd6Ef4B0KHHaGmzK0vfP+AK7FxNMoHnj3iYT33KZNqtDozdn5tYyH/bThPebEtgqUn+/w5l6wZIC/8zzvls/127ngHk+jNa0PlNyS2TxhPUK4NaPHIEnnrlp07JEYC4ImcBjaYCWAdcTcUkcJjwZQkN4bGmyO9cjICH98SdLD/HxqzTHeaYDbAX/Hu9HfaBb5dXLWsjw3Xc6hoVnUUZbMQyfgb0KgxDLh92eNGxJkpZiL0VDNOWCxDWsNpzwhLNkLqCvI6lyxiLaUzvJAk6dPaRhExmCbU1lDO2eR0FdSwC1TEhJOT9eDIK1r2hztZKs2oa5FNFfB/IFHVWasVFC9N2h/r/egB5zsRxC9MqBLRBq95NBxaRSFng6ML5WZSw41Qi4C/JWVm89rdj2WqScDHYyAdwyyppWU4T5c9Fmw== example@example.com"'],
-      ['api:environments:domains-clear-varnish', 'postestApiCommandErrorResponset', 'api:environments:domains-clear-varnish 12-d314739e-296f-11e9-b210-d663bd873d93 --domains="domain1.example.com" --domains="domain2.example.com"'],
+      ['api:environments:domains-clear-varnish', 'post', 'api:environments:domains-clear-varnish 12-d314739e-296f-11e9-b210-d663bd873d93 --domains="domain1.example.com" --domains="domain2.example.com"'],
     ];
   }
 

--- a/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
@@ -6,6 +6,7 @@ use Acquia\Cli\Command\Auth\AuthLogoutCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Validator\Exception\ValidatorException;
+use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Class AuthLogoutCommandTest.
@@ -52,11 +53,8 @@ class AuthLogoutCommandTest extends CommandTestBase {
     $output = $this->getDisplay();
     // Assert creds are removed locally.
     $this->assertFileExists($this->cloudConfigFilepath);
-    $contents = file_get_contents($this->cloudConfigFilepath);
-    $this->assertJson($contents);
-    $config = json_decode($contents, TRUE);
-    $this->assertNull($config['key']);
-    $this->assertNull($config['secret']);
+    $config = new JsonFileStore($this->cloudConfigFilepath, JsonFileStore::NO_SERIALIZE_STRINGS);
+    $this->assertFalse($config->exists('acli_key'));
   }
 
 }

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -80,7 +80,7 @@ class TelemetryCommandTest extends CommandTestBase {
   public function testTelemetryPrompt(array $inputs, $message): void {
     $this->command = $this->injectCommand(LinkCommand::class);
     $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => NULL];
-    $this->createMockConfigFile();
+    $this->createMockConfigFiles();
     $this->createMockAcliConfigFile('a47ac10b-58cc-4372-a567-0e02b2c3d470');
     $this->mockApplicationRequest();
     $this->executeCommand([], $inputs);
@@ -96,7 +96,7 @@ class TelemetryCommandTest extends CommandTestBase {
    */
   public function testAmplitudeDisabled(): void {
     $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => FALSE];
-    $this->createMockConfigFile();
+    $this->createMockConfigFiles();
     $this->executeCommand();
 
     $this->assertEquals(0, $this->getStatusCode());
@@ -105,7 +105,7 @@ class TelemetryCommandTest extends CommandTestBase {
 
   public function testMigrateLegacyTelemetryPreference(): void {
     $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => NULL];
-    $this->createMockConfigFile();
+    $this->createMockConfigFiles();
     $this->fs->remove($this->legacyAcliConfigFilepath);
     $legacy_acli_config = ['send_telemetry' => FALSE];
     $contents = json_encode($legacy_acli_config);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -190,7 +190,7 @@ abstract class TestBase extends TestCase {
     $this->setIo($input, $output);
 
     $this->removeMockConfigFiles();
-    $this->createMockConfigFile();
+    $this->createMockConfigFiles();
     ClearCacheCommand::clearCaches();
 
     parent::setUp();
@@ -378,18 +378,33 @@ abstract class TestBase extends TestCase {
     return $public_key_filepath;
   }
 
-  protected function createMockConfigFile(): void {
-    // @todo Read from config object.
-    $default_values = ['key' => 'testkey', 'secret' => 'test', DataStoreContract::SEND_TELEMETRY => FALSE];
-    $cloud_config = array_merge($default_values, $this->cloudConfig);
-    $contents = json_encode($cloud_config);
-    $filepath = $this->cloudConfigFilepath;
-    $this->fs->dumpFile($filepath, $contents);
+  protected function createMockConfigFiles(): void {
+    $this->createMockCloudConfigFile();
 
     $default_values = [];
     $acli_config = array_merge($default_values, $this->acliConfig);
     $contents = json_encode($acli_config);
     $filepath = $this->acliConfigFilepath;
+    $this->fs->dumpFile($filepath, $contents);
+  }
+
+  protected function createMockCloudConfigFile($default_values = []) {
+    if (!$default_values) {
+      $default_values = [
+        'acli_key' => 'testkey',
+        'keys' => [
+          'testkey' => [
+            'uuid' => 'testkey',
+            'label' => 'Test Key',
+            'secret' => 'test',
+          ],
+        ],
+        DataStoreContract::SEND_TELEMETRY => FALSE,
+      ];
+    }
+    $cloud_config = array_merge($default_values, $this->cloudConfig);
+    $contents = json_encode($cloud_config);
+    $filepath = $this->cloudConfigFilepath;
     $this->fs->dumpFile($filepath, $contents);
   }
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -94,6 +94,16 @@ abstract class TestBase extends TestCase {
   /**
    * @var string
    */
+  protected $key = '17feaf34-5d04-402b-9a67-15d5161d24e1';
+
+  /**
+   * @var string
+   */
+  protected $secret = 'X1u\/PIQXtYaoeui.4RJSJpGZjwmWYmfl5AUQkAebYE=';
+
+  /**
+   * @var string
+   */
   protected $dataDir;
 
   /**
@@ -391,12 +401,12 @@ abstract class TestBase extends TestCase {
   protected function createMockCloudConfigFile($default_values = []) {
     if (!$default_values) {
       $default_values = [
-        'acli_key' => 'testkey',
+        'acli_key' => $this->key,
         'keys' => [
-          'testkey' => [
-            'uuid' => 'testkey',
+          (string) ($this->key) => [
+            'uuid' => $this->key,
             'label' => 'Test Key',
-            'secret' => 'test',
+            'secret' => $this->secret,
           ],
         ],
         DataStoreContract::SEND_TELEMETRY => FALSE,


### PR DESCRIPTION
User Experience:

1. User runs `acli login`
  a. If no keys are saved locally, prompt to enter new key.
  b. If keys already exist locally, prompt user to choose among existing keys or create a new key.
    i. If selected existing key, set it as the default key for ACLI.
    ii. If create new key, prompt to enter new key.
2. User runs `acli logout`
  a. Unset the default key for ACLI, but do not remove the key from the filesystem.

This PR includes an automated migration path.