### PR TITLE
Fix #398: [pull] Change dir argument to option

### DIFF
--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -20,7 +20,7 @@ class PullCodeCommand extends PullCommandBase {
    */
   protected function configure() {
     $this->setDescription('Copy code from a Cloud Platform environment')
-      ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
+      ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
       ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,
         'Do not run any additional scripts after code is pulled. E.g., composer install , drush cache-rebuild, etc.')

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -22,7 +22,7 @@ class PullCommand extends PullCommandBase {
   protected function configure() {
     $this->setAliases(['refresh', 'pull'])
       ->setDescription('Copy code, database, and files from a Cloud Platform environment')
-      ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
+      ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
       ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->addOption('no-code', NULL, InputOption::VALUE_NONE, 'Do not refresh code from remote repository')
       ->addOption('no-files', NULL, InputOption::VALUE_NONE, 'Do not refresh files')

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -572,7 +572,7 @@ abstract class PullCommandBase extends CommandBase {
       return;
     }
 
-    if ($input->hasArgument('dir') && $dir = $input->getArgument('dir')) {
+    if ($input->hasOption('dir') && $dir = $input->getOption('dir')) {
       $this->dir = $dir;
     }
     elseif ($this->repoRoot) {

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -25,7 +25,7 @@ class PullScriptsCommand extends PullCommandBase {
    */
   protected function configure() {
     $this->setDescription('Execute post pull scripts')
-      ->addArgument('dir', InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
+      ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
       ->addArgument('environmentId', InputArgument::OPTIONAL, 'The UUID of the associated Cloud Platform source environment')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }

--- a/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
@@ -63,7 +63,7 @@ class PullCodeCommandTest extends PullCommandTestBase {
     ];
     $this->executeCommand([
       '--no-scripts' => TRUE,
-      'dir' => $dir,
+      '--dir' => $dir,
     ], $inputs);
     $this->prophet->checkPredictions();
   }
@@ -240,8 +240,8 @@ class PullCodeCommandTest extends PullCommandTestBase {
 
     $this->executeCommand([
       // @todo Execute ONLY match php aspect, not the code pull.
-      'dir' => $dir,
       'environmentId' => $environment_response->id,
+      '--dir' => $dir,
       '--no-scripts' => TRUE,
     ], [
       // Please choose an Acquia environment:

--- a/tests/phpunit/src/Commands/Pull/PullScriptsCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullScriptsCommandTest.php
@@ -57,7 +57,7 @@ class PullScriptsCommandTest extends PullCommandTestBase {
     ];
 
     $this->executeCommand([
-      'dir' => $this->projectFixtureDir,
+      '--dir' => $this->projectFixtureDir,
     ], $inputs);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();


### PR DESCRIPTION
**Motivation**
Fixes #398

**Proposed changes**
For pull commands, change the `dir` argument to an option. This is a breaking change for customers that were previously using the `dir` argument, but not severe enough that it warrants a major version bump I think.

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli pull environmentId=foo` and `acli pull environmentId=foo --dir=bar` to make sure the command works with and without the dir argument.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [x] Manual testing by a reviewer
