### PR TITLE
DX-3448 | Adding violuke/rsa-ssh-key-fingerprint and code to show fin…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     "symfony/yaml": "^5.1@dev",
     "typhonius/acquia-logstream": "^0.0.8",
     "typhonius/acquia-php-sdk-v2": "dev-master as 2.0.15",
+    "violuke/rsa-ssh-key-fingerprint": "^1.1",
     "webmozart/json": "^1.2",
     "webmozart/key-value-store": "^1.0",
     "zumba/amplitude-php": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ad75b3bc538c0ac03c41e4423daa768",
+    "content-hash": "2f8748a33a53d78de1e7ed6eb64786af",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -4667,6 +4667,43 @@
                 }
             ],
             "time": "2021-01-18T23:11:48+00:00"
+        },
+        {
+            "name": "violuke/rsa-ssh-key-fingerprint",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/violuke/rsa-ssh-key-fingerprint.git",
+                "reference": "e1be5f95851cecf0471a653bd7c618fc638248a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/violuke/rsa-ssh-key-fingerprint/zipball/e1be5f95851cecf0471a653bd7c618fc638248a1",
+                "reference": "e1be5f95851cecf0471a653bd7c618fc638248a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "violuke\\RsaSshKeyFingerprint": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0+"
+            ],
+            "description": "Generate a fingerprint from an RSA SSH public key.",
+            "support": {
+                "issues": "https://github.com/violuke/rsa-ssh-key-fingerprint/issues",
+                "source": "https://github.com/violuke/rsa-ssh-key-fingerprint/tree/v1.1.1"
+            },
+            "time": "2020-11-29T11:08:48+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,10 +12,13 @@
 
   <file>.</file>
 
