### PR TITLE
Warn users to configure sites.php

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1434,6 +1434,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       $site = reset($sites);
       return $site;
     }
+    $this->io->writeln("This is a multisite application. Drupal will load the default site unless you've configured sites.php for this environment: https://docs.acquia.com/cloud-platform/develop/drupal/multisite/");
     return $this->io->choice('Choose a site', $sites, $sites[0]);
   }
 

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1434,7 +1434,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       $site = reset($sites);
       return $site;
     }
-    $this->io->writeln("This is a multisite application. Drupal will load the default site unless you've configured sites.php for this environment: https://docs.acquia.com/cloud-platform/develop/drupal/multisite/");
+    $this->warnMultisite();
     return $this->io->choice('Choose a site', $sites, $sites[0]);
   }
 
@@ -1511,6 +1511,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       'key' => $api_key,
       'secret' => $api_secret
     ]), $base_uri);
+  }
+
+  protected function warnMultisite(): void {
+    $this->io->note("This is a multisite application. Drupal will load the default site unless you've configured sites.php for this environment: https://docs.acquia.com/cloud-platform/develop/drupal/multisite/");
   }
 
 }

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -635,6 +635,7 @@ abstract class PullCommandBase extends CommandBase {
         }
         return $databases[array_search($site, array_column($databases, 'name'))];
       }
+      $this->io->writeln("This is a multisite application. Drupal will load the default site unless you've configured sites.php for this environment: https://docs.acquia.com/cloud-platform/develop/drupal/multisite/");
       return $this->promptChooseDatabase($chosen_environment, $databases);
     }
 

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -635,7 +635,7 @@ abstract class PullCommandBase extends CommandBase {
         }
         return $databases[array_search($site, array_column($databases, 'name'))];
       }
-      $this->io->writeln("This is a multisite application. Drupal will load the default site unless you've configured sites.php for this environment: https://docs.acquia.com/cloud-platform/develop/drupal/multisite/");
+      $this->warnMultisite();
       return $this->promptChooseDatabase($chosen_environment, $databases);
     }
 


### PR DESCRIPTION
**Motivation**
Fixes DX-3908

If users fail to configure sites.php for an environment and pull a db or files from a multisite install, they will be pretty confused when Drupal loads the default site instead of whatever multisite they selected.

Note that this isn't ACLI misbehaving, it always pulls the db or files as expected. The problem is that Drupal may not know to utilize the db/files that were just pulled, causing a split-brain scenario where it tries to load files from the wrong site directory.

**Proposed changes**
Warn users of the need to configure sites.php
