### PR TITLE
Switch from bug/feature to major/minor/patch labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,5 +17,5 @@ How can we replicate the issue and verify that this PR fixes it?
 3. (add specific steps for this pr)
 
 **Merge requirements**
-- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
+- [ ] _Major_, _Minor_, or _Patch_ label applied
 - [ ] Manual testing by a reviewer

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,25 +2,23 @@ name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 categories:
   - title: '🚨 Major changes'
-    label: 'breaking change'
-  - title: '🚀 Enhancements'
-    label: 'enhancement'
-  - title: '🐛 Bug Fixes'
-    label: 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
+    label: 'major'
+  - title: '🚀 Minor changes'
+    label: 'minor'
+  - title: '🧰 Patch changes'
+    label: 'patch'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
-      - 'breaking change'
+      - 'major'
   minor:
     labels:
-      - 'enhancement'
+      - 'minor'
   patch:
     labels:
-      - 'bug'
+      - 'patch'
   default: patch
 template: |
   ## What's new since $PREVIOUS_TAG


### PR DESCRIPTION
**Motivation**
I find our adherence to semver a little stifling. Linking bug fixes/features to minor/patch versions doesn't reflect (even in the slightest) the potential risk/impact/value to a customer. A huge bug fix like https://github.com/acquia/cli/pull/423 warrants more attention than a patch release. Conversely, a tiny enhancement like https://github.com/acquia/cli/pull/429 barely warrants a patch release. Yet we are stuck with bug fix == patch release and feature == minor release because of semver.

Especially in releases with multiple issues, I think the biggest changes should be featured most prominently, rather than grouping changes by bug fix/feature.

Removing a layer of abstraction and controlling the version number directly seems easiest here.

**Proposed changes**
Label PRs as major/minor/patch changes, and use these to determine release version numbers.