+  <exclude-pattern>build/</exclude-pattern>
   <exclude-pattern>var/</exclude-pattern>
   <exclude-pattern>vendor/*</exclude-pattern>
   <exclude-pattern>tests/fixtures/*</exclude-pattern>
 
-  <rule ref="AcquiaPHP"/>
+  <rule ref="AcquiaPHP">
+    <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_lastFound"/>
+  </rule>
 
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,8 +17,6 @@
   <exclude-pattern>vendor/*</exclude-pattern>
   <exclude-pattern>tests/fixtures/*</exclude-pattern>
 
-  <rule ref="AcquiaPHP">
-    <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_lastFound"/>
-  </rule>
+  <rule ref="AcquiaPHP"/>
 
 </ruleset>

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -34,7 +34,7 @@ class SshKeyListCommand extends SshKeyCommandBase {
     $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
     $local_keys = $this->findLocalSshKeys();
 
-    $this->io->title('Cloud keys with matching local keys');
+    $this->io->title('Cloud Platform keys with matching local keys');
     foreach ($local_keys as $local_index => $local_file) {
       foreach ($cloud_keys as $index => $cloud_key) {
         if (trim($local_file->getContents()) === trim($cloud_key->public_key)) {
@@ -44,14 +44,14 @@ class SshKeyListCommand extends SshKeyCommandBase {
             ['UUID' => $cloud_key->uuid],
             ['Local filename' => $local_file->getFilename()],
             ['sha256 hash' => $sha256_hash],
-            ['md5' => $cloud_key->fingerprint]
+            ['md5 hash' => $cloud_key->fingerprint]
           );
           unset($cloud_keys[$index], $local_keys[$local_index]);
           break;
         }
       }
     }
-    $this->io->title('Cloud keys with no matching local keys');
+    $this->io->title('Cloud Platform keys with no matching local keys');
     foreach ($cloud_keys as $index => $cloud_key) {
       $sha256_hash = FingerprintGenerator::getFingerprint($cloud_key->public_key, 'sha256');
       $this->io->definitionList(
@@ -59,11 +59,11 @@ class SshKeyListCommand extends SshKeyCommandBase {
         ['UUID' => $cloud_key->uuid],
         ['Local filename' => 'none'],
         ['sha256 hash' => $sha256_hash],
-        ['md5' => $cloud_key->fingerprint]
+        ['md5 hash' => $cloud_key->fingerprint]
       );
     }
 
-    $this->io->title('Local keys with no matching cloud keys');
+    $this->io->title('Local keys with no matching Cloud Platform keys');
     foreach ($local_keys as $index => $local_file) {
       $sha256_hash = FingerprintGenerator::getFingerprint($local_file->getContents(), 'sha256');
       $md5_hash = FingerprintGenerator::getFingerprint($local_file->getContents(), 'md5');
@@ -72,7 +72,7 @@ class SshKeyListCommand extends SshKeyCommandBase {
         ['UUID' => 'none'],
         ['Local filename' => $local_file->getFilename()],
         ['sha256 hash' => $sha256_hash],
-        ['md5' => $md5_hash]
+        ['md5 hash' => $md5_hash]
       );
     }
 

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -41,19 +41,19 @@ class SshKeyListCommand extends SshKeyCommandBase {
       'Hashes — sha256 and md5',
     ]);
     // First list all keys for which there are both Cloud and local keys.
+    $last_key = array_key_last($cloud_keys);
     foreach ($local_keys as $local_index => $local_file) {
-      $last_key = array_key_last($cloud_keys);
       foreach ($cloud_keys as $index => $cloud_key) {
         if (trim($local_file->getContents()) === trim($cloud_key->public_key)) {
-            $sha256_hash = FingerprintGenerator::getFingerprint($cloud_key->public_key, 'sha256');
-            $table->addRow([
-              $cloud_key->label . PHP_EOL . $cloud_key->uuid,
-              $local_file->getFilename(),
-              $sha256_hash . PHP_EOL . $cloud_key->fingerprint,
-            ]);
-            if ($last_key !== $index) {
-              $table->addRow(new TableSeparator());
-            }
+          $sha256_hash = FingerprintGenerator::getFingerprint($cloud_key->public_key, 'sha256');
+          $table->addRow([
+            $cloud_key->label . PHP_EOL . $cloud_key->uuid,
+            $local_file->getFilename(),
+            $sha256_hash . PHP_EOL . $cloud_key->fingerprint,
+          ]);
+          if ($last_key !== $index) {
+            $table->addRow(new TableSeparator());
+          }
           unset($cloud_keys[$index], $local_keys[$local_index]);
           break;
         }
@@ -68,14 +68,14 @@ class SshKeyListCommand extends SshKeyCommandBase {
         'none',
         $sha256_hash . PHP_EOL . $cloud_key->fingerprint,
       ]);
-      if ($last_key !== $index) {
+      if ($last_key !== $index || $local_keys) {
         $table->addRow(new TableSeparator());
       }
     }
 
     // Last list all local keys for which there is no cloud key.
-    $local_keys = array_key_last($cloud_keys);
-    foreach ($local_keys as $local_file) {
+    $last_key = array_key_last($local_keys);
+    foreach ($local_keys as $index => $local_file) {
       $sha256_hash = FingerprintGenerator::getFingerprint($local_file->getContents(), 'sha256');
       $md5_hash = FingerprintGenerator::getFingerprint($local_file->getContents(), 'md5');
       $table->addRow([

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -40,6 +40,7 @@ class SshKeyListCommand extends SshKeyCommandBase {
       'Local key filename',
       'Hashes — sha256 and md5',
     ]);
+    // First list all keys for which there are both Cloud and local keys.
     foreach ($local_keys as $local_index => $local_file) {
       foreach ($cloud_keys as $index => $cloud_key) {
         if (trim($local_file->getContents()) === trim($cloud_key->public_key)) {
@@ -55,6 +56,7 @@ class SshKeyListCommand extends SshKeyCommandBase {
         }
       }
     }
+    // Second list all cloud keys for which there is no local key.
     foreach ($cloud_keys as $index => $cloud_key) {
       $hash = FingerprintGenerator::getFingerprint($cloud_key->public_key, 'sha256');
       $table->addRow([
@@ -65,6 +67,7 @@ class SshKeyListCommand extends SshKeyCommandBase {
       $table->addRow(new TableSeparator());
     }
 
+    // Last list all local keys for which there is no cloud key.
     foreach ($local_keys as $local_file) {
       $table->addRow(['none', $local_file->getFilename(), '']);
     }

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -40,10 +40,11 @@ class SshKeyListCommand extends SshKeyCommandBase {
     foreach ($local_keys as $local_index => $local_file) {
       foreach ($cloud_keys as $index => $cloud_key) {
         if (trim($local_file->getContents()) === trim($cloud_key->public_key)) {
+          $hash = FingerprintGenerator::getFingerprint($cloud_key->public_key, 'sha256');
           $table->addRow([
             $cloud_key->label,
             $local_file->getFilename(),
-            $cloud_key->fingerprint,
+            $hash,
           ]);
           unset($cloud_keys[$index], $local_keys[$local_index]);
           break;
@@ -55,10 +56,11 @@ class SshKeyListCommand extends SshKeyCommandBase {
 
     $table = $this->createSshKeyTable($output, 'Cloud Platform keys with no matching local keys');
     foreach ($cloud_keys as $index => $cloud_key) {
+      $hash = FingerprintGenerator::getFingerprint($cloud_key->public_key, 'sha256');
       $table->addRow([
         $cloud_key->label,
         'none',
-        $cloud_key->fingerprint,
+        $hash,
       ]);
     }
     $table->render();
@@ -66,11 +68,11 @@ class SshKeyListCommand extends SshKeyCommandBase {
 
     $table = $this->createSshKeyTable($output, 'Local keys with no matching Cloud Platform keys');
     foreach ($local_keys as $index => $local_file) {
-      $md5_hash = FingerprintGenerator::getFingerprint($local_file->getContents(), 'md5');
+      $hash = FingerprintGenerator::getFingerprint($local_file->getContents(), 'sha256');
       $table->addRow([
         'none',
         $local_file->getFilename(),
-        $md5_hash,
+        $hash,
       ]);
     }
     $table->render();
@@ -91,7 +93,7 @@ class SshKeyListCommand extends SshKeyCommandBase {
     $table->setHeaders([
       'Cloud Platform label',
       'Local filename',
-      'Fingerprint',
+      'Fingerprint (sha256)',
     ]);
     $table->setHeaderTitle($title);
     $table->setColumnWidths([

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -35,13 +35,21 @@ class SshKeyListCommand extends SshKeyCommandBase {
     $local_keys = $this->findLocalSshKeys();
 
     $table = new Table($output);
-    $table->setHeaders(['Cloud Platform Key Label and UUID', 'Local Key Filename', 'Hashes — sha256 and md5']);
+    $table->setHeaders([
+      'Cloud platform key label and UUID',
+      'Local key filename',
+      'Hashes — sha256 and md5',
+    ]);
     foreach ($local_keys as $local_index => $local_file) {
       foreach ($cloud_keys as $index => $cloud_key) {
         if (trim($local_file->getContents()) === trim($cloud_key->public_key)) {
             $hash = FingerprintGenerator::getFingerprint($cloud_key->public_key, 'sha256');
-            $table->addRow([$cloud_key->label . PHP_EOL . $cloud_key->uuid, $local_file->getFilename(), $hash . PHP_EOL . $cloud_key->fingerprint]);
-            $table->addRow([PHP_EOL]);
+            $table->addRow([
+              $cloud_key->label . PHP_EOL . $cloud_key->uuid,
+              $local_file->getFilename(),
+              $hash . PHP_EOL . $cloud_key->fingerprint,
+            ]);
+            $table->addRow(new TableSeparator());
           unset($cloud_keys[$index], $local_keys[$local_index]);
           break;
         }
@@ -49,12 +57,16 @@ class SshKeyListCommand extends SshKeyCommandBase {
     }
     foreach ($cloud_keys as $index => $cloud_key) {
       $hash = FingerprintGenerator::getFingerprint($cloud_key->public_key, 'sha256');
-      $table->addRow([$cloud_key->label . PHP_EOL . $cloud_key->uuid, '---', $hash . PHP_EOL . $cloud_key->fingerprint]);
-      $table->addRow([PHP_EOL]);
+      $table->addRow([
+        $cloud_key->label . PHP_EOL . $cloud_key->uuid,
+        'none',
+        $hash . PHP_EOL . $cloud_key->fingerprint,
+      ]);
+      $table->addRow(new TableSeparator());
     }
 
     foreach ($local_keys as $local_file) {
-      $table->addRow(['---', $local_file->getFilename(), '']);
+      $table->addRow(['none', $local_file->getFilename(), '']);
     }
     $table->render();
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -422,6 +422,9 @@
     "typhonius/acquia-php-sdk-v2": {
         "version": "2.0.12"
     },
+    "violuke/rsa-ssh-key-fingerprint": {
+        "version": "v1.1.1"
+    },
     "webmozart/assert": {
         "version": "1.8.0"
     },

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -37,8 +37,8 @@ class SshKeyListCommandTest extends CommandTestBase
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString('Local Key Filename', $output);
-    $this->assertStringContainsString('Cloud Platform Key Label', $output);
+    $this->assertStringContainsString('Local key filename', $output);
+    $this->assertStringContainsString('Cloud platform key label', $output);
     $this->assertStringContainsString($base_filename, $output);
     $this->assertStringContainsString($mock_body->_embedded->items[0]->label, $output);
     $this->assertStringContainsString($mock_body->_embedded->items[1]->label, $output);

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -40,7 +40,7 @@ class SshKeyListCommandTest extends CommandTestBase
     $this->assertStringContainsString('Local filename', $output);
     $this->assertStringContainsString('Label', $output);
     $this->assertStringContainsString('UUID', $output);
-    $this->assertStringContainsString('sha256', $output);
+    $this->assertStringContainsString('sha256 hash', $output);
     $this->assertStringContainsString('md5 hash', $output);
     $this->assertStringContainsString($base_filename, $output);
     $this->assertStringContainsString($mock_body->_embedded->items[0]->label, $output);

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -37,8 +37,8 @@ class SshKeyListCommandTest extends CommandTestBase
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString('Local key filename', $output);
-    $this->assertStringContainsString('Cloud platform key label', $output);
+    $this->assertStringContainsString('Local filename', $output);
+    $this->assertStringContainsString('Cloud Platform key label', $output);
     $this->assertStringContainsString($base_filename, $output);
     $this->assertStringContainsString($mock_body->_embedded->items[0]->label, $output);
     $this->assertStringContainsString($mock_body->_embedded->items[1]->label, $output);

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -38,10 +38,8 @@ class SshKeyListCommandTest extends CommandTestBase
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
     $this->assertStringContainsString('Local filename', $output);
-    $this->assertStringContainsString('Label', $output);
-    $this->assertStringContainsString('UUID', $output);
-    $this->assertStringContainsString('sha256 hash', $output);
-    $this->assertStringContainsString('md5 hash', $output);
+    $this->assertStringContainsString('Cloud Platform label', $output);
+    $this->assertStringContainsString('Fingerprint', $output);
     $this->assertStringContainsString($base_filename, $output);
     $this->assertStringContainsString($mock_body->_embedded->items[0]->label, $output);
     $this->assertStringContainsString($mock_body->_embedded->items[1]->label, $output);

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -38,7 +38,10 @@ class SshKeyListCommandTest extends CommandTestBase
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
     $this->assertStringContainsString('Local filename', $output);
-    $this->assertStringContainsString('Cloud Platform key label', $output);
+    $this->assertStringContainsString('Label', $output);
+    $this->assertStringContainsString('UUID', $output);
+    $this->assertStringContainsString('sha256', $output);
+    $this->assertStringContainsString('md5 hash', $output);
     $this->assertStringContainsString($base_filename, $output);
     $this->assertStringContainsString($mock_body->_embedded->items[0]->label, $output);
     $this->assertStringContainsString($mock_body->_embedded->items[1]->label, $output);


### PR DESCRIPTION
…gerprint hashes

**Motivation**

`acli ssh-key:list` shows a compact view of the keys returned by Cloud API and local, but does not provide the UUID which is necessary to be able to call `ssh-key:delete` with the `-uuid, --cloud-key-uuid=CLOUD-KEY-UUID` options.

It also does not provide a way to troubleshoot ssh connections by showing fingerprints of the keys.

Since CloudAPI fingerprint on the ssh key is MD5 but most logs and ssh output will note the fingerprint of the key as sha256 (see CXAPI-6802 for more info on getting sha256 added to the output), it would be handy to output these values as well.


**Proposed changes**
This simply changes the output of a listing command, no impact to users


**Merge requirements**
- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
