### PR TITLE
Fix Travis CI tests (curl failure)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
         - sed -i 's/memory_limit = .*/memory_limit = 512M/' /c/tools/php74/php.ini
         - choco install composer
         # Fix curl errors in coveralls.
-        - curl -o /c/tools/php74/extras/ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
+        - curl -L -o /c/tools/php74/extras/ssl/cacert.pem https://curl.se/ca/cacert.pem
         - echo 'curl.cainfo = "C:\tools\php74\extras\ssl\cacert.pem"' >> /c/tools/php74/php.ini
         # Emulate RefreshEnv to pick up new bin paths in Git Bash (the native Travis CI shell).
         - export PATH=$(cmd.exe //c "refreshenv > nul & C:\Progra~1\Git\bin\bash -c 'echo \$PATH' ")


### PR DESCRIPTION
Note that curl is involved two ways here: we first use it to download cacert.pem so that PHP can later call curl. It's the second (PHP) call that was visibly failing, but the reason is that the first one (downloading the CA cert) failed silently.

It looks like the curl maintainers recently added a redirect from curl.haxx.se to curl.se. Curl doesn't follow redirects by default, resulting in a corrupt cacert.pem.

I considered adding a sha256 verification of cacert.pem so at least it wouldn't fail silently next time, but it seems like unnecessary complexity given that the sole purpose would be to accelerate debugging (and now that we've seen this error we can search for it in GH / Jira).

I also linked a follow-up ticket in Jira since our test cases shouldn't be making network calls in the first place.