### PR TITLE
Fix #392: pull:files multisite support

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -436,7 +436,6 @@ abstract class PullCommandBase extends CommandBase {
    * @throws \Exception
    */
   protected function rsyncFilesFromCloud($chosen_environment, $output_callback = NULL): void {
-    $destination = $this->dir . '/docroot/sites/default/';
     $sitegroup = self::getSiteGroupFromSshUrl($chosen_environment);
 
     if ($this->isAcsfEnv($chosen_environment)) {
@@ -447,6 +446,7 @@ abstract class PullCommandBase extends CommandBase {
       $site = $this->promptChooseCloudSite($chosen_environment);
       $source_dir = $this->getCloudSitesPath($chosen_environment, $sitegroup) . "/$site/files";
     }
+    $destination = $this->dir . '/docroot/sites/' . $site . '/';
     $this->localMachineHelper->getFilesystem()->mkdir($destination);
     $command = [
       'rsync',

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -142,7 +142,7 @@ class PullFilesCommandTest extends PullCommandTestBase {
       '-rltDvPhe',
       'ssh -o StrictHostKeyChecking=no',
       'profserv2.01dev@profserv201dev.ssh.enterprise-g1.acquia-sites.com:/mnt/files/profserv2.dev/sites/g/files/jxr5000596dev/files',
-      $this->projectFixtureDir . '/docroot/sites/default/',
+      $this->projectFixtureDir . '/docroot/sites/jxr5000596dev/',
     ];
     $local_machine_helper->execute($command, Argument::type('callable'), NULL, FALSE, 60 * 60)
       ->willReturn($process->reveal())
@@ -164,7 +164,7 @@ class PullFilesCommandTest extends PullCommandTestBase {
       '-rltDvPhe',
       'ssh -o StrictHostKeyChecking=no',
       'something.dev@somethingdev.ssh.prod.acquia-sites.com:/mnt/files/something.dev/sites/bar/files',
-      $this->projectFixtureDir . '/docroot/sites/default/',
+      $this->projectFixtureDir . '/docroot/sites/bar/',
     ];
     $local_machine_helper->execute($command, Argument::type('callable'), NULL, FALSE, 60 * 60)
       ->willReturn($process->reveal())


### PR DESCRIPTION
Motivation
----------

Fixes #392 

Testing steps
---------

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli pull:files`
4. Choose a multisite and ensure that files are placed in the multisite directory rather than `default`
