### PR TITLE
Upload acli.phar on every commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
         # Warm the symfony cache so it gets bundled with phar.
         - ./bin/acli
       script: composer box-compile
-      after_script: curl --upload-file build/acli.phar https://transfer.sh/acli.phar
+      after_script: echo "$(curl --upload-file build/acli.phar https://transfer.sh/acli.phar)"
       deploy:
         provider: releases
         api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
         # Warm the symfony cache so it gets bundled with phar.
         - ./bin/acli
       script: composer box-compile
+      after_script: curl --upload-file build/acli.phar https://transfer.sh/acli.phar
       deploy:
         provider: releases
         api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
         # Warm the symfony cache so it gets bundled with phar.
         - ./bin/acli
       script: composer box-compile
-      after_script: echo "$(curl --upload-file build/acli.phar https://transfer.sh/acli.phar)"
+      after_script: echo "$(curl -s --upload-file build/acli.phar https://transfer.sh/acli.phar)"
       deploy:
         provider: releases
         api_key:


### PR DESCRIPTION
**Motivation**
We regularly need to enlist the help of people less familiar with the ACLI codebase to test PRs or HEAD. We can facilitate this by providing a pre-built Phar for any commit (rather than forcing people to build from source).

**Proposed changes**
For any commit that runs on Travis CI (master or PRs), upload a phar to transfer.sh. We can grab a link to this phar from the Travis CI logs and distribute to anyone for testing. The link is good for 14 days.

**Testing steps**
1. Check the Travis CI logs on this PR and ensure you can download the ACLI dev build (I'll add a link here):
- https://travis-ci.com/github/acquia/cli/jobs/497913802#L502 (click to expand)
- https://transfer.sh/4wc5M/acli.phar

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
