### PR TITLE
Better set expectations when a pre-provisioned IDE is going to be available

### DIFF
--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -86,7 +86,7 @@ class IdeCreateCommand extends IdeCommandBase {
     }
 
     $loop = Factory::create();
-    $spinner = LoopHelper::addSpinnerToLoop($loop, 'Waiting for the IDE to be configured. This can take up to 15 minutes...', $this->output);
+    $spinner = LoopHelper::addSpinnerToLoop($loop, 'Waiting for the IDE to be ready. This can take up to 15 minutes...', $this->output);
 
     $loop->addPeriodicTimer(5, function () use ($loop, $spinner) {
       try {

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -86,7 +86,7 @@ class IdeCreateCommand extends IdeCommandBase {
     }
 
     $loop = Factory::create();
-    $spinner = LoopHelper::addSpinnerToLoop($loop, 'Waiting for DNS to propagate...', $this->output);
+    $spinner = LoopHelper::addSpinnerToLoop($loop, 'Waiting for the IDE to be configured. This can take up to 15 minutes...', $this->output);
 
     $loop->addPeriodicTimer(5, function () use ($loop, $spinner) {
       try {

--- a/tests/phpunit/src/Commands/ChecklistTest.php
+++ b/tests/phpunit/src/Commands/ChecklistTest.php
@@ -44,7 +44,7 @@ class ChecklistTest extends TestBase {
   public function testLoopTimeout(): void {
     $loop = Factory::create();
     $output = new BufferedOutput();
-    $message = 'Waiting for the IDE to be configured. This can take up to 15 minutes...';
+    $message = 'Waiting for the IDE to be ready. This can take up to 15 minutes...';
     $spinner = LoopHelper::addSpinnerToLoop($loop, $message, $output);
     LoopHelper::addTimeoutToLoop($loop, .01, $spinner, $output);
     try {

--- a/tests/phpunit/src/Commands/ChecklistTest.php
+++ b/tests/phpunit/src/Commands/ChecklistTest.php
@@ -44,7 +44,7 @@ class ChecklistTest extends TestBase {
   public function testLoopTimeout(): void {
     $loop = Factory::create();
     $output = new BufferedOutput();
-    $message = 'Waiting for DNS to propagate...';
+    $message = 'Waiting for the IDE to be configured. This can take up to 15 minutes...';
     $spinner = LoopHelper::addSpinnerToLoop($loop, $message, $output);
     LoopHelper::addTimeoutToLoop($loop, .01, $spinner, $output);
     try {


### PR DESCRIPTION
**Motivation**
Fixes #445

Right now, we're checking for a 200 at the `/health` endpoint. This _assumes_ we're waiting for DNS propagation to reach the end user. But in reality, DNS propagation usually happens fairly quickly and it's the queue processing times that can take time. Additionally, with IDE pre-provisioning, DNS propagation times will no longer be an issue. Instead, we'll be returning a different response code (503) until the IDE has its UUIDs pre-configured. We need to reflect this in the message.

More importantly, what matters is that we don't let people wait forever without setting expectations. We know it can take up to 15mn for the queue to be processed, so by giving this indication to our customers we're also making the wait time less painful. Often, it'll be faster than that, leading to a good surprise.

**Proposed changes**

This PR only changes a string, to better represent the expected wait time and move away from the DNS terminology to configuration, which is more accurate.

**Alternatives considered**

ATM there's none.

**Testing steps**

Create an IDE and confirm the message is returned correctly.

```
$ ./bin/acli ide:create myapp

 Please enter a label for your Cloud IDE:
 > dnstoconfig

    ✔ Creating your Cloud IDE
    ✔ Getting IDE information
    ✔ Waiting for the IDE to be configured. This can take up to 15 minutes...

Your IDE is ready!

Your IDE URL: https://9104a8d0-d237-4bd3-9d2b-0f72dc5030d2.ide.ahdev.cloud
Your Drupal Site URL: https://9104a8d0-d237-4bd3-9d2b-0f72dc5030d2.web.ahdev.cloud
```

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [X] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
