### PR TITLE
DX-3486: [new] fails for existing git repo

### DIFF
--- a/src/Command/NewCommand.php
+++ b/src/Command/NewCommand.php
@@ -120,6 +120,10 @@ class NewCommand extends CommandBase {
    * @throws \Exception
    */
   protected function initializeGitRepository(string $dir): void {
+    if ($this->localMachineHelper->getFilesystem()->exists(Path::join($dir, '.git'))) {
+      $this->logger->debug('.git directory detected, skipping Git repo initialization');
+      return;
+    }
     $this->localMachineHelper->execute([
       'git',
       'init',

--- a/tests/phpunit/src/Commands/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/NewCommandTest.php
@@ -54,6 +54,7 @@ class NewCommandTest extends CommandTestBase {
 
     $local_machine_helper = $this->mockLocalMachineHelper();
 
+    $this->mockGetFilesystem($local_machine_helper);
     $this->mockExecuteComposerCreate($this->newProjectDir, $local_machine_helper, $process, $project);
     $this->mockExecuteComposerUpdate($local_machine_helper, $this->newProjectDir, $process);
     $this->mockExecuteGitInit($local_machine_helper, $this->newProjectDir, $process);


### PR DESCRIPTION
**Motivation**
Fixes #427

**Proposed changes**
Check for existing `.git` repo before initializing one of our own.

**Alternatives considered**
Set dummy Git credentials or otherwise deal with missing Git creds in Cloud IDEs. This is the ideal solution, but requires a lot more work (see example implementation in BLT).

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli new` in a Cloud IDE with the recommended project template and verify there are no errors.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
