### PR TITLE
Support legacy API keys.

### DIFF
--- a/src/Helpers/CloudCredentials.php
+++ b/src/Helpers/CloudCredentials.php
@@ -29,7 +29,17 @@ class CloudCredentials {
    * @return string|null
    */
   public function getCloudKey(): ?string {
-    return $this->datastoreCloud->get('acli_key');
+    if ($this->datastoreCloud->get('acli_key')) {
+      return $this->datastoreCloud->get('acli_key');
+    }
+
+    // Legacy format.
+    if ($this->datastoreCloud->get('key') &&
+      $this->datastoreCloud->get('secret')) {
+      return $this->datastoreCloud->get('key');
+    }
+
+    return NULL;
   }
 
   /**
@@ -37,9 +47,17 @@ class CloudCredentials {
    */
   public function getCloudSecret(): ?string {
     $acli_key = $this->getCloudKey();
-    $keys = $this->datastoreCloud->get('keys');
-    if (is_array($keys) && array_key_exists($acli_key, $keys)) {
-      return $this->datastoreCloud->get('keys')[$acli_key]['secret'];
+    if ($this->datastoreCloud->get('keys')) {
+      $keys = $this->datastoreCloud->get('keys');
+      if (is_array($keys) && array_key_exists($acli_key, $keys)) {
+        return $this->datastoreCloud->get('keys')[$acli_key]['secret'];
+      }
+    }
+
+    // Legacy format.
+    if ($this->datastoreCloud->get('key') &&
+      $this->datastoreCloud->get('secret')) {
+      return $this->datastoreCloud->get('secret');
     }
 
     return NULL;


### PR DESCRIPTION
Currently, key's created in ACLI < 1.6.0 are not properly inserted into the services container. This PR resolves that issue.