### PR TITLE
[push:code] build artifacts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,10 +89,14 @@
     "patches": {
       "symfony/console": [
         "https://github.com/symfony/symfony/commit/57910d696b1a3b8573cd562d438880854ba4328e.patch"
+      ],
+      "symfony/filesystem": [
+        "symfony-fs-mirror.patch"
       ]
     },
     "patchLevel": {
-      "symfony/console": "-p5"
+      "symfony/console": "-p5",
+      "symfony/filesystem": "-p5"
     }
   },
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a22621e5458ee452eb736edb355225cd",
+    "content-hash": "f9db117f9fcd52543faa000e33a5e60b",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -3008,16 +3008,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.4",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108"
+                "reference": "8c86a82f51658188119e62cff0a050a12d09836f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/710d364200997a5afde34d9fe57bd52f3cc1e108",
-                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8c86a82f51658188119e62cff0a050a12d09836f",
+                "reference": "8c86a82f51658188119e62cff0a050a12d09836f",
                 "shasum": ""
             },
             "require": {
@@ -3050,7 +3050,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.4"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -3066,7 +3066,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-12T10:38:38+00:00"
+            "time": "2021-03-28T14:30:26+00:00"
         },
         {
             "name": "symfony/finder",

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -482,6 +482,20 @@ abstract class PullCommandBase extends CommandBase {
     return (bool) $process->getOutput();
   }
 
+  protected function getLocalGitCommitHash(): string {
+    $process = $this->localMachineHelper->execute([
+      'git',
+      'rev-parse',
+      'HEAD',
+    ], NULL, $this->dir, FALSE);
+
+    if (!$process->isSuccessful()) {
+      throw new AcquiaCliException("Unable to determine Git commit hash.");
+    }
+
+    return trim($process->getOutput());
+  }
+
   /**
    * @param $acquia_cloud_client
    * @param string $cloud_application_uuid

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Acquia\Cli\Command\Push;
+
+use Acquia\Cli\Command\Pull\PullCommandBase;
+use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\Cli\Output\Checklist;
+use Closure;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+use Webmozart\PathUtil\Path;
+
+/**
+ * Class PushArtifactCommand.
+ */
+class PushArtifactCommand extends PullCommandBase {
+
+  protected static $defaultName = 'push:artifact';
+
+  /**
+   * @var string
+   */
+  protected $dir;
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure(): void {
+    $this->setDescription('Build and push a code artifact to a Cloud Platform environment')
+      ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be pushed')
+      ->addOption('no-sanitize', NULL, InputOption::VALUE_NONE, 'Do not sanitize the build artifact')
+      ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Do not push changes to Acquia Cloud')
+      ->acceptEnvironmentId()
+    ->setHelp("This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.\n\n"
+      . "The following vendor files and directories are committed to the build artifact even if they are ignored in the source repository: " . implode(', ', self::vendorFiles()) . "\n\n"
+      . "To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events");
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return int 0 if everything went fine, or an exit code
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    // @todo change deploy strategy depending on whether this is a "source" repo (requiring building) or not
+    // @todo handle if Git user name/email is missing
+    $this->setDirAndRequireProjectCwd($input);
+    $is_dirty = $this->isLocalGitRepoDirty();
+    $commit_hash = $this->getLocalGitCommitHash();
+    if ($is_dirty) {
+      throw new AcquiaCliException('Pushing code was aborted because your local Git repository has uncommitted changes. Please either commit, reset, or stash your changes via git.');
+    }
+    $this->checklist = new Checklist($output);
+
+    // @todo handle environments with tags deployed
+    $this->logger->warning('You must select an environment with a Git branch deployed');
+    $environment = $this->determineEnvironment($input, $output, TRUE);
+    if (strpos($environment->vcs->path, 'tags') === 0) {
+      throw new AcquiaCliException("Environments with Git tags are not supported. Environment {$environment->name} has {$environment->vcs->path} deployed.");
+    }
+    $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
+    $output_callback = $this->getOutputCallback($output, $this->checklist);
+
+    $this->checklist->addItem('Preparing artifact directory');
+    $this->prepareDir($output_callback, $artifact_dir, $environment->vcs->url, $environment->vcs->path);
+    $this->checklist->completePreviousItem();
+
+    $this->checklist->addItem('Generating build artifact');
+    $this->build($output_callback, $artifact_dir);
+    $this->checklist->completePreviousItem();
+
+    if (!$input->getOption('no-sanitize')) {
+      $this->checklist->addItem('Sanitizing build artifact');
+      $this->sanitize($artifact_dir);
+      $this->checklist->completePreviousItem();
+    }
+
+    $this->checklist->addItem("Committing changes (commit hash: $commit_hash)");
+    $this->commit($output_callback, $artifact_dir, $commit_hash);
+    $this->checklist->completePreviousItem();
+
+    if (!$input->getOption('dry-run')) {
+      $this->checklist->addItem("Pushing changes to {$environment->vcs->path} branch in the {$environment->name} environment");
+      $this->push($output_callback, $artifact_dir);
+      $this->checklist->completePreviousItem();
+    }
+    else {
+      $this->logger->warning("The <options=bold>--dry-run</> option prevented changes from being pushed to Acquia Cloud. The artifact has been built at $artifact_dir");
+    }
+
+    return 0;
+  }
+
+  /**
+   * Prepares a directory to build the artifact.
+   *
+   * @param \Closure $output_callback
+   * @param string $artifact_dir
+   * @param string $vcs_url
+   * @param string $vcs_path
+   *
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   */
+  protected function prepareDir(Closure $output_callback, string $artifact_dir, string $vcs_url, string $vcs_path): void {
+    $fs = $this->localMachineHelper->getFilesystem();
+
+    $this->logger->info("Removing $artifact_dir if it exists");
+    $fs->remove($artifact_dir);
+
+    $this->logger->info("Initializing Git in $artifact_dir");
+    $process = $this->localMachineHelper->executeFromCmd("git clone --depth 1 --branch $vcs_path $vcs_url $artifact_dir", $output_callback, NULL, $this->output->isVerbose());
+    if (!$process->isSuccessful()) {
+      throw new AcquiaCliException('Failed to clone repository from the Cloud Platform: {message}', ['message' => $process->getErrorOutput()]);
+    }
+
+    $this->logger->info('Global .gitignore file is temporarily disabled during artifact builds.');
+    $this->localMachineHelper->executeFromCmd('git config --local core.excludesFile false', $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->executeFromCmd('git config --local core.fileMode true', $output_callback, $artifact_dir, $this->output->isVerbose());
+
+    // Vendor directories can be "corrupt" (i.e. missing scaffold files due to earlier sanitization) in ways that break composer install.
+    $this->logger->info('Removing vendor directories');
+    foreach (self::vendorFiles() as $vendor_directory) {
+      $fs->remove(Path::join($artifact_dir, $vendor_directory));
+    }
+  }
+
+  protected function build(Closure $output_callback, string $artifact_dir): void {
+    // @todo generate a deploy identifier
+    // @see https://git.drupalcode.org/project/drupal/-/blob/9.1.x/sites/default/default.settings.php#L295
+    $this->logger->info("Mirroring source files from {$this->dir} to $artifact_dir");
+    $originFinder = Finder::create();
+    $originFinder->files()->in($this->dir)
+      // Include dot files like .htaccess.
+      ->ignoreDotFiles(FALSE)
+      // Ignore VCS ignored files (e.g. vendor) to speed up the mirror (Composer will restore them later).
+      ->ignoreVCSIgnored(TRUE);
+    $targetFinder = Finder::create();
+    $targetFinder->files()->in($artifact_dir)->ignoreDotFiles(FALSE);
+    $this->localMachineHelper->getFilesystem()->mirror($this->dir, $artifact_dir, $originFinder, ['override' => TRUE, 'delete' => TRUE], $targetFinder);
+
+    $this->logger->info('Installing Composer production dependencies');
+    $this->localMachineHelper->executeFromCmd('composer install --no-dev --no-interaction --optimize-autoloader', $output_callback, $artifact_dir, $this->output->isVerbose());
+  }
+
+  protected function sanitize(string $artifact_dir):void {
+    $this->logger->info('Finding Drupal core text files');
+    $sanitizeFinder = Finder::create()
+      ->files()
+      ->name('*.txt')
+      ->notName('LICENSE.txt')
+      ->in("$artifact_dir/docroot/core");
+
+    $this->logger->info('Finding VCS directories');
+    $vcsFinder = Finder::create()
+      ->ignoreDotFiles(FALSE)
+      ->ignoreVCS(FALSE)
+      ->directories()
+      ->in(["$artifact_dir/docroot",
+        "$artifact_dir/vendor",
+      ])
+      ->name('.git');
+    $drush_dir = "$artifact_dir/drush";
+    if (file_exists($drush_dir)) {
+      $vcsFinder->in($drush_dir);
+    }
+    if ($vcsFinder->hasResults()) {
+      $sanitizeFinder->append($vcsFinder);
+    }
+
+    $this->logger->info('Finding INSTALL database text files');
+    $dbInstallFinder = Finder::create()
+      ->files()
+      ->in([$artifact_dir])
+      ->name('/INSTALL\.[a-z]+\.(md|txt)$/');
+    if ($dbInstallFinder->hasResults()) {
+      $sanitizeFinder->append($dbInstallFinder);
+    }
+
+    $this->logger->info('Finding other common text files');
+    $filenames = [
+      'AUTHORS',
+      'CHANGELOG',
+      'CONDUCT',
+      'CONTRIBUTING',
+      'INSTALL',
+      'MAINTAINERS',
+      'PATCHES',
+      'TESTING',
+      'UPDATE',
+    ];
+    $textFileFinder = Finder::create()
+      ->files()
+      ->in(["$artifact_dir/docroot"])
+      ->name('/(' . implode('|', $filenames) . ')\.(md|txt)$/');
+    if ($textFileFinder->hasResults()) {
+      $sanitizeFinder->append($textFileFinder);
+    }
+
+    $this->logger->info("Removing sanitized files from build");
+    $this->localMachineHelper->getFilesystem()->remove($sanitizeFinder);
+  }
+
+  protected function commit(Closure $output_callback, string $artifact_dir, string $commit_hash):void {
+    $this->logger->info('Adding and committing changed files');
+    $this->localMachineHelper->executeFromCmd('git add -A', $output_callback, $artifact_dir, $this->output->isVerbose());
+    foreach (self::vendorFiles() as $vendor_directory) {
+      // This will fatally error if the directory doesn't exist. Suppress error output.
+      $this->logger->debug("Forcibly adding $vendor_directory");
+      $this->localMachineHelper->executeFromCmd('git add -f ' . $vendor_directory, NULL, $artifact_dir, FALSE);
+    }
+    $this->localMachineHelper->executeFromCmd('git commit -m "Automated commit by Acquia CLI (source commit: ' . $commit_hash . ')"', $output_callback, $artifact_dir, $this->output->isVerbose());
+  }
+
+  protected function push(Closure $output_callback, string $artifact_dir):void {
+    $this->logger->info('Pushing changes to Acquia Git');
+    $this->localMachineHelper->executeFromCmd('git push', $output_callback, $artifact_dir, $this->output->isVerbose());
+  }
+
+  private static function vendorFiles(): array {
+    return [
+      'vendor',
+      'docroot/core',
+      'docroot/modules/contrib',
+      'docroot/themes/contrib',
+      'docroot/profiles/contrib',
+      'docroot/libraries',
+      'drush/Commands',
+      'docroot/index.php',
+      'docroot/.htaccess',
+      'docroot/autoload.php',
+      'docroot/robots.txt',
+      'docroot/update.php',
+      'docroot/web.config'
+    ];
+  }
+
+}

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -22,16 +22,22 @@ class PushArtifactCommand extends PullCommandBase {
 
   /**
    * @var string
+   *
+   * Drupal project directory.
    */
   protected $dir;
 
   /**
    * @var array
+   *
+   * Composer vendor directories.
    */
   protected $vendorDirs;
 
   /**
    * @var array
+   *
+   * Composer scaffold files.
    */
   protected $scaffoldFiles;
 
@@ -231,7 +237,14 @@ class PushArtifactCommand extends PullCommandBase {
     $this->localMachineHelper->execute(['git', 'push'], $output_callback, $artifact_dir, $this->output->isVerbose());
   }
 
-  private function vendorDirs(string $artifact_dir): array {
+  /**
+   * Get a list of Composer vendor directories from the root composer.json.
+   *
+   * @param string $artifact_dir
+   *
+   * @return array|string[]
+   */
+  protected function vendorDirs(string $artifact_dir): array {
     if (!empty($this->vendorDirs)) {
       return $this->vendorDirs;
     }
@@ -246,7 +259,14 @@ class PushArtifactCommand extends PullCommandBase {
     return $this->vendorDirs;
   }
 
-  private function scaffoldFiles(string $artifact_dir): array {
+  /**
+   * Get a list of scaffold files from Drupal core's composer.json.
+   *
+   * @param string $artifact_dir
+   *
+   * @return array
+   */
+  protected function scaffoldFiles(string $artifact_dir): array {
     if (!empty($this->scaffoldFiles)) {
       return $this->scaffoldFiles;
     }

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -58,7 +58,7 @@ class PushArtifactCommand extends PullCommandBase {
     $this->checklist = new Checklist($output);
 
     // @todo handle environments with tags deployed
-    $this->logger->warning('You must select an environment with a Git branch deployed');
+    $output->writeln('<info>You must select an environment with a Git branch deployed</info>');
     $environment = $this->determineEnvironment($input, $output, TRUE);
     if (strpos($environment->vcs->path, 'tags') === 0) {
       throw new AcquiaCliException("You cannot push to an environment that has a git tag deployed to it. Environment {$environment->name} has {$environment->vcs->path} deployed. Please select a different environment.");

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -85,7 +85,7 @@ class PushArtifactCommand extends PullCommandBase {
     $this->checklist->completePreviousItem();
 
     if (!$input->getOption('dry-run')) {
-      $this->checklist->addItem("Pushing changes to {$environment->vcs->path} branch in the {$environment->name} environment");
+      $this->checklist->addItem("Pushing changes to <options=bold>{$environment->vcs->path}</> branch in the <options=bold>{$environment->name}</> environment");
       $this->push($output_callback, $artifact_dir);
       $this->checklist->completePreviousItem();
     }

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -61,7 +61,7 @@ class PushArtifactCommand extends PullCommandBase {
     $this->logger->warning('You must select an environment with a Git branch deployed');
     $environment = $this->determineEnvironment($input, $output, TRUE);
     if (strpos($environment->vcs->path, 'tags') === 0) {
-      throw new AcquiaCliException("Environments with Git tags are not supported. Environment {$environment->name} has {$environment->vcs->path} deployed.");
+      throw new AcquiaCliException("You cannot push to an environment that has a git tag deployed to it. Environment {$environment->name} has {$environment->vcs->path} deployed. Please select a different environment.");
     }
     $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $output_callback = $this->getOutputCallback($output, $this->checklist);

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -103,7 +103,7 @@ class PushArtifactCommand extends PullCommandBase {
 
     if (!$input->getOption('dry-run')) {
       $this->checklist->addItem("Pushing changes to <options=bold>{$environment->vcs->path}</> branch in the <options=bold>{$environment->name}</> environment");
-      $this->push($output_callback, $artifact_dir);
+      $this->push($output_callback, $artifact_dir, $environment->vcs->url);
       $this->checklist->completePreviousItem();
     }
     else {
@@ -258,8 +258,8 @@ class PushArtifactCommand extends PullCommandBase {
    * @param \Closure $output_callback
    * @param string $artifact_dir
    */
-  protected function push(Closure $output_callback, string $artifact_dir):void {
-    $output_callback('out', 'Pushing changes to Acquia Git');
+  protected function push(Closure $output_callback, string $artifact_dir, string $vcs_url):void {
+    $output_callback('out', "Pushing changes to Acquia Git ($vcs_url)");
     $this->localMachineHelper->execute(['git', 'push'], $output_callback, $artifact_dir, $this->output->isVerbose());
   }
 

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -230,7 +230,7 @@ class PushArtifactCommand extends PullCommandBase {
       $sanitizeFinder->append($textFileFinder);
     }
 
-    $output_callback('out', "Removing sanitized files from build");
+    $output_callback('out', "Removing sensitive files from build");
     $this->localMachineHelper->getFilesystem()->remove($sanitizeFinder);
   }
 

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -52,7 +52,8 @@ class PushArtifactCommand extends PullCommandBase {
       ->acceptEnvironmentId()
     ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL
-      . 'To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events');
+      . 'To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events')
+      ->addUsage('--no-sanitize --dry-run # skip sanitization and Git push');
   }
 
   /**

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -74,7 +74,7 @@ class PushArtifactCommand extends PullCommandBase {
     $this->checklist = new Checklist($output);
 
     // @todo handle environments with tags deployed
-    $output->writeln('<info>You must select an environment with a Git branch deployed</info>');
+    $this->io->writeln('<info>You must select an environment with a Git branch deployed</info>');
     $environment = $this->determineEnvironment($input, $output, TRUE);
     if (strpos($environment->vcs->path, 'tags') === 0) {
       throw new AcquiaCliException("You cannot push to an environment that has a git tag deployed to it. Environment {$environment->name} has {$environment->vcs->path} deployed. Please select a different environment.");

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -113,7 +113,7 @@ class PushArtifactCommand extends PullCommandBase {
   }
 
   /**
-   * Prepares a directory to build the artifact.
+   * Prepare a directory to build the artifact.
    *
    * @param \Closure $output_callback
    * @param string $artifact_dir
@@ -145,6 +145,12 @@ class PushArtifactCommand extends PullCommandBase {
     }
   }
 
+  /**
+   * Build the artifact.
+   *
+   * @param \Closure $output_callback
+   * @param string $artifact_dir
+   */
   protected function build(Closure $output_callback, string $artifact_dir): void {
     // @todo generate a deploy identifier
     // @see https://git.drupalcode.org/project/drupal/-/blob/9.1.x/sites/default/default.settings.php#L295
@@ -163,6 +169,12 @@ class PushArtifactCommand extends PullCommandBase {
     $this->localMachineHelper->execute(['composer', 'install', '--no-dev', '--no-interaction', '--optimize-autoloader'], $output_callback, $artifact_dir, $this->output->isVerbose());
   }
 
+  /**
+   * Sanitize the artifact.
+   *
+   * @param \Closure $output_callback
+   * @param string $artifact_dir
+   */
   protected function sanitize(Closure $output_callback, string $artifact_dir):void {
     $output_callback('out', 'Finding Drupal core text files');
     $sanitizeFinder = $this->localMachineHelper->getFinder()
@@ -221,6 +233,13 @@ class PushArtifactCommand extends PullCommandBase {
     $this->localMachineHelper->getFilesystem()->remove($sanitizeFinder);
   }
 
+  /**
+   * Commit the artifact.
+   *
+   * @param \Closure $output_callback
+   * @param string $artifact_dir
+   * @param string $commit_hash
+   */
   protected function commit(Closure $output_callback, string $artifact_dir, string $commit_hash):void {
     $output_callback('out', 'Adding and committing changed files');
     $this->localMachineHelper->execute(['git', 'add', '-A'], $output_callback, $artifact_dir, $this->output->isVerbose());
@@ -232,6 +251,12 @@ class PushArtifactCommand extends PullCommandBase {
     $this->localMachineHelper->execute(['git', 'commit', '-m', "Automated commit by Acquia CLI (source commit: $commit_hash)"], $output_callback, $artifact_dir, $this->output->isVerbose());
   }
 
+  /**
+   * Push the artifact.
+   *
+   * @param \Closure $output_callback
+   * @param string $artifact_dir
+   */
   protected function push(Closure $output_callback, string $artifact_dir):void {
     $output_callback('out', 'Pushing changes to Acquia Git');
     $this->localMachineHelper->execute(['git', 'push'], $output_callback, $artifact_dir, $this->output->isVerbose());

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -113,14 +113,14 @@ class PushArtifactCommand extends PullCommandBase {
     $fs->remove($artifact_dir);
 
     $output_callback('out', "Initializing Git in $artifact_dir");
-    $process = $this->localMachineHelper->executeFromCmd("git clone --depth 1 --branch $vcs_path $vcs_url $artifact_dir", $output_callback, NULL, $this->output->isVerbose());
+    $process = $this->localMachineHelper->execute(['git', 'clone', '--depth', '1', '--branch', $vcs_path, $vcs_url, $artifact_dir], $output_callback, NULL, $this->output->isVerbose());
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Failed to clone repository from the Cloud Platform: {message}', ['message' => $process->getErrorOutput()]);
     }
 
     $output_callback('out', 'Global .gitignore file is temporarily disabled during artifact builds.');
-    $this->localMachineHelper->executeFromCmd('git config --local core.excludesFile false', $output_callback, $artifact_dir, $this->output->isVerbose());
-    $this->localMachineHelper->executeFromCmd('git config --local core.fileMode true', $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->execute(['git', 'config', '--local', 'core.excludesFile', 'false'], $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->execute(['git', 'config', '--local', 'core.fileMode', 'true'], $output_callback, $artifact_dir, $this->output->isVerbose());
 
     // Vendor directories can be "corrupt" (i.e. missing scaffold files due to earlier sanitization) in ways that break composer install.
     $output_callback('out', 'Removing vendor directories');
@@ -144,7 +144,7 @@ class PushArtifactCommand extends PullCommandBase {
     $this->localMachineHelper->getFilesystem()->mirror($this->dir, $artifact_dir, $originFinder, ['override' => TRUE, 'delete' => TRUE], $targetFinder);
 
     $output_callback('out', 'Installing Composer production dependencies');
-    $this->localMachineHelper->executeFromCmd('composer install --no-dev --no-interaction --optimize-autoloader', $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->execute(['composer', 'install', '--no-dev', '--no-interaction', '--optimize-autoloader'], $output_callback, $artifact_dir, $this->output->isVerbose());
   }
 
   protected function sanitize(Closure $output_callback, string $artifact_dir):void {
@@ -207,18 +207,18 @@ class PushArtifactCommand extends PullCommandBase {
 
   protected function commit(Closure $output_callback, string $artifact_dir, string $commit_hash):void {
     $output_callback('out', 'Adding and committing changed files');
-    $this->localMachineHelper->executeFromCmd('git add -A', $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->execute(['git', 'add', '-A'], $output_callback, $artifact_dir, $this->output->isVerbose());
     foreach (self::vendorFiles() as $vendor_directory) {
       // This will fatally error if the directory doesn't exist. Suppress error output.
       $this->logger->debug("Forcibly adding $vendor_directory");
-      $this->localMachineHelper->executeFromCmd('git add -f ' . $vendor_directory, NULL, $artifact_dir, FALSE);
+      $this->localMachineHelper->execute(['git', 'add', '-f', $vendor_directory], NULL, $artifact_dir, FALSE);
     }
-    $this->localMachineHelper->executeFromCmd('git commit -m "Automated commit by Acquia CLI (source commit: ' . $commit_hash . ')"', $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->execute(['git', 'commit', '-m', "Automated commit by Acquia CLI (source commit: ' . $commit_hash . ')"], $output_callback, $artifact_dir, $this->output->isVerbose());
   }
 
   protected function push(Closure $output_callback, string $artifact_dir):void {
     $output_callback('out', 'Pushing changes to Acquia Git');
-    $this->localMachineHelper->executeFromCmd('git push', $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->execute(['git', 'push'], $output_callback, $artifact_dir, $this->output->isVerbose());
   }
 
   private static function vendorFiles(): array {

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -34,9 +34,9 @@ class PushArtifactCommand extends PullCommandBase {
       ->addOption('no-sanitize', NULL, InputOption::VALUE_NONE, 'Do not sanitize the build artifact')
       ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Do not push changes to Acquia Cloud')
       ->acceptEnvironmentId()
-    ->setHelp("This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.\n\n"
-      . "The following vendor files and directories are committed to the build artifact even if they are ignored in the source repository: " . implode(', ', self::vendorFiles()) . "\n\n"
-      . "To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events");
+    ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
+      . 'The following vendor files and directories are committed to the build artifact even if they are ignored in the source repository: ' . implode(', ', self::vendorFiles()) . PHP_EOL . PHP_EOL
+      . 'To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events');
   }
 
   /**

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -90,7 +90,7 @@ class PushArtifactCommand extends PullCommandBase {
       $this->checklist->completePreviousItem();
     }
     else {
-      $this->logger->warning("The <options=bold>--dry-run</> option prevented changes from being pushed to Acquia Cloud. The artifact has been built at $artifact_dir");
+      $this->logger->warning("The <options=bold>--dry-run</> option prevented changes from being pushed to Acquia Cloud. The artifact has been built at <options=bold>$artifact_dir</>");
     }
 
     return 0;

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -61,8 +61,7 @@ class PushCodeCommand extends PullCommandBase {
     $this->logger->warning('You must select an environment with a Git branch deployed');
     $environment = $this->determineEnvironment($input, $output, TRUE);
     if (strpos($environment->vcs->path, 'tags') === 0) {
-      $this->logger->alert("Environments with Git tags are not supported. Environment {$environment->name} has {$environment->vcs->path} deployed.");
-      return 1;
+      throw new AcquiaCliException("Environments with Git tags are not supported. Environment {$environment->name} has {$environment->vcs->path} deployed.");
     }
     $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $output_callback = $this->getOutputCallback($output, $this->checklist);

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -3,9 +3,14 @@
 namespace Acquia\Cli\Command\Push;
 
 use Acquia\Cli\Command\Pull\PullCommandBase;
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\Cli\Output\Checklist;
+use Closure;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+use Webmozart\PathUtil\Path;
 
 /**
  * Class PushCodeCommand.
@@ -22,9 +27,10 @@ class PushCodeCommand extends PullCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
-    $this->setDescription('Push code from your IDE to a Cloud Platform environment')
-      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
+  protected function configure(): void {
+    $this->setDescription('Push local code to a Cloud Platform environment')
+      ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be pushed')
+      ->acceptEnvironmentId();
   }
 
   /**
@@ -34,10 +40,157 @@ class PushCodeCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
-    $output->writeln("Please use <options=bold>git</> to push code changes upstream.");
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    // @todo change deploy strategy depending on whether this is a "source" repo (requiring building) or not
+    // @todo handle if Git user name/email is missing
+    $this->setDirAndRequireProjectCwd($input);
+    $is_dirty = $this->isLocalGitRepoDirty();
+    $commit_hash = $this->getLocalGitCommitHash();
+    if ($is_dirty) {
+      throw new AcquiaCliException('Pushing code was aborted because your local Git repository has uncommitted changes. Please either commit, reset, or stash your changes via git.');
+    }
+    $this->checklist = new Checklist($output);
+
+    // @todo handle environments with tags deployed
+    $environment = $this->determineEnvironment($input, $output, FALSE);
+    $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
+    $output_callback = $this->getOutputCallback($output, $this->checklist);
+
+    $this->checklist->addItem('Preparing artifact directory');
+    $this->prepareDir($output_callback, $artifact_dir, $environment->vcs->url, $environment->vcs->path);
+    $this->checklist->completePreviousItem();
+
+    $this->checklist->addItem('Generating build artifact');
+    $this->build($output_callback, $artifact_dir);
+    $this->checklist->completePreviousItem();
+
+    $this->checklist->addItem('Sanitizing build artifact');
+    $this->sanitize($artifact_dir);
+    $this->checklist->completePreviousItem();
+
+    $this->checklist->addItem("Pushing changes to {$environment->vcs->path} branch in the {$environment->name} environment");
+    $this->push($output_callback, $artifact_dir, $commit_hash);
+    $this->checklist->completePreviousItem();
 
     return 0;
+  }
+
+  /**
+   * Prepares a directory to build the artifact.
+   *
+   * @param \Closure $output_callback
+   * @param string $artifact_dir
+   * @param string $vcs_url
+   * @param string $vcs_path
+   *
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   */
+  protected function prepareDir(Closure $output_callback, string $artifact_dir, string $vcs_url, string $vcs_path): void {
+    $fs = $this->localMachineHelper->getFilesystem();
+
+    $this->logger->info("Removing $artifact_dir if it exists");
+    $fs->remove($artifact_dir);
+
+    $this->logger->info("Initializing Git in $artifact_dir");
+    $process = $this->localMachineHelper->executeFromCmd("git clone --depth 1 --branch $vcs_path $vcs_url $artifact_dir", $output_callback, NULL, $this->output->isVerbose());
+    if (!$process->isSuccessful()) {
+      throw new AcquiaCliException('Failed to clone repository from the Cloud Platform: {message}', ['message' => $process->getErrorOutput()]);
+    }
+
+    $this->logger->info('Global .gitignore file is temporarily disabled during artifact builds.');
+    $this->localMachineHelper->executeFromCmd('git config --local core.excludesFile false', $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->executeFromCmd('git config --local core.fileMode true', $output_callback, $artifact_dir, $this->output->isVerbose());
+  }
+
+  protected function build(Closure $output_callback, string $artifact_dir): void {
+    // @todo generate a deploy identifier
+    // @see https://git.drupalcode.org/project/drupal/-/blob/9.1.x/sites/default/default.settings.php#L295
+
+    // @todo support user-defined scripts such as npm build, or recommend how to run them via Composer
+
+    $this->logger->info("Mirroring source files from {$this->dir} to $artifact_dir");
+    $originFinder = Finder::create();
+    $originFinder->files()->in($this->dir)
+      // Include dot files like .htaccess.
+      ->ignoreDotFiles(FALSE)
+      // Ignore VCS ignored files (e.g. vendor) to speed up the mirror (Composer will restore them later).
+      ->ignoreVCSIgnored(TRUE)
+      // Ignore .gitignore files (everything should be committed to the artifact).
+      ->notName('.gitignore');
+    $targetFinder = Finder::create();
+    $targetFinder->files()->in($artifact_dir)->ignoreDotFiles(FALSE);
+    $this->localMachineHelper->getFilesystem()->mirror($this->dir, $artifact_dir, $originFinder, ['override' => TRUE, 'delete' => TRUE], $targetFinder);
+
+    $this->logger->info('Installing Composer production dependencies');
+    $this->localMachineHelper->executeFromCmd('composer install --no-dev --no-interaction --optimize-autoloader', $output_callback, $artifact_dir, $this->output->isVerbose());
+  }
+
+  protected function sanitize(string $artifact_dir):void {
+    $this->logger->info('Finding Drupal core text files');
+    $sanitizeFinder = Finder::create()
+      ->files()
+      ->name('*.txt')
+      ->notName('LICENSE.txt')
+      ->in("$artifact_dir/docroot/core");
+
+    $this->logger->info('Finding VCS directories');
+    $vcsFinder = Finder::create()
+      ->ignoreDotFiles(FALSE)
+      ->ignoreVCS(FALSE)
+      ->directories()
+      ->in(["$artifact_dir/docroot",
+        "$artifact_dir/vendor",
+      ])
+      ->name('.git');
+    $drush_dir = "$artifact_dir/drush";
+    if (file_exists($drush_dir)) {
+      $vcsFinder->in($drush_dir);
+    }
+    if ($vcsFinder->hasResults()) {
+      $sanitizeFinder->append($vcsFinder);
+    }
+
+    $this->logger->info('Finding INSTALL database text files');
+    $dbInstallFinder = Finder::create()
+      ->files()
+      ->in([$artifact_dir])
+      ->name('/INSTALL\.[a-z]+\.(md|txt)$/');
+    if ($dbInstallFinder->hasResults()) {
+      $sanitizeFinder->append($dbInstallFinder);
+    }
+
+    $this->logger->info('Finding other common text files');
+    $filenames = [
+      'AUTHORS',
+      'CHANGELOG',
+      'CONDUCT',
+      'CONTRIBUTING',
+      'INSTALL',
+      'MAINTAINERS',
+      'PATCHES',
+      'TESTING',
+      'UPDATE',
+    ];
+    $textFileFinder = Finder::create()
+      ->files()
+      ->in(["$artifact_dir/docroot"])
+      ->name('/(' . implode('|', $filenames) . ')\.(md|txt)$/');
+    if ($textFileFinder->hasResults()) {
+      $sanitizeFinder->append($textFileFinder);
+    }
+
+    // @todo support custom sanitization as with BLT?
+    $this->logger->info("Removing sanitized files from build");
+    $this->localMachineHelper->getFilesystem()->remove($sanitizeFinder);
+  }
+
+  protected function push(Closure $output_callback, string $artifact_dir, string $commit_hash):void {
+    $this->logger->info('Adding and committing changed files');
+    $this->localMachineHelper->executeFromCmd('git add -A', $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->executeFromCmd('git commit -m "Automated commit by Acquia CLI (source commit: ' . $commit_hash . ')"', $output_callback, $artifact_dir, $this->output->isVerbose());
+
+    $this->logger->info('Pushing changes to Acquia Git');
+    $this->localMachineHelper->executeFromCmd('git push', $output_callback, $artifact_dir, $this->output->isVerbose());
   }
 
 }

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -177,7 +177,6 @@ class PushCodeCommand extends PullCommandBase {
       $sanitizeFinder->append($textFileFinder);
     }
 
-    // @todo support custom sanitization as with BLT?
     $this->logger->info("Removing sanitized files from build");
     $this->localMachineHelper->getFilesystem()->remove($sanitizeFinder);
   }

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -30,7 +30,8 @@ class PushCodeCommand extends PullCommandBase {
   protected function configure(): void {
     $this->setDescription('Push local code to a Cloud Platform environment')
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be pushed')
-      ->acceptEnvironmentId();
+      ->acceptEnvironmentId()
+    ->setHelp('This command builds a sanitized deploy artifact by running composer install and removing common sensitive files. To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events');
   }
 
   /**
@@ -105,9 +106,6 @@ class PushCodeCommand extends PullCommandBase {
   protected function build(Closure $output_callback, string $artifact_dir): void {
     // @todo generate a deploy identifier
     // @see https://git.drupalcode.org/project/drupal/-/blob/9.1.x/sites/default/default.settings.php#L295
-
-    // @todo support user-defined scripts such as npm build, or recommend how to run them via Composer
-
     $this->logger->info("Mirroring source files from {$this->dir} to $artifact_dir");
     $originFinder = Finder::create();
     $originFinder->files()->in($this->dir)

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -205,7 +205,8 @@ class PushCodeCommand extends PullCommandBase {
       'docroot/modules/contrib',
       'docroot/themes/contrib',
       'docroot/profiles/contrib',
-      'docroot/libraries'
+      'docroot/libraries',
+      'drush/Commands'
     ];
   }
 

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -3,15 +3,9 @@
 namespace Acquia\Cli\Command\Push;
 
 use Acquia\Cli\Command\Pull\PullCommandBase;
-use Acquia\Cli\Exception\AcquiaCliException;
-use Acquia\Cli\Output\Checklist;
-use Closure;
-use Symfony\Component\Console\Input\InputArgument;
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Finder\Finder;
-use Webmozart\PathUtil\Path;
 
 /**
  * Class PushCodeCommand.
@@ -28,15 +22,9 @@ class PushCodeCommand extends PullCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure(): void {
-    $this->setDescription('Push local code to a Cloud Platform environment')
-      ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be pushed')
-      ->addOption('no-sanitize', NULL, InputOption::VALUE_NONE, 'Do not sanitize the build artifact')
-      ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Do not push changes to Acquia Cloud')
-      ->acceptEnvironmentId()
-    ->setHelp("This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.\n\n"
-      . "The following vendor files and directories are committed to the build artifact even if they are ignored in the source repository: " . implode(', ', self::vendorFiles()) . "\n\n"
-      . "To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events");
+  protected function configure() {
+    $this->setDescription('Push code from your IDE to a Cloud Platform environment')
+      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 
   /**
@@ -46,197 +34,10 @@ class PushCodeCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output): int {
-    // @todo change deploy strategy depending on whether this is a "source" repo (requiring building) or not
-    // @todo handle if Git user name/email is missing
-    $this->setDirAndRequireProjectCwd($input);
-    $is_dirty = $this->isLocalGitRepoDirty();
-    $commit_hash = $this->getLocalGitCommitHash();
-    if ($is_dirty) {
-      throw new AcquiaCliException('Pushing code was aborted because your local Git repository has uncommitted changes. Please either commit, reset, or stash your changes via git.');
-    }
-    $this->checklist = new Checklist($output);
-
-    // @todo handle environments with tags deployed
-    $this->logger->warning('You must select an environment with a Git branch deployed');
-    $environment = $this->determineEnvironment($input, $output, TRUE);
-    if (strpos($environment->vcs->path, 'tags') === 0) {
-      throw new AcquiaCliException("Environments with Git tags are not supported. Environment {$environment->name} has {$environment->vcs->path} deployed.");
-    }
-    $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
-    $output_callback = $this->getOutputCallback($output, $this->checklist);
-
-    $this->checklist->addItem('Preparing artifact directory');
-    $this->prepareDir($output_callback, $artifact_dir, $environment->vcs->url, $environment->vcs->path);
-    $this->checklist->completePreviousItem();
-
-    $this->checklist->addItem('Generating build artifact');
-    $this->build($output_callback, $artifact_dir);
-    $this->checklist->completePreviousItem();
-
-    if (!$input->getOption('no-sanitize')) {
-      $this->checklist->addItem('Sanitizing build artifact');
-      $this->sanitize($artifact_dir);
-      $this->checklist->completePreviousItem();
-    }
-
-    $this->checklist->addItem("Committing changes (commit hash: $commit_hash)");
-    $this->commit($output_callback, $artifact_dir, $commit_hash);
-    $this->checklist->completePreviousItem();
-
-    if (!$input->getOption('dry-run')) {
-      $this->checklist->addItem("Pushing changes to {$environment->vcs->path} branch in the {$environment->name} environment");
-      $this->push($output_callback, $artifact_dir);
-      $this->checklist->completePreviousItem();
-    }
-    else {
-      $this->logger->warning("The <options=bold>--dry-run</> option prevented changes from being pushed to Acquia Cloud. The artifact has been built at $artifact_dir");
-    }
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $output->writeln("Please use <options=bold>git</> to push code changes upstream.");
 
     return 0;
-  }
-
-  /**
-   * Prepares a directory to build the artifact.
-   *
-   * @param \Closure $output_callback
-   * @param string $artifact_dir
-   * @param string $vcs_url
-   * @param string $vcs_path
-   *
-   * @throws \Acquia\Cli\Exception\AcquiaCliException
-   */
-  protected function prepareDir(Closure $output_callback, string $artifact_dir, string $vcs_url, string $vcs_path): void {
-    $fs = $this->localMachineHelper->getFilesystem();
-
-    $this->logger->info("Removing $artifact_dir if it exists");
-    $fs->remove($artifact_dir);
-
-    $this->logger->info("Initializing Git in $artifact_dir");
-    $process = $this->localMachineHelper->executeFromCmd("git clone --depth 1 --branch $vcs_path $vcs_url $artifact_dir", $output_callback, NULL, $this->output->isVerbose());
-    if (!$process->isSuccessful()) {
-      throw new AcquiaCliException('Failed to clone repository from the Cloud Platform: {message}', ['message' => $process->getErrorOutput()]);
-    }
-
-    $this->logger->info('Global .gitignore file is temporarily disabled during artifact builds.');
-    $this->localMachineHelper->executeFromCmd('git config --local core.excludesFile false', $output_callback, $artifact_dir, $this->output->isVerbose());
-    $this->localMachineHelper->executeFromCmd('git config --local core.fileMode true', $output_callback, $artifact_dir, $this->output->isVerbose());
-
-    // Vendor directories can be "corrupt" (i.e. missing scaffold files due to earlier sanitization) in ways that break composer install.
-    $this->logger->info('Removing vendor directories');
-    foreach (self::vendorFiles() as $vendor_directory) {
-      $fs->remove(Path::join($artifact_dir, $vendor_directory));
-    }
-  }
-
-  protected function build(Closure $output_callback, string $artifact_dir): void {
-    // @todo generate a deploy identifier
-    // @see https://git.drupalcode.org/project/drupal/-/blob/9.1.x/sites/default/default.settings.php#L295
-    $this->logger->info("Mirroring source files from {$this->dir} to $artifact_dir");
-    $originFinder = Finder::create();
-    $originFinder->files()->in($this->dir)
-      // Include dot files like .htaccess.
-      ->ignoreDotFiles(FALSE)
-      // Ignore VCS ignored files (e.g. vendor) to speed up the mirror (Composer will restore them later).
-      ->ignoreVCSIgnored(TRUE);
-    $targetFinder = Finder::create();
-    $targetFinder->files()->in($artifact_dir)->ignoreDotFiles(FALSE);
-    $this->localMachineHelper->getFilesystem()->mirror($this->dir, $artifact_dir, $originFinder, ['override' => TRUE, 'delete' => TRUE], $targetFinder);
-
-    $this->logger->info('Installing Composer production dependencies');
-    $this->localMachineHelper->executeFromCmd('composer install --no-dev --no-interaction --optimize-autoloader', $output_callback, $artifact_dir, $this->output->isVerbose());
-  }
-
-  protected function sanitize(string $artifact_dir):void {
-    $this->logger->info('Finding Drupal core text files');
-    $sanitizeFinder = Finder::create()
-      ->files()
-      ->name('*.txt')
-      ->notName('LICENSE.txt')
-      ->in("$artifact_dir/docroot/core");
-
-    $this->logger->info('Finding VCS directories');
-    $vcsFinder = Finder::create()
-      ->ignoreDotFiles(FALSE)
-      ->ignoreVCS(FALSE)
-      ->directories()
-      ->in(["$artifact_dir/docroot",
-        "$artifact_dir/vendor",
-      ])
-      ->name('.git');
-    $drush_dir = "$artifact_dir/drush";
-    if (file_exists($drush_dir)) {
-      $vcsFinder->in($drush_dir);
-    }
-    if ($vcsFinder->hasResults()) {
-      $sanitizeFinder->append($vcsFinder);
-    }
-
-    $this->logger->info('Finding INSTALL database text files');
-    $dbInstallFinder = Finder::create()
-      ->files()
-      ->in([$artifact_dir])
-      ->name('/INSTALL\.[a-z]+\.(md|txt)$/');
-    if ($dbInstallFinder->hasResults()) {
-      $sanitizeFinder->append($dbInstallFinder);
-    }
-
-    $this->logger->info('Finding other common text files');
-    $filenames = [
-      'AUTHORS',
-      'CHANGELOG',
-      'CONDUCT',
-      'CONTRIBUTING',
-      'INSTALL',
-      'MAINTAINERS',
-      'PATCHES',
-      'TESTING',
-      'UPDATE',
-    ];
-    $textFileFinder = Finder::create()
-      ->files()
-      ->in(["$artifact_dir/docroot"])
-      ->name('/(' . implode('|', $filenames) . ')\.(md|txt)$/');
-    if ($textFileFinder->hasResults()) {
-      $sanitizeFinder->append($textFileFinder);
-    }
-
-    $this->logger->info("Removing sanitized files from build");
-    $this->localMachineHelper->getFilesystem()->remove($sanitizeFinder);
-  }
-
-  protected function commit(Closure $output_callback, string $artifact_dir, string $commit_hash):void {
-    $this->logger->info('Adding and committing changed files');
-    $this->localMachineHelper->executeFromCmd('git add -A', $output_callback, $artifact_dir, $this->output->isVerbose());
-    foreach (self::vendorFiles() as $vendor_directory) {
-      // This will fatally error if the directory doesn't exist. Suppress error output.
-      $this->logger->debug("Forcibly adding $vendor_directory");
-      $this->localMachineHelper->executeFromCmd('git add -f ' . $vendor_directory, NULL, $artifact_dir, FALSE);
-    }
-    $this->localMachineHelper->executeFromCmd('git commit -m "Automated commit by Acquia CLI (source commit: ' . $commit_hash . ')"', $output_callback, $artifact_dir, $this->output->isVerbose());
-  }
-
-  protected function push(Closure $output_callback, string $artifact_dir):void {
-    $this->logger->info('Pushing changes to Acquia Git');
-    $this->localMachineHelper->executeFromCmd('git push', $output_callback, $artifact_dir, $this->output->isVerbose());
-  }
-
-  private static function vendorFiles(): array {
-    return [
-      'vendor',
-      'docroot/core',
-      'docroot/modules/contrib',
-      'docroot/themes/contrib',
-      'docroot/profiles/contrib',
-      'docroot/libraries',
-      'drush/Commands',
-      'docroot/index.php',
-      'docroot/.htaccess',
-      'docroot/autoload.php',
-      'docroot/robots.txt',
-      'docroot/update.php',
-      'docroot/web.config'
-    ];
   }
 
 }

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -112,9 +112,7 @@ class PushCodeCommand extends PullCommandBase {
       // Include dot files like .htaccess.
       ->ignoreDotFiles(FALSE)
       // Ignore VCS ignored files (e.g. vendor) to speed up the mirror (Composer will restore them later).
-      ->ignoreVCSIgnored(TRUE)
-      // Ignore .gitignore files (everything should be committed to the artifact).
-      ->notName('.gitignore');
+      ->ignoreVCSIgnored(TRUE);
     $targetFinder = Finder::create();
     $targetFinder->files()->in($artifact_dir)->ignoreDotFiles(FALSE);
     $this->localMachineHelper->getFilesystem()->mirror($this->dir, $artifact_dir, $originFinder, ['override' => TRUE, 'delete' => TRUE], $targetFinder);
@@ -183,7 +181,16 @@ class PushCodeCommand extends PullCommandBase {
 
   protected function push(Closure $output_callback, string $artifact_dir, string $commit_hash):void {
     $this->logger->info('Adding and committing changed files');
+    $force_add = [
+      'vendor',
+      'docroot/core',
+      'docroot/modules/contrib',
+      'docroot/themes/contrib',
+      'docroot/profiles/contrib',
+      'docroot/libraries'
+    ];
     $this->localMachineHelper->executeFromCmd('git add -A', $output_callback, $artifact_dir, $this->output->isVerbose());
+    $this->localMachineHelper->executeFromCmd('git add -f ' . implode(' ', $force_add), $output_callback, $artifact_dir, $this->output->isVerbose());
     $this->localMachineHelper->executeFromCmd('git commit -m "Automated commit by Acquia CLI (source commit: ' . $commit_hash . ')"', $output_callback, $artifact_dir, $this->output->isVerbose());
 
     $this->logger->info('Pushing changes to Acquia Git');

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -58,7 +58,12 @@ class PushCodeCommand extends PullCommandBase {
     $this->checklist = new Checklist($output);
 
     // @todo handle environments with tags deployed
-    $environment = $this->determineEnvironment($input, $output, FALSE);
+    $this->logger->warning('You must select an environment with a Git branch deployed');
+    $environment = $this->determineEnvironment($input, $output, TRUE);
+    if (strpos($environment->vcs->path, 'tags') === 0) {
+      $this->logger->alert("Environments with Git tags are not supported. Environment {$environment->name} has {$environment->vcs->path} deployed.");
+      return 1;
+    }
     $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $output_callback = $this->getOutputCallback($output, $this->checklist);
 

--- a/symfony-fs-mirror.patch
+++ b/symfony-fs-mirror.patch
@@ -1,0 +1,52 @@
+diff --git a/src/Symfony/Component/Filesystem/Filesystem.php b/src/Symfony/Component/Filesystem/Filesystem.php
+index 3498e7f9fb..4d68341136 100644
+--- a/src/Symfony/Component/Filesystem/Filesystem.php
++++ b/src/Symfony/Component/Filesystem/Filesystem.php
+@@ -497,16 +497,17 @@ class Filesystem
+      *  - existing files in the target directory will be overwritten, except if they are newer (see the `override` option)
+      *  - files in the target directory that do not exist in the source directory will not be deleted (see the `delete` option)
+      *
+-     * @param \Traversable|null $iterator Iterator that filters which files and directories to copy, if null a recursive iterator is created
++     * @param \Traversable|null $originIterator Iterator that filters which files and directories to copy, if null a recursive iterator is created
+      * @param array             $options  An array of boolean options
+      *                                    Valid options are:
+      *                                    - $options['override'] If true, target files newer than origin files are overwritten (see copy(), defaults to false)
+      *                                    - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink(), defaults to false)
+      *                                    - $options['delete'] Whether to delete files that are not in the source directory (defaults to false)
++     * @param \Traversable|null $targetIterator Iterator that filters which files and directory in target directory to delete if not in source directory (if $options['delete'] is true)
+      *
+      * @throws IOException When file type is unknown
+      */
+-    public function mirror(string $originDir, string $targetDir, \Traversable $iterator = null, array $options = [])
++    public function mirror(string $originDir, string $targetDir, \Traversable $originIterator = null, array $options = [], \Traversable $targetIterator = null)
+     {
+         $targetDir = rtrim($targetDir, '/\\');
+         $originDir = rtrim($originDir, '/\\');
+@@ -518,7 +519,7 @@ class Filesystem
+ 
+         // Iterate in destination folder to remove obsolete entries
+         if ($this->exists($targetDir) && isset($options['delete']) && $options['delete']) {
+-            $deleteIterator = $iterator;
++            $deleteIterator = $targetIterator;
+             if (null === $deleteIterator) {
+                 $flags = \FilesystemIterator::SKIP_DOTS;
+                 $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);
+@@ -534,15 +535,15 @@ class Filesystem
+ 
+         $copyOnWindows = $options['copy_on_windows'] ?? false;
+ 
+-        if (null === $iterator) {
++        if (null === $originIterator) {
+             $flags = $copyOnWindows ? \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS : \FilesystemIterator::SKIP_DOTS;
+-            $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($originDir, $flags), \RecursiveIteratorIterator::SELF_FIRST);
++            $originIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($originDir, $flags), \RecursiveIteratorIterator::SELF_FIRST);
+         }
+ 
+         $this->mkdir($targetDir);
+         $filesCreatedWhileMirroring = [];
+ 
+-        foreach ($iterator as $file) {
++        foreach ($originIterator as $file) {
+             if ($file->getPathname() === $targetDir || $file->getRealPath() === $targetDir || isset($filesCreatedWhileMirroring[$file->getRealPath()])) {
+                 continue;
+             }

--- a/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
@@ -313,26 +313,6 @@ class PullCodeCommandTest extends PullCommandTestBase {
   }
 
   /**
-   * @param $failed
-   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
-   * @param $cwd
-   */
-  protected function mockExecuteGitStatus(
-    $failed,
-    ObjectProphecy $local_machine_helper,
-    $cwd
-  ): void {
-    $process = $this->prophet->prophesize(Process::class);
-    $process->isSuccessful()->willReturn(!$failed)->shouldBeCalled();
-    $process->getOutput()->willReturn('')->shouldBeCalled();
-    $local_machine_helper->execute([
-      'git',
-      'status',
-      '--short',
-    ], NULL, $cwd, FALSE)->willReturn($process->reveal())->shouldBeCalled();
-  }
-
-  /**
    * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
    * @param $vcs_path
    * @param $cwd
@@ -346,19 +326,6 @@ class PullCodeCommandTest extends PullCommandTestBase {
     ], Argument::type('callable'), $cwd, FALSE)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
-  }
-
-  /**
-   * @return \Prophecy\Prophecy\ObjectProphecy
-   */
-  protected function mockFinder(): ObjectProphecy {
-    $finder = $this->prophet->prophesize(Finder::class);
-    $finder->files()->willReturn($finder);
-    $finder->in(Argument::type('string'))->willReturn($finder);
-    $finder->ignoreDotFiles(FALSE)->willReturn($finder);
-    $finder->hasResults()->willReturn($finder);
-
-    return $finder;
   }
 
 }

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -173,4 +173,56 @@ abstract class PullCommandTestBase extends CommandTestBase {
       ]);
   }
 
+  /**
+   * @param $failed
+   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
+   * @param $cwd
+   */
+  protected function mockExecuteGitStatus(
+    $failed,
+    ObjectProphecy $local_machine_helper,
+    $cwd
+  ): void {
+    $process = $this->prophet->prophesize(Process::class);
+    $process->isSuccessful()->willReturn(!$failed)->shouldBeCalled();
+    $process->getOutput()->willReturn('')->shouldBeCalled();
+    $local_machine_helper->execute([
+      'git',
+      'status',
+      '--short',
+    ], NULL, $cwd, FALSE)->willReturn($process->reveal())->shouldBeCalled();
+  }
+
+  /**
+   * @param $failed
+   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
+   * @param $cwd
+   */
+  protected function mockGetLocalCommitHash(
+    ObjectProphecy $local_machine_helper,
+    $cwd
+  ): void {
+    $process = $this->prophet->prophesize(Process::class);
+    $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
+    $process->getOutput()->willReturn('abc123')->shouldBeCalled();
+    $local_machine_helper->execute([
+      'git',
+      'rev-parse',
+      'HEAD',
+    ], NULL, $cwd, FALSE)->willReturn($process->reveal())->shouldBeCalled();
+  }
+
+  /**
+   * @return \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected function mockFinder(): ObjectProphecy {
+    $finder = $this->prophet->prophesize(Finder::class);
+    $finder->files()->willReturn($finder);
+    $finder->in(Argument::type('string'))->willReturn($finder);
+    $finder->ignoreDotFiles(FALSE)->willReturn($finder);
+    $finder->hasResults()->willReturn($finder);
+
+    return $finder;
+  }
+
 }

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -200,11 +200,12 @@ abstract class PullCommandTestBase extends CommandTestBase {
    */
   protected function mockGetLocalCommitHash(
     ObjectProphecy $local_machine_helper,
-    $cwd
+    $cwd,
+    $commit_hash
   ): void {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
-    $process->getOutput()->willReturn('abc123')->shouldBeCalled();
+    $process->getOutput()->willReturn($commit_hash)->shouldBeCalled();
     $local_machine_helper->execute([
       'git',
       'rev-parse',
@@ -219,8 +220,15 @@ abstract class PullCommandTestBase extends CommandTestBase {
     $finder = $this->prophet->prophesize(Finder::class);
     $finder->files()->willReturn($finder);
     $finder->in(Argument::type('string'))->willReturn($finder);
+    $finder->in(Argument::type('array'))->willReturn($finder);
     $finder->ignoreDotFiles(FALSE)->willReturn($finder);
+    $finder->ignoreVCS(FALSE)->willReturn($finder);
+    $finder->ignoreVCSIgnored(TRUE)->willReturn($finder);
     $finder->hasResults()->willReturn($finder);
+    $finder->name(Argument::type('string'))->willReturn($finder);
+    $finder->notName(Argument::type('string'))->willReturn($finder);
+    $finder->directories()->willReturn($finder);
+    $finder->append(Argument::type(Finder::class))->willReturn($finder);
 
     return $finder;
   }

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -89,7 +89,6 @@ class PushArtifactCommandTest extends PullCommandTestBase {
    */
   protected function mockLocalGitConfig(ObjectProphecy $local_machine_helper, $artifact_dir): void {
     $process = $this->prophet->prophesize(Process::class);
-    $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
     $local_machine_helper->execute(['git', 'config', '--local', 'core.excludesFile', 'false'], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
     $local_machine_helper->execute(['git', 'config', '--local', 'core.fileMode', 'true'], Argument::type('callable'), $artifact_dir, TRUE)
@@ -102,7 +101,6 @@ class PushArtifactCommandTest extends PullCommandTestBase {
    */
   protected function mockComposerInstall(ObjectProphecy $local_machine_helper, $artifact_dir): void {
     $process = $this->prophet->prophesize(Process::class);
-    $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
     $local_machine_helper->execute(['composer', 'install', '--no-dev', '--no-interaction', '--optimize-autoloader'], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
@@ -113,7 +111,6 @@ class PushArtifactCommandTest extends PullCommandTestBase {
    */
   protected function mockGitAddCommitPush(ObjectProphecy $local_machine_helper, $artifact_dir, $commit_hash): void {
     $process = $this->prophet->prophesize(Process::class);
-    $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
     $local_machine_helper->execute(['git', 'add', '-A'], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
     $local_machine_helper->execute(['git', 'add', '-f', 'docroot/core/index.php'], NULL, $artifact_dir, FALSE)

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Acquia\Cli\Tests\Commands\Push;
+
+use Acquia\Cli\Command\Push\PushArtifactCommand;
+use Acquia\Cli\Tests\Commands\Pull\PullCommandTestBase;
+use Acquia\Cli\Tests\CommandTestBase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Process\Process;
+use Webmozart\PathUtil\Path;
+
+/**
+ * Class PushCodeCommandTest.
+ *
+ * @property \Acquia\Cli\Command\Push\PushCodeCommand $command
+ */
+class PushArtifactCommandTest extends PullCommandTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function createCommand(): Command {
+    return $this->injectCommand(PushArtifactCommand::class);
+  }
+
+  public function testPushArtifact(): void {
+    $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
+    $applications_response = $this->mockApplicationsRequest();
+    $this->mockApplicationRequest();
+    $environments_response = $this->mockEnvironmentsRequest($applications_response);
+    $this->createMockGitConfigFile();
+
+    $local_machine_helper = $this->mockLocalMachineHelper();
+    $finder = $this->mockFinder();
+    $local_machine_helper->getFinder()->willReturn($finder->reveal());
+    $this->mockGetFilesystem($local_machine_helper);
+    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $this->command->vendorDirs = ['vendor'];
+
+    $this->mockExecuteGitStatus(FALSE, $local_machine_helper, $this->projectFixtureDir);
+    $this->mockGetLocalCommitHash($local_machine_helper, $this->projectFixtureDir);
+    $this->mockCloneShallow($local_machine_helper, $environments_response->vcs->path, $environments_response->vcs->url, $artifact_dir);
+    $this->mockLocalGitConfig($local_machine_helper, $artifact_dir);
+    $this->mockComposerInstall($local_machine_helper, $artifact_dir);
+
+    $inputs = [
+      // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
+      'n',
+      // Please select a Cloud Platform application:
+      0,
+      // Would you like to link the project at ... ?
+      'n',
+      // Please choose an Acquia environment:
+      0,
+    ];
+    $this->executeCommand([], $inputs);
+    $this->prophet->checkPredictions();
+    $output = $this->getDisplay();
+
+    $this->assertStringContainsString('Please select a Cloud Platform application:', $output);
+    $this->assertStringContainsString('[0] Sample application 1', $output);
+    $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
+    $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
+  }
+
+  /**
+   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
+   * @param $cwd
+   * @param $vcs_path
+   * @param $vcs_url
+   * @param $artifact_dir
+   */
+  protected function mockCloneShallow(ObjectProphecy $local_machine_helper, $vcs_path, $vcs_url, $artifact_dir): void {
+    $process = $this->prophet->prophesize(Process::class);
+    $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
+    $local_machine_helper->execute(['git', 'clone', '--depth', '1', '--branch', $vcs_path, $vcs_url, $artifact_dir], Argument::type('callable'), NULL, TRUE)
+      ->willReturn($process->reveal())->shouldBeCalled();
+  }
+
+  /**
+   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
+   * @param $artifact_dir
+   */
+  protected function mockLocalGitConfig(ObjectProphecy $local_machine_helper, $artifact_dir): void {
+    $process = $this->prophet->prophesize(Process::class);
+    $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
+    $local_machine_helper->execute(['git', 'config', '--local', 'core.excludesFile', 'false'], Argument::type('callable'), $artifact_dir, TRUE)
+      ->willReturn($process->reveal())->shouldBeCalled();
+    $local_machine_helper->execute(['git', 'config', '--local', 'core.fileMode', 'true'], Argument::type('callable'), $artifact_dir, TRUE)
+      ->willReturn($process->reveal())->shouldBeCalled();
+  }
+
+  /**
+   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
+   * @param $artifact_dir
+   */
+  protected function mockComposerInstall(ObjectProphecy $local_machine_helper, $artifact_dir): void {
+    $process = $this->prophet->prophesize(Process::class);
+    $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
+    $local_machine_helper->execute(['composer', 'install', '--no-dev', '--no-interaction', '--optimize-autoloader'], Argument::type('callable'), $artifact_dir, TRUE)
+      ->willReturn($process->reveal())->shouldBeCalled();
+  }
+
+  /**
+   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
+   * @param $artifact_dir
+   */
+  protected function mockGitAddCommitPush(ObjectProphecy $local_machine_helper, $artifact_dir): void {
+    $process = $this->prophet->prophesize(Process::class);
+    $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
+    $local_machine_helper->execute(['git', 'add', '-A'], Argument::type('callable'), $artifact_dir, TRUE)
+      ->willReturn($process->reveal())->shouldBeCalled();
+    $local_machine_helper->execute(['git', 'add', '-f'], NULL, $artifact_dir, TRUE)
+      ->willReturn($process->reveal())->shouldBeCalled();
+    $local_machine_helper->execute(['git', 'commit', '-m', 'Automated commit by Acquia CLI (source commit: abc123)'], Argument::type('callable'), $artifact_dir, TRUE)
+      ->willReturn($process->reveal())->shouldBeCalled();
+    $local_machine_helper->execute(['git', 'push'], Argument::type('callable'), $artifact_dir, TRUE)
+      ->willReturn($process->reveal())->shouldBeCalled();
+  }
+
+}

--- a/tests/phpunit/src/Commands/Push/PushCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushCodeCommandTest.php
@@ -2,29 +2,14 @@
 
 namespace Acquia\Cli\Tests\Commands\Push;
 
-use Acquia\Cli\Command\Ide\IdePhpVersionCommand;
-use Acquia\Cli\Command\Pull\PullCodeCommand;
-use Acquia\Cli\Command\Pull\PullCommand;
-use Acquia\Cli\Command\Pull\PullDatabaseCommand;
-use Acquia\Cli\Command\Pull\PullFilesCommand;
-use Acquia\Cli\Command\Push\PushArtifactCommand;
-use Acquia\Cli\Command\Push\PushFilesCommand;
-use Acquia\Cli\Exception\AcquiaCliException;
-use Acquia\Cli\Helpers\SshHelper;
-use Acquia\Cli\Tests\Commands\Ide\IdeRequiredTestBase;
+use Acquia\Cli\Command\Push\PushCodeCommand;
 use Acquia\Cli\Tests\CommandTestBase;
-use AcquiaCloudApi\Response\EnvironmentResponse;
-use Prophecy\Argument;
-use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Process\Process;
-use Webmozart\PathUtil\Path;
 
 /**
  * Class PushCodeCommandTest.
  *
- * @property \Acquia\Cli\Command\Push\PushArtifactCommand $command
+ * @property \Acquia\Cli\Command\Push\PushCodeCommand $command
  * @package Acquia\Cli\Tests\Commands\Push
  */
 class PushCodeCommandTest extends CommandTestBase {
@@ -33,7 +18,7 @@ class PushCodeCommandTest extends CommandTestBase {
    * {@inheritdoc}
    */
   protected function createCommand(): Command {
-    return $this->injectCommand(PushArtifactCommand::class);
+    return $this->injectCommand(PushCodeCommand::class);
   }
 
   public function testPushCode(): void {

--- a/tests/phpunit/src/Commands/Push/PushCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushCodeCommandTest.php
@@ -7,7 +7,7 @@ use Acquia\Cli\Command\Pull\PullCodeCommand;
 use Acquia\Cli\Command\Pull\PullCommand;
 use Acquia\Cli\Command\Pull\PullDatabaseCommand;
 use Acquia\Cli\Command\Pull\PullFilesCommand;
-use Acquia\Cli\Command\Push\PushCodeCommand;
+use Acquia\Cli\Command\Push\PushArtifactCommand;
 use Acquia\Cli\Command\Push\PushFilesCommand;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\SshHelper;
@@ -24,7 +24,7 @@ use Webmozart\PathUtil\Path;
 /**
  * Class PushCodeCommandTest.
  *
- * @property \Acquia\Cli\Command\Push\PushCodeCommand $command
+ * @property \Acquia\Cli\Command\Push\PushArtifactCommand $command
  * @package Acquia\Cli\Tests\Commands\Push
  */
 class PushCodeCommandTest extends CommandTestBase {
@@ -33,7 +33,7 @@ class PushCodeCommandTest extends CommandTestBase {
    * {@inheritdoc}
    */
   protected function createCommand(): Command {
-    return $this->injectCommand(PushCodeCommand::class);
+    return $this->injectCommand(PushArtifactCommand::class);
   }
 
   public function testPushCode(): void {


### PR DESCRIPTION
**Motivation**
Currently, ACLI supports pulling code but not pushing it. Additionally, it has no awareness of the distinction between "source" and "build" repositories. Best practice for Drupal 8+ using Composer is to keep a "source" repo (without dependencies committed, i.e. Github) and an "artifact" repo (with dependencies committed, i.e. Acquia Git). The only way to support this workflow today is with `blt deploy`, which is overly complicated for most users.

**Proposed changes**
Replicate the `blt deploy` command in ACLI, but in a much more streamlined form that's more tightly coupled with Acquia environments, so it's a true deployment manager (not just an artifact builder): allow users to select a specific environment to push to (as long as that environment has a branch checked out).

**Alternatives considered**
Creating a standalone CLI tool to manage deployments so that Acquia CLI remains decoupled from the guts of a Drupal codebase. But this would involve duplicating so much of Acquia CLI, I think it belongs here.

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Clone a Drupal project where vendor dependencies have _not_ been committed. Or create a new project using `composer create-project acquia/drupal-recommended-project`, which should ignore vendor dependencies.
4. Run `acli push:code` and verify that usable code (with production dependencies committed) is deployed to your Acquia environment.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
