### PR TITLE
Do not show help text for invalid commands.

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -73,9 +73,11 @@ class ExceptionListener {
     }
 
     $this->helpMessages[] = "You can find Acquia CLI documentation at https://docs.acquia.com/acquia-cli/";
-    /** @var \Acquia\Cli\Application $application */
-    $application = $event->getCommand()->getApplication();
-    $application->setHelpMessages($this->helpMessages);
+    if ($application = $event->getCommand()) {
+      /** @var \Acquia\Cli\Application $application */
+      $application = $event->getCommand()->getApplication();
+      $application->setHelpMessages($this->helpMessages);
+    }
 
     if (isset($new_error_message)) {
       $event->setError(new AcquiaCliException($new_error_message, [], $exitCode));


### PR DESCRIPTION
As of 1.8.0, if a user tries to run an non-existent command like `acli fake-command` an exception will be thrown rather than showing the correct error output:

```
Fatal error: Uncaught Error: Call to a member function getApplication() on null in phar:///private/tmp/acli.phar/src/EventListener/ExceptionListener.php on line 77

Error: Call to a member function getApplication() on null in phar:///private/tmp/acli.phar/src/EventListener/ExceptionListener.php on line 77

Call Stack:
    0.0856    1649144   1. {main}() /private/tmp/acli.phar:0
    0.1502    1980968   2. require('phar:///private/tmp/acli.phar/bin/acli') /private/tmp/acli.phar:14
    0.5803   16775344   3. Acquia\Cli\Application->run(???, ???) phar:///private/tmp/acli.phar/bin/acli:86
    0.5983   16782488   4. Acquia\Cli\Application->doRun(???, ???) phar:///private/tmp/acli.phar/vendor/symfony/console/Application.php:166
    0.6129   16840544   5. Symfony\Component\EventDispatcher\EventDispatcher->dispatch(???, ???) phar:///private/tmp/acli.phar/vendor/symfony/console/Application.php:259
    0.6130   16842064   6. Symfony\Component\EventDispatcher\EventDispatcher->callListeners(???, ???, ???) phar:///private/tmp/acli.phar/vendor/symfony/event-dispatcher/EventDispatcher.php:59
    0.6130   16842064   7. Symfony\Component\EventDispatcher\EventDispatcher::Symfony\Component\EventDispatcher\{closure:phar:///private/tmp/acli.phar/vendor/symfony/event-dispatcher/EventDispatcher.php:265-271}(...variadic(???, ???, ???)) phar:///private/tmp/acli.phar/vendor/symfony/event-dispatcher/EventDispatcher.php:230
    0.6134   16859432   8. Acquia\Cli\EventListener\ExceptionListener->onConsoleError(???, ???, ???) phar:///private/tmp/acli.phar/vendor/symfony/event-dispatcher/EventDispatcher.php:270
```