### PR TITLE
Fixes #434: Override the spec to better set expectations when an IDE is going to be deleted.

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -25,6 +25,10 @@ class ExceptionListener
         case "There are no available Cloud IDEs for this application.\n":
           $newErrorMessage = $errorMessage . "Delete an existing IDE (acli ide:delete) or contact your Account Manager or Acquia Sales to purchase additional IDEs.\n You may also submit a support ticket to ask for more information (https://insight.acquia.com/support/tickets/new?product=p:ride)";
           break;
+        // @todo Remove after CXAPI-8261 is closed.
+        case "The Cloud IDE is being deleted.\n":
+          $newErrorMessage = "The Cloud IDE will be deleted momentarily. This process usually takes a few minutes.\n";
+          break;
         default:
           $newErrorMessage = 'Cloud Platform API returned an error: ' . $errorMessage;
       }


### PR DESCRIPTION
Fix #434 