### PR TITLE
Updated build and release docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build
 .DS_STORE
 tests/fixtures/.acquia/acquia-cli.json
 tests/fixtures/.acquia/cloud_api.conf
-*.phar
 
 ###> squizlabs/php_codesniffer ###
 /.phpcs-cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,15 +51,22 @@ composer install
 
 Be sure to validate and test your code locally using the provided Composer test scripts (`composer test`) before opening a PR.
 
+### Building acli.phar
+
+To test changes in production mode, build and run acli.phar using this process. You can verify that the "Build PHAR" stage of .travis.yml follows a similar process.
+
+1. Install Composer production dependencies: `composer install --no-dev --optimize-autoloader`
+1. Clear and rebuild your Symfony cache: `./bin/acli ckc && ./bin/acli`
+1. Install Box and dump env vars (only need to do this once): `composer box-install && composer dump-env prod`
+1. Compile phar: `composer box-compile`
+
 ### Testing the `update` command
 
 Any changes to the `acli update` command should be manually tested using the following steps:
 
 1. Replace `@package_version@` on this line with `1.0.0` or any older version string: https://github.com/acquia/cli/blob/v1.0.0/bin/acli#L84
-2. Clear and rebuild your Symfony cache: `./bin/acli ckc && ./bin/acli`
-4. Install Box if you haven't already: `composer box-install && composer dump-env prod`
-5. Compile phar: `composer box-compile`
-6. Now test: `./build/acli.phar self:update`
+1. Build acli.phar as described above.
+1. Now test: `./build/acli.phar self:update`
 
 ## Updating Cloud Platform API spec
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,10 @@ If you are testing a change to `consolidation/self-update`, start by linking it 
     }
   ],
 ```
-Run `composer update` and ensure your development copy of self-update is linked. Then follow the steps below to test the update command.
+
+In the `composer.json` requirements section, then change the version string to match your locally checked-out branch. For instance: `"consolidation/self-update": "dev-foo as 1.1",` 
+
+Finally, run `composer update` and ensure your development copy of self-update is linked. Then follow the steps below to test the update command.
 
 ### Testing the `update` command
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,22 @@ To test changes in production mode, build and run acli.phar using this process. 
 1. Install Box and dump env vars (only need to do this once): `composer box-install && composer dump-env prod`
 1. Compile phar: `composer box-compile`
 
+### Testing changes to consolidation/self-update
+
+If you are testing a change to `consolidation/self-update`, start by linking it to ACLI. Modify the repositories key in composer.json so that the url is the path to your working copy of `self-update` on your local machine, and optionally disable symlinking if Composer has autoloading complaints:
+```
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "../self-update",
+      "options": {
+        "symlink": false
+      }
+    }
+  ],
+```
+Run `composer update` and ensure your development copy of self-update is linked. Then follow the steps below to test the update command.
+
 ### Testing the `update` command
 
 Any changes to the `acli update` command should be manually tested using the following steps:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,0 @@
-# Release process
-
-1. Draft a new release and tag via the Github UI. If releasing against a particular commit (rather than HEAD), make sure to choose the commit in the Github UI, do not create a release on an existing tag. Travis CI doesn’t seem to react to releases created on existing tags.
-1. Copy and paste relevant commits since the previous release into the release notes (find relevant commits by drafting a pull request, e.g. https://github.com/acquia/cli/compare/v1.3.0...master)
-1. Pay special attention to issues with the "change record" label, these need to be called out in release notes.
-1. Publish the release.
-1. Ensure that Travis CI builds and attaches acli.phar as a release asset.
-1. Update RELEASE.md with new version numbers.

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
       "rm -rf cx-api-spec"
     ],
     "box-install": [
-      "curl -O -L https://github.com/humbug/box/releases/latest/download/box.phar"
+      "curl -L https://github.com/humbug/box/releases/latest/download/box.phar -o build/box.phar"
     ],
     "box-compile": [
       "php build/box.phar compile"

--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
       "curl -O -L https://github.com/humbug/box/releases/latest/download/box.phar"
     ],
     "box-compile": [
-      "php box.phar compile"
+      "php build/box.phar compile"
     ],
     "cs": "phpcs",
     "cbf": "phpcbf",


### PR DESCRIPTION
- Add build steps to contributing doc
- Remove release doc, since release drafter manages everything now
- Move box.phar to build directory so it's more easily excluded from Git and IDE indexing

These steps are necessary to test the fix for https://github.com/consolidation/self-update/issues/9 via https://github.com/danepowell/self-update/pull/3