### PR TITLE
Fix #398: Change environment id, application id, and directory to options

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -385,20 +385,18 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * Add argument and usage examples for applicationUuid.
    */
   protected function acceptApplicationUuid() {
-    $this->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The Cloud Platform application UUID or alias.')
-    ->addUsage(self::getDefaultName() . ' [<applicationAlias>]')
-    ->addUsage(self::getDefaultName() . ' myapp')
-    ->addUsage(self::getDefaultName() . ' abcd1234-1111-2222-3333-0e02b2c3d470');
+    return $this->addOption('applicationUuid', NULL, InputArgument::OPTIONAL, 'The Cloud Platform application UUID or alias.')
+    ->addUsage(self::getDefaultName() . ' --applicationUuid myapp')
+    ->addUsage(self::getDefaultName() . ' --applicationUuid abcd1234-1111-2222-3333-0e02b2c3d470');
   }
 
   /**
    * Add argument and usage examples for environmentId.
    */
   protected function acceptEnvironmentId() {
-    $this->addArgument('environmentId', InputArgument::OPTIONAL, 'The Cloud Platform environment ID or alias.')
-    ->addUsage(self::getDefaultName() . ' [<environmentAlias>]')
-    ->addUsage(self::getDefaultName() . ' myapp.dev')
-    ->addUsage(self::getDefaultName() . ' 12345-abcd1234-1111-2222-3333-0e02b2c3d470');
+    return $this->addOption('environmentId', NULL, InputArgument::OPTIONAL, 'The Cloud Platform environment ID or alias.')
+    ->addUsage(self::getDefaultName() . ' --environmentId myapp.dev')
+    ->addUsage(self::getDefaultName() . ' --environmentId 12345-abcd1234-1111-2222-3333-0e02b2c3d470');
   }
 
   /**

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -21,7 +21,7 @@ class PullCodeCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Copy code from a Cloud Platform environment')
       ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
-      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
+      ->acceptEnvironmentId()
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,
         'Do not run any additional scripts after code is pulled. E.g., composer install , drush cache-rebuild, etc.')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -22,8 +22,8 @@ class PullCommand extends PullCommandBase {
   protected function configure() {
     $this->setAliases(['refresh', 'pull'])
       ->setDescription('Copy code, database, and files from a Cloud Platform environment')
-      ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
-      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
+      ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
+      ->acceptEnvironmentId()
       ->addOption('no-code', NULL, InputOption::VALUE_NONE, 'Do not refresh code from remote repository')
       ->addOption('no-files', NULL, InputOption::VALUE_NONE, 'Do not refresh files')
       ->addOption('no-databases', NULL, InputOption::VALUE_NONE, 'Do not refresh databases')

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -546,8 +546,8 @@ abstract class PullCommandBase extends CommandBase {
       return $this->sourceEnvironment;
     }
 
-    if ($input->getArgument('environmentId')) {
-      $environment_id = $input->getArgument('environmentId');
+    if ($input->getOption('environmentId')) {
+      $environment_id = $input->getOption('environmentId');
       $chosen_environment = $this->getCloudEnvironment($environment_id);
     }
     else {

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -22,7 +22,7 @@ class PullDatabaseCommand extends PullCommandBase {
     $this->setDescription('Import latest database backup from a Cloud Platform environment')
       ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. You can generate an on-demand backup using api:environments:database-backup-create.')
       ->setAliases(['pull:db'])
-      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
+      ->acceptEnvironmentId()
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,
         'Do not run any additional scripts after the database is pulled. E.g., drush cache-rebuild, drush sql-sanitize, etc.')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -20,7 +20,7 @@ class PullFilesCommand extends PullCommandBase {
    */
   protected function configure() {
     $this->setDescription('Copy files from a Cloud Platform environment')
-      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
+      ->acceptEnvironmentId()
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -26,7 +26,7 @@ class PullScriptsCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Execute post pull scripts')
       ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
-      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
+      ->acceptEnvironmentId()
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -29,7 +29,7 @@ class PushDatabaseCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Push a database from your IDE to a Cloud Platform environment')
       ->setAliases(['push:db'])
-      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
+      ->acceptEnvironmentId()
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -28,7 +28,7 @@ class PushFilesCommand extends PullCommandBase {
    */
   protected function configure() {
     $this->setDescription('Push Drupal files from your IDE to a Cloud Platform environment')
-      ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
+      ->acceptEnvironmentId()
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/tests/fixtures/project/blt/blt.yml
+++ b/tests/fixtures/project/blt/blt.yml
@@ -1,2 +1,0 @@
-cloud:
-    appId: a47ac10b-58cc-4372-a567-0e02b2c3d470

--- a/tests/fixtures/project/blt/blt.yml
+++ b/tests/fixtures/project/blt/blt.yml
@@ -1,0 +1,2 @@
+cloud:
+    appId: a47ac10b-58cc-4372-a567-0e02b2c3d470

--- a/tests/phpunit/src/Commands/LogTailCommandTest.php
+++ b/tests/phpunit/src/Commands/LogTailCommandTest.php
@@ -65,7 +65,7 @@ class LogTailCommandTest extends CommandTestBase {
     $this->mockLogListRequest();
     $this->mockLogStreamRequest();
     $this->executeCommand(
-      ['environmentId' => '24-a47ac10b-58cc-4372-a567-0e02b2c3d470'],
+      ['--environmentId' => '24-a47ac10b-58cc-4372-a567-0e02b2c3d470'],
       // Select log.
       [0]
     );

--- a/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
@@ -241,7 +241,7 @@ class PullCodeCommandTest extends PullCommandTestBase {
     $this->executeCommand([
       // @todo Execute ONLY match php aspect, not the code pull.
       'dir' => $dir,
-      'environmentId' => $environment_response->id,
+      '--environmentId' => $environment_response->id,
       '--no-scripts' => TRUE,
     ], [
       // Please choose an Acquia environment:

--- a/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
@@ -2,24 +2,11 @@
 
 namespace Acquia\Cli\Tests\Commands\Push;
 
-use Acquia\Cli\Command\Ide\IdePhpVersionCommand;
-use Acquia\Cli\Command\Pull\PullCodeCommand;
-use Acquia\Cli\Command\Pull\PullCommand;
-use Acquia\Cli\Command\Pull\PullDatabaseCommand;
-use Acquia\Cli\Command\Pull\PullFilesCommand;
 use Acquia\Cli\Command\Push\PushFilesCommand;
-use Acquia\Cli\Exception\AcquiaCliException;
-use Acquia\Cli\Helpers\SshHelper;
-use Acquia\Cli\Tests\Commands\Ide\IdeRequiredTestBase;
 use Acquia\Cli\Tests\CommandTestBase;
-use AcquiaCloudApi\Response\EnvironmentResponse;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Logger\ConsoleLogger;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Process\Process;
-use Webmozart\PathUtil\Path;
 
 /**
  * Class PushFilesCommandTest.


### PR DESCRIPTION
**Motivation**
Fixes #398

**Proposed changes**
Change the `environmentId`, `applicationId`, and `dir` arguments to options, since they are all technically optional and it can be confusing when you want to provide one without the other (see #398 for example). Options are more verbose, but also more functional. They are optional because if empty, we (almost?) always prompt to select the environment/application.

A few examples of how commands would change:

- `acli pull . myapp.dev` becomes `acli pull --dir . --environmentId myapp.dev`
- `acli log:tail myapp.dev` becomes `acli log:tail --environmentId myapp.dev`

Note that this is a rather seriously breaking change, so we'd ideally cut a new major release, and we need to tell people that these arguments are changing to parameters.

**Alternatives considered**
I don't have any other ideas about how to solve #398. There's no way to provide one argument without providing all arguments.

**Testing steps**
How can we replicate the issue and verify that this PR fixes it?

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Test any commands that use environment and application arguments, especially API and pull commands.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
