### PR TITLE
Fix #495: [windows] No browser found

### DIFF
--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -36,6 +36,11 @@ class LocalMachineHelper {
   }
 
   /**
+   * Check if a command exists.
+   *
+   * This won't find aliases or shell built-ins, so use it mindfully (e.g. only
+   * for commands that you _know_ to be system commands).
+   *
    * @param $command
    *
    * @return bool
@@ -366,18 +371,20 @@ class LocalMachineHelper {
     if ($browser === NULL) {
       // See if we can find an OS helper to open URLs in default browser.
       if ($this->commandExists('xdg-open')) {
+        // Linux.
         $browser = 'xdg-open';
       }
       else {
         if ($this->commandExists('open')) {
+          // Darwin.
           $browser = 'open';
         }
         else {
-          if ($this->commandExists('start')) {
+          if (OsInfo::isWindows()) {
             $browser = 'start';
           }
           else {
-            $this->logger->warning('Could not find a browser on your local machine.');
+            $this->logger->warning('Could not find a browser on your local machine. Check that one of <options=bold>xdg-open</>, <options=bold>open</>, or <options=bold>start</> are installed.');
             return FALSE;
           }
         }

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -392,8 +392,7 @@ class LocalMachineHelper {
     }
     if ($browser) {
       $this->logger->info('Opening browser !browser at !uri', ['!browser' => $browser, '!uri' => $uri]);
-      $process = new Process([$browser, $uri]);
-      $process->run();
+      $this->executeFromCmd("$browser $uri");
 
       return TRUE;
     }


### PR DESCRIPTION
**Motivation**
Fixes #495

**Proposed changes**
On Windows, assume `start` exists instead of checking for it (AFAICT, it _always_ exists as a built-in in common shells, and there's not a consistent way of finding commands across shells on Windows).

Also improve error output to guide people towards self-solving the issue.

**Alternatives considered**
Fix `commandExists` to properly find commands on Windows. Good luck with that one, I couldn't untangle how to check that `start` exists, and any solution would probably be shell-specific.

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `auth:login` on Windows and check that it opens a browser window when prompted.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
