### PR TITLE
Ensure every prompt has a default response

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1396,7 +1396,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     foreach ($acsf_sites['sites'] as $domain => $acsf_site) {
       $choices[] = "{$acsf_site['name']} ($domain)";
     }
-    $choice = $this->io->choice('Choose a site', $choices);
+    $choice = $this->io->choice('Choose a site', $choices, $choices[0]);
     $key = array_search($choice, $choices, TRUE);
     $sites = array_values($acsf_sites['sites']);
     $site = $sites[$key];
@@ -1416,7 +1416,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       $site = reset($sites);
       return $site;
     }
-    return $this->io->choice('Choose a site', $sites);
+    return $this->io->choice('Choose a site', $sites, $sites[0]);
   }
 
   /**

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -554,7 +554,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       }
     }
     $labels = array_values($list);
-    $question = new ChoiceQuestion($question_text, $labels);
+    $default = $multiselect ? NULL : $labels[0];
+    $question = new ChoiceQuestion($question_text, $labels, $default);
     $question->setMultiselect($multiselect);
     $choice_id = $this->io->askQuestion($question);
     if (!$multiselect) {

--- a/src/Command/Ide/IdeCommandBase.php
+++ b/src/Command/Ide/IdeCommandBase.php
@@ -38,7 +38,7 @@ abstract class IdeCommandBase extends CommandBase {
     foreach ($ides as $key => $ide) {
       $choices[] = "{$ide->label} ($ide->uuid)";
     }
-    $choice = $this->io->choice($question_text, $choices);
+    $choice = $this->io->choice($question_text, $choices, $choices[0]);
     $chosen_environment_index = array_search($choice, $choices, TRUE);
 
     return $ides[$chosen_environment_index];

--- a/src/Command/NewCommand.php
+++ b/src/Command/NewCommand.php
@@ -39,7 +39,7 @@ class NewCommand extends CommandBase {
       'acquia/drupal-recommended-project',
       'acquia/drupal-minimal-project',
     ];
-    $project = $this->io->choice('Choose a starting project', $distros);
+    $project = $this->io->choice('Choose a starting project', $distros, $distros[0]);
 
     if ($input->hasArgument('directory') && $input->getArgument('directory')) {
       $dir = Path::canonicalize($input->getArgument('directory'));

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -495,7 +495,7 @@ abstract class PullCommandBase extends CommandBase {
       }
       $choices[] = "{$environment->label}, {$environment->name} (vcs: {$environment->vcs->path})";
     }
-    $chosen_environment_label = $this->io->choice('Choose a Cloud Platform environment', $choices);
+    $chosen_environment_label = $this->io->choice('Choose a Cloud Platform environment', $choices, $choices[0]);
     $chosen_environment_index = array_search($chosen_environment_label, $choices, TRUE);
 
     return $application_environments[$chosen_environment_index];

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -41,7 +41,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
 
     $this->assertStringContainsString('Please select a Cloud Platform application:', $output);
     $this->assertStringContainsString('[0] Sample application 1', $output);
-    $this->assertStringContainsString('Choose a Cloud Platform environment:', $output);
+    $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
     $this->assertStringContainsString('Choose a database', $output);
     $this->assertStringContainsString('jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)', $output);
@@ -59,9 +59,9 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
 
-    $this->assertStringContainsString('Please select a Cloud Platform application:', $output);
+    $this->assertStringContainsString('Please select a Cloud Platform application', $output);
     $this->assertStringContainsString('[0] Sample application 1', $output);
-    $this->assertStringContainsString('Choose a Cloud Platform environment:', $output);
+    $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
     $this->assertStringContainsString('Choose a database', $output);
     $this->assertStringContainsString('jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)', $output);

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -70,7 +70,7 @@ class PullFilesCommandTest extends PullCommandTestBase {
 
     $this->assertStringContainsString('Please select a Cloud Platform application:', $output);
     $this->assertStringContainsString('[0] Sample application 1', $output);
-    $this->assertStringContainsString('Choose a Cloud Platform environment:', $output);
+    $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
   }
 
@@ -108,9 +108,9 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
 
-    $this->assertStringContainsString('Please select a Cloud Platform application:', $output);
+    $this->assertStringContainsString('Please select a Cloud Platform application', $output);
     $this->assertStringContainsString('[0] Sample application 1', $output);
-    $this->assertStringContainsString('Choose a Cloud Platform environment:', $output);
+    $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
   }
 

--- a/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
@@ -44,7 +44,7 @@ class SshKeyDeleteCommandTest extends CommandTestBase
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString('Choose an SSH key to delete from the Cloud Platform:', $output);
+    $this->assertStringContainsString('Choose an SSH key to delete from the Cloud Platform', $output);
     $this->assertStringContainsString($ssh_key_list_response->_embedded->items[0]->label, $output);
   }
 

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -46,7 +46,7 @@ class SshKeyUploadCommandTest extends CommandTestBase
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString('Choose a local SSH key to upload to the Cloud Platform:', $output);
+    $this->assertStringContainsString('Choose a local SSH key to upload to the Cloud Platform', $output);
     $this->assertStringContainsString('Please enter a Cloud Platform label for this SSH key:', $output);
     $base_filename = basename($temp_file_name);
     $this->assertStringContainsString("Uploaded $base_filename to the Cloud Platform with label " . $mock_request_args['label'], $output);


### PR DESCRIPTION
**Motivation**
It's annoying to not have a default response to prompts, _especially_ when there's only a single available option.

**Proposed changes**
Ensure every prompt has a default response, even if it's just the first option in whatever array of choices we present.

**Alternatives considered**
Wrap the Symfony `choice()` method in a utility class/method that ensures that every choice has a default even if it's not explicitly set. Seems like overkill.

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Try commands like `acli new` or `acli pull:db` that force a selection from a list, and ensure a default is set.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
