### PR TITLE
Fix #496: Deploy builds failing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
       "rm -rf cx-api-spec"
     ],
     "box-install": [
-      "curl -L https://github.com/humbug/box/releases/latest/download/box.phar -o build/box.phar"
+      "curl -f -L https://github.com/humbug/box/releases/latest/download/box.phar -o build/box.phar"
     ],
     "box-compile": [
       "php build/box.phar compile"

--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
       "rm -rf cx-api-spec"
     ],
     "box-install": [
-      "curl -f -L https://github.com/humbug/box/releases/latest/download/box.phar -o build/box.phar"
+      "curl -f -L https://github.com/box-project/box/releases/download/3.11.1/box.phar -o build/box.phar"
     ],
     "box-compile": [
       "php build/box.phar compile"


### PR DESCRIPTION
**Motivation**
Fixes #496

**Proposed changes**
Pin the Box version and add the curl `--fail` flag so the script will exit and alert us next time instead of failing silently. Also update the namespace (apparently the project changed ownership).

**Alternatives considered**
Switch to something other than Box that can be properly verified. These have been known issues for a while with no maintainer response:
- https://github.com/box-project/box/issues/487
- https://github.com/box-project/box/issues/530

**Testing steps**
1. See that the first commit fails (as it should, since Box master is broken)
2. See that the second commit passes (after pinning Box to known good release)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
