### PR TITLE
Fix #535: [pull:code][windows] GIT_SSH_COMMAND not recognized

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -684,14 +684,12 @@ abstract class PullCommandBase extends CommandBase {
    */
   protected function cloneFromCloud(EnvironmentResponse $chosen_environment, \Closure $output_callback): void {
     $command = [
-      'GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"',
       'git',
       'clone',
       $chosen_environment->vcs->url,
       $this->dir,
     ];
-    $command = implode(' ', $command);
-    $process = $this->localMachineHelper->executeFromCmd($command, $output_callback, NULL, $this->output->isVerbose(), NULL);
+    $process = $this->localMachineHelper->execute($command, $output_callback, NULL, $this->output->isVerbose(), NULL, ['GIT_SSH_COMMAND' => 'ssh -o StrictHostKeyChecking=no']);
     $this->checkoutBranchFromEnv($chosen_environment, $output_callback);
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Failed to clone repository from the Cloud Platform: {message}', ['message' => $process->getErrorOutput()]);

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -72,6 +72,14 @@ class LocalMachineHelper {
   }
 
   /**
+   * Executes a command directly in a shell (without additional parsing).
+   *
+   * Use `execute()` instead whenever possible. `executeFromCmd()` does not
+   * automatically escape arguments and should only be used for commands with
+   * pipes or redirects not supported by `execute()`.
+   *
+   * Windows does not support prepending commands with environment variables.
+   *
    * @param string $cmd
    * @param callable $callback
    * @param string $cwd

--- a/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
@@ -278,14 +278,12 @@ class PullCodeCommandTest extends PullCommandTestBase {
     $dir
   ): void {
     $command = [
-      'GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"',
       'git',
       'clone',
       $environments_response->vcs->url,
       $dir,
     ];
-    $command = implode(' ', $command);
-    $local_machine_helper->executeFromCmd($command, Argument::type('callable'), NULL, TRUE, NULL)
+    $local_machine_helper->execute($command, Argument::type('callable'), NULL, TRUE, NULL, ['GIT_SSH_COMMAND' => 'ssh -o StrictHostKeyChecking=no'])
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }


### PR DESCRIPTION
**Motivation**
Fixes #535

**Proposed changes**
Use the safer `execute()` method and pass environment variables as context, rather than as part of the CLI.

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `acli pull:code` on Windows (Git Bash or Powershell) and confirm it works.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer

This has been broken for almost a year 😱 : https://github.com/acquia/cli/pull/156

This regression occurred because we mock Git shell commands, we don't actually try to execute them in a Windows environment. I'm not sure how we could catch this without end-to-end integrated tests (e.g. actually cloning a repo) on Windows. @grasmash I don't really want to pursue this, do you?
