### PR TITLE
Fix #483: [pull/push] add site argument

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -446,6 +446,21 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   /**
+   * Add site argument.
+   *
+   * Only call this after acceptEnvironmentId() to keep arguments in the expected order.
+   *
+   * @return $this
+   */
+  protected function acceptSite() {
+    // Do not set a default site in order to force a user prompt.
+    $this->addArgument('site', InputArgument::OPTIONAL, 'For a multisite application, the directory name of the site')
+      ->addUsage(self::getDefaultName() . ' myapp.dev default');
+
+    return $this;
+  }
+
+  /**
    * Indicates whether the command requires the machine to be authenticated with the Cloud Platform.
    *
    * @param $input

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -427,7 +427,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * Add argument and usage examples for applicationUuid.
    */
   protected function acceptApplicationUuid() {
-    $this->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The Cloud Platform application UUID or alias.')
+    $this->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The Cloud Platform application UUID or alias')
     ->addUsage(self::getDefaultName() . ' [<applicationAlias>]')
     ->addUsage(self::getDefaultName() . ' myapp')
     ->addUsage(self::getDefaultName() . ' abcd1234-1111-2222-3333-0e02b2c3d470');
@@ -437,7 +437,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * Add argument and usage examples for environmentId.
    */
   protected function acceptEnvironmentId() {
-    $this->addArgument('environmentId', InputArgument::OPTIONAL, 'The Cloud Platform environment ID or alias.')
+    $this->addArgument('environmentId', InputArgument::OPTIONAL, 'The Cloud Platform environment ID or alias')
     ->addUsage(self::getDefaultName() . ' [<environmentAlias>]')
     ->addUsage(self::getDefaultName() . ' myapp.dev')
     ->addUsage(self::getDefaultName() . ' 12345-abcd1234-1111-2222-3333-0e02b2c3d470');

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -23,6 +23,7 @@ class PullCommand extends PullCommandBase {
     $this->setAliases(['refresh', 'pull'])
       ->setDescription('Copy code, database, and files from a Cloud Platform environment')
       ->acceptEnvironmentId()
+      ->acceptSite()
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
       ->addOption('no-code', NULL, InputOption::VALUE_NONE, 'Do not refresh code from remote repository')
       ->addOption('no-files', NULL, InputOption::VALUE_NONE, 'Do not refresh files')

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -108,7 +108,7 @@ abstract class PullCommandBase extends CommandBase {
    * @throws \Exception
    */
   protected function pullDatabase(InputInterface $input, OutputInterface $output): void {
-    //$this->connectToLocalDatabase($this->getLocalDbHost(), $this->getLocalDbUser(), $this->getLocalDbName(), $this->getLocalDbPassword(), $this->getOutputCallback($output, $this->checklist));
+    $this->connectToLocalDatabase($this->getLocalDbHost(), $this->getLocalDbUser(), $this->getLocalDbName(), $this->getLocalDbPassword(), $this->getOutputCallback($output, $this->checklist));
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $source_environment = $this->determineEnvironment($input, $output, TRUE);
     $database = $this->determineCloudDatabase($acquia_cloud_client, $source_environment, $input->getArgument('site'));

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -23,6 +23,7 @@ class PullDatabaseCommand extends PullCommandBase {
       ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. If no backup exists, one will be created.')
       ->setAliases(['pull:db'])
       ->acceptEnvironmentId()
+      ->acceptSite()
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,
         'Do not run any additional scripts after the database is pulled. E.g., drush cache-rebuild, drush sql-sanitize, etc.')
       ->addOption('on-demand', 'od', InputOption::VALUE_NONE,

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -21,6 +21,7 @@ class PullFilesCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Copy files from a Cloud Platform environment')
       ->acceptEnvironmentId()
+      ->acceptSite()
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -30,6 +30,7 @@ class PushDatabaseCommand extends PullCommandBase {
     $this->setDescription('Push a database from your IDE to a Cloud Platform environment')
       ->setAliases(['push:db'])
       ->acceptEnvironmentId()
+      ->acceptSite()
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 
@@ -43,7 +44,7 @@ class PushDatabaseCommand extends PullCommandBase {
   protected function execute(InputInterface $input, OutputInterface $output) {
     $destination_environment = $this->determineEnvironment($input, $output, FALSE);
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $database = $this->determineCloudDatabase($acquia_cloud_client, $destination_environment);
+    $database = $this->determineCloudDatabase($acquia_cloud_client, $destination_environment, $input->getArgument('site'));
 
     $answer = $this->io->confirm("Overwrite the <bg=cyan;options=bold>{$database->name}</> database on <bg=cyan;options=bold>{$destination_environment->name}</> with a copy of the database from the current machine?");
     if (!$answer) {

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -29,6 +29,7 @@ class PushFilesCommand extends PullCommandBase {
   protected function configure() {
     $this->setDescription('Push Drupal files from your IDE to a Cloud Platform environment')
       ->acceptEnvironmentId()
+      ->acceptSite()
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 
@@ -42,11 +43,14 @@ class PushFilesCommand extends PullCommandBase {
   protected function execute(InputInterface $input, OutputInterface $output) {
     $this->setDirAndRequireProjectCwd($input);
     $destination_environment = $this->determineEnvironment($input, $output, FALSE);
-    if ($this->isAcsfEnv($destination_environment)) {
-      $chosen_site = $this->promptChooseAcsfSite($destination_environment);
-    }
-    else {
-      $chosen_site = $this->promptChooseCloudSite($destination_environment);
+    $chosen_site = $input->getArgument('site');
+    if (!$chosen_site) {
+      if ($this->isAcsfEnv($destination_environment)) {
+        $chosen_site = $this->promptChooseAcsfSite($destination_environment);
+      }
+      else {
+        $chosen_site = $this->promptChooseCloudSite($destination_environment);
+      }
     }
     $answer = $this->io->confirm("Overwrite the public files directory on <bg=cyan;options=bold>{$destination_environment->name}</> with a copy of the files from the current machine?");
     if (!$answer) {

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -5,11 +5,8 @@ namespace Acquia\Cli\Tests\Commands\Pull;
 use Acquia\Cli\Command\Pull\PullCommandBase;
 use Acquia\Cli\Command\Pull\PullDatabaseCommand;
 use Acquia\Cli\Exception\AcquiaCliException;
-use Acquia\Cli\Helpers\SshHelper;
-use AcquiaCloudApi\Response\EnvironmentResponse;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
-use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Filesystem\Filesystem;
@@ -154,9 +151,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->mockDatabasesResponse($environments_response);
     $this->mockDatabaseBackupsResponse($environments_response, 'profserv2', 1);
     $this->mockDownloadBackupResponse($environments_response, 'profserv2', 1);
-
+    $ssh_helper = $this->mockSshHelper();
     if ($mock_get_acsf_sites) {
-      $ssh_helper = $this->mockSshHelper();
       $this->mockGetAcsfSites($ssh_helper);
     }
 


### PR DESCRIPTION
**Motivation**
Fixes #483

**Proposed changes**
Add `site` argument to `push:files`, `push:db`, `pull:files`, and `pull:db`.

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Test the affected `push/pull` commands, including multisite arguments as well as the `default` site argument (since `default` is handled a little differently between commands)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
