### PR TITLE
Check access token expiration.

### DIFF
--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -73,6 +73,7 @@ services:
         key: '@=service("cloud.credentials").getCloudKey()'
         secret: '@=service("cloud.credentials").getCloudSecret()'
         accessToken: '@=service("cloud.credentials").getCloudAccessToken()'
+        accessTokenExpiry: '@=service("cloud.credentials").getCloudAccessTokenExpiry()'
       $base_uri: '@=service("cloud.credentials").getBaseUri()'
   AcquiaCloudApi\Connector\ConnectorInterface:
     alias: Acquia\Cli\CloudApi\ConnectorFactory

--- a/src/CloudApi/AccessTokenConnector.php
+++ b/src/CloudApi/AccessTokenConnector.php
@@ -22,7 +22,9 @@ class AccessTokenConnector extends Connector {
   public function __construct(array $config, string $base_uri = NULL) {
     $this->accessToken = new AccessToken([
       'access_token' => $config['accessToken'],
+      'expires' => $config['accessTokenExpiry'],
     ]);
+
     parent::__construct($config, $base_uri);
   }
 

--- a/src/CloudApi/AccessTokenConnector.php
+++ b/src/CloudApi/AccessTokenConnector.php
@@ -20,11 +20,7 @@ class AccessTokenConnector extends Connector {
    * @inheritdoc
    */
   public function __construct(array $config, string $base_uri = NULL) {
-    $this->accessToken = new AccessToken([
-      'access_token' => $config['accessToken'],
-      'expires' => $config['accessTokenExpiry'],
-    ]);
-
+    $this->accessToken = $config['access_token'];
     parent::__construct($config, $base_uri);
   }
 

--- a/src/CloudApi/CloudCredentials.php
+++ b/src/CloudApi/CloudCredentials.php
@@ -37,6 +37,17 @@ class CloudCredentials {
   /**
    * @return string|null
    */
+  public function getCloudAccessTokenExpiry(): ?string {
+    if (getenv('ACLI_ACCESS_TOKEN_EXPIRY')) {
+      return getenv('ACLI_ACCESS_TOKEN_EXPIRY');
+    }
+
+    return NULL;
+  }
+
+  /**
+   * @return string|null
+   */
   public function getCloudKey(): ?string {
     if ($this->datastoreCloud->get('acli_key')) {
       return $this->datastoreCloud->get('acli_key');

--- a/src/CloudApi/ConnectorFactory.php
+++ b/src/CloudApi/ConnectorFactory.php
@@ -31,7 +31,11 @@ class ConnectorFactory {
         'expires' => $this->config['accessTokenExpiry'],
       ]);
       if (!$access_token->hasExpired()) {
-        return new AccessTokenConnector($this->config, $this->baseUri);
+        return new AccessTokenConnector([
+          'access_token' => $access_token,
+          'key' => NULL,
+          'secret' => NULL,
+        ], $this->baseUri);
       }
     }
 

--- a/src/CloudApi/ConnectorFactory.php
+++ b/src/CloudApi/ConnectorFactory.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\CloudApi;
 
 use AcquiaCloudApi\Connector\Connector;
+use League\OAuth2\Client\Token\AccessToken;
 
 class ConnectorFactory {
 
@@ -25,7 +26,13 @@ class ConnectorFactory {
    */
   public function createConnector() {
     if ($this->config['accessToken']) {
-      return new AccessTokenConnector($this->config, $this->baseUri);
+      $access_token = new AccessToken([
+        'access_token' => $this->config['accessToken'],
+        'expires' => $this->config['accessTokenExpiry'],
+      ]);
+      if (!$access_token->hasExpired()) {
+        return new AccessTokenConnector($this->config, $this->baseUri);
+      }
     }
 
     return new Connector($this->config, $this->baseUri);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Ensure that expired access tokens are not used.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Use ACLI_ACCESS_TOKEN_EXPIRY to check if ACLI_ACCESS_TOKEN is expired. If it is expired, the typical authentication flow will occur, checking cloud_api.conf.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Get a real access token. It will expire after 5 minutes
* Open Google Chrome Dev Tools
* Change to "network" tab to begin recording requests
* Login to Acquia Cloud
* Immediately, before changing URLs, filter the network tab for the "token" resource and select it
* Select the 'preview' subtab to see find the access token
4. Run `export ACLI_ACCESS_TOKEN=[my token]`
5. Run `export ACLI_ACCESS_TOKEN_EXPIRY=[unix timestamp]`
6. If you have a local ~/.acquia/cloud_api.conf, run `mv ~/.acquia/cloud_api.conf ~/.acquia/cloud_api.conf.bak` so that it does not interfere
7. Run an Acquia CLI command and validate that authentication works, even without creds present. E.g., `./bin/acli api:applications:find`
8. When done, restore your local creds file with `mv ~/.acquia/cloud_api.conf.bak ~/.acquia/cloud_api.conf` 



**Merge requirements**
- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
