### PR TITLE
Fix #509: [push/pull] cannot select environment

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -497,6 +497,8 @@ abstract class PullCommandBase extends CommandBase {
     foreach ($application_environments as $key => $environment) {
       if (!$allow_production && $environment->flags->production) {
         unset($application_environments[$key]);
+        // Re-index array so keys match those in $choices.
+        $application_environments = array_values($application_environments);
         continue;
       }
       $choices[] = "{$environment->label}, {$environment->name} (vcs: {$environment->vcs->path})";


### PR DESCRIPTION
**Motivation**
Fixes #509

**Proposed changes**
Re-index the environments array after unsetting the prod environment, in case it's ordered like:
- dev
- prod
- stage

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli push:files` on an environment previously affected by this issue, and select the non-default environment.

Unfortunately this isn't easy to write an automated test for, because we don't mock a multi-environment response _anywhere_ in our test suite (due to a CXAPI bug). I opened an internal ticket to fix this.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
