### PR TITLE
[pull:db] Allow on-demand backups

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -107,7 +107,7 @@ abstract class PullCommandBase extends CommandBase {
     $source_environment = $this->determineEnvironment($input, $output);
     $database = $this->determineSourceDatabase($acquia_cloud_client, $source_environment);
     if ($input->getOption('on-demand')) {
-      $this->checklist->addItem('Creating an on-demand backup');
+      $this->checklist->addItem("Creating an on-demand database backup on Cloud Platform");
       $this->createBackup($source_environment, $database, $acquia_cloud_client);
       $this->checklist->completePreviousItem();
     }

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -258,7 +258,7 @@ abstract class PullCommandBase extends CommandBase {
     $this->logger->debug('Using database backup (id #' . $backup_response->id . ') generated at ' . $backup_response->completedAt);
     $interval = time() - strtotime($backup_response->completedAt);
     if ($interval > 24*60*60) {
-      $this->logger->warning('Using database backup generated at ' . $backup_response->completedAt . ', which is more than 24 hours old. To generate a new backup, re-run this command with the `--on-demand` option.');
+      $this->logger->warning('Using database backup generated at ' . $backup_response->completedAt . ', which is more than 24 hours old. To generate a new backup, re-run this command with the <options=bold>--on-demand</> option.');
     }
     // Filename roughly matches what you'd get with a manual download from Cloud UI.
     $filename = implode('-', ['backup', $backup_response->completedAt, $database->name]) . '.sql.gz';

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -255,7 +255,11 @@ abstract class PullCommandBase extends CommandBase {
       $backups_response = $database_backups->getAll($environment->uuid, $database->name);
     }
     $backup_response = $backups_response[0];
-    $this->logger->debug('Using database backup generated at ' . $backup_response->completedAt);
+    $this->logger->debug('Using database backup (id #' . $backup_response->id . ') generated at ' . $backup_response->completedAt);
+    $interval = time() - strtotime($backup_response->completedAt);
+    if ($interval > 24*60*60) {
+      $this->logger->warning('Using database backup generated at ' . $backup_response->completedAt . ', which is more than 24 hours old. To generate a new backup, re-run this command with the `--on-demand` option.');
+    }
     // Filename roughly matches what you'd get with a manual download from Cloud UI.
     $filename = implode('-', ['backup', $backup_response->completedAt, $database->name]) . '.sql.gz';
     $local_filepath = Path::join(sys_get_temp_dir(), $filename);

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -19,12 +19,14 @@ class PullDatabaseCommand extends PullCommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Import latest database backup from a Cloud Platform environment')
-      ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. You can generate an on-demand backup using api:environments:database-backup-create.')
+    $this->setDescription('Import database backup from a Cloud Platform environment')
+      ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. If no backup exists, one will be created.')
       ->setAliases(['pull:db'])
       ->acceptEnvironmentId()
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,
         'Do not run any additional scripts after the database is pulled. E.g., drush cache-rebuild, drush sql-sanitize, etc.')
+      ->addOption('on-demand', NULL, InputOption::VALUE_NONE,
+        'Force creation of an on-demand backup. This takes much longer than using an existing backup (when one is available)')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -375,7 +375,6 @@ abstract class CommandTestBase extends TestBase {
     $environments_response,
     $db_name
   ) {
-    //$backup_create_response = json_decode(file_get_contents(Path::join($this->fixtureDir, '/backup_create_response.json')));
     $backup_create_response = $this->getMockResponseFromSpec('/environments/{environmentId}/databases/{databaseName}/backups', 'post', 202)->{'Creating backup'}->value;
     $this->clientProphecy->request('post', "/environments/{$environments_response->id}/databases/{$db_name}/backups")
       ->willReturn($backup_create_response)
@@ -386,7 +385,6 @@ abstract class CommandTestBase extends TestBase {
 
   protected function mockNotificationResponse($notification_uuid) {
     $notification_response = $this->getMockResponseFromSpec('/notifications/{notificationUuid}', 'get', 200);
-    // $notification_response = json_decode(file_get_contents(Path::join($this->fixtureDir, '/notification_response.json')));
     $this->clientProphecy->request('get', "/notifications/$notification_uuid")
       ->willReturn($notification_response)
       ->shouldBeCalled();

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -371,4 +371,27 @@ abstract class CommandTestBase extends TestBase {
       ->shouldBeCalled();
   }
 
+  protected function mockDatabaseBackupCreateResponse(
+    $environments_response,
+    $db_name
+  ) {
+    //$backup_create_response = json_decode(file_get_contents(Path::join($this->fixtureDir, '/backup_create_response.json')));
+    $backup_create_response = $this->getMockResponseFromSpec('/environments/{environmentId}/databases/{databaseName}/backups', 'post', 202)->{'Creating backup'}->value;
+    $this->clientProphecy->request('post', "/environments/{$environments_response->id}/databases/{$db_name}/backups")
+      ->willReturn($backup_create_response)
+      ->shouldBeCalled();
+
+    return $backup_create_response;
+  }
+
+  protected function mockNotificationResponse($notification_uuid) {
+    $notification_response = $this->getMockResponseFromSpec('/notifications/{notificationUuid}', 'get', 200);
+    // $notification_response = json_decode(file_get_contents(Path::join($this->fixtureDir, '/notification_response.json')));
+    $this->clientProphecy->request('get', "/notifications/$notification_uuid")
+      ->willReturn($notification_response)
+      ->shouldBeCalled();
+
+    return $notification_response;
+  }
+
 }

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -139,6 +139,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
 
     if ($on_demand) {
       $this->mockDatabaseBackupCreateResponse($environments_response, 'profserv2');
+      // Cloud API does not provide the notification UUID as part of the backup response, so we must hardcode it.
       $this->mockNotificationResponse('42b56cff-0b55-4bdf-a949-1fd0fca61c6c');
     }
 

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -46,6 +46,26 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('profserv2 (default)', $output);
   }
 
+  public function testPullDatabasesOnDemand(): void {
+    $this->setupPullDatabase(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE);
+    $inputs = $this->getInputs();
+
+    $this->executeCommand([
+      '--no-scripts' => TRUE,
+      '--on-demand' => TRUE
+    ], $inputs);
+    $this->prophet->checkPredictions();
+    $output = $this->getDisplay();
+
+    $this->assertStringContainsString('Please select a Cloud Platform application:', $output);
+    $this->assertStringContainsString('[0] Sample application 1', $output);
+    $this->assertStringContainsString('Choose a Cloud Platform environment:', $output);
+    $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
+    $this->assertStringContainsString('Choose a database', $output);
+    $this->assertStringContainsString('jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)', $output);
+    $this->assertStringContainsString('profserv2 (default)', $output);
+  }
+
   /**
    * Test that settings files are created for multisite DBs in IDEs.
    *
@@ -106,7 +126,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     }
   }
 
-  protected function setupPullDatabase($mysql_dl_successful, $mysql_drop_successful, $mysql_create_successful, $mysql_import_successful, $mock_ide_fs = FALSE): void {
+  protected function setupPullDatabase($mysql_dl_successful, $mysql_drop_successful, $mysql_create_successful, $mysql_import_successful, $mock_ide_fs = FALSE, $on_demand = FALSE): void {
     $applications_response = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
     $environments_response = $this->mockAcsfEnvironmentsRequest($applications_response);
@@ -116,6 +136,11 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->mockDownloadBackupResponse($environments_response, 'profserv2', 1);
     $ssh_helper = $this->mockSshHelper();
     $this->mockGetAcsfSites($ssh_helper);
+
+    if ($on_demand) {
+      $this->mockDatabaseBackupCreateResponse($environments_response, 'profserv2');
+      $this->mockNotificationResponse('42b56cff-0b55-4bdf-a949-1fd0fca61c6c');
+    }
 
     $fs = $this->prophet->prophesize(Filesystem::class);
     $local_machine_helper = $this->mockLocalMachineHelper();


### PR DESCRIPTION
**Motivation**
Currently, the `pull:db` command uses the latest periodic backup. This is undesirable in two cases:
1. If the environment has no backups (this is especially likely for ACSF dev environments)
2. If the customer wants a more recent backup

**Proposed changes**
Support using an on-demand backup under two conditions:
1. Automatically, if there are no existing backups available
2. Manually, if requested via the `--on-demand` option

**Testing steps**
How can we replicate the issue and verify that this PR fixes it?

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli pull:db` in scenarios including ACE and ACSF subscriptions, and for environment with and without existing backups

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer