### PR TITLE
Fixes #542: provide the HTTP request in debug-level output.

### DIFF
--- a/src/Command/Api/ApiCommandBase.php
+++ b/src/Command/Api/ApiCommandBase.php
@@ -98,13 +98,9 @@ class ApiCommandBase extends CommandBase {
     ]);
 
     try {
-      $this->output->writeln([
-        'Making API Request...',
-        'method: ' . $this->method,
-        'path: ' . $path,
-        'query: ' . print_r($acquia_cloud_client->getQuery(), TRUE),
-        'options: ' . print_r($acquia_cloud_client->getOptions(), TRUE),
-      ], OutputInterface::VERBOSITY_DEBUG);
+      if ($this->output->isVeryVerbose()) {
+        $acquia_cloud_client->addOption('debug', $this->output);
+      }
       $response = $acquia_cloud_client->request($this->method, $path);
       $exit_code = 0;
     }

--- a/src/Command/Api/ApiCommandBase.php
+++ b/src/Command/Api/ApiCommandBase.php
@@ -98,6 +98,13 @@ class ApiCommandBase extends CommandBase {
     ]);
 
     try {
+      $this->output->writeln([
+        'Making API Request...',
+        'method: ' . $this->method,
+        'path: ' . $path,
+        'query: ' . print_r($acquia_cloud_client->getQuery(), TRUE),
+        'options: ' . print_r($acquia_cloud_client->getOptions(), TRUE),
+      ], OutputInterface::VERBOSITY_DEBUG);
       $response = $acquia_cloud_client->request($this->method, $path);
       $exit_code = 0;
     }

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -204,6 +204,8 @@ abstract class TestBase extends TestCase {
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN', 'Accept' => 'application/json']);
     $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
     $this->clientServiceProphecy->getClient()->willReturn($this->clientProphecy->reveal());
+    $this->clientServiceProphecy->getQuery()->willReturn([]);
+    $this->clientServiceProphecy->getOptions()->willReturn([]);
     $this->logStreamManagerProphecy = $this->prophet->prophesize(LogstreamManager::class);
 
     $this->setIo($input, $output);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -202,10 +202,10 @@ abstract class TestBase extends TestCase {
     $this->cloudCredentials = new CloudCredentials($this->datastoreCloud);
     $this->clientProphecy = $this->prophet->prophesize(Client::class);
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN', 'Accept' => 'application/json']);
+    $this->clientProphecy->getQuery()->willReturn([]);
+    $this->clientProphecy->getOptions()->willReturn([]);
     $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
     $this->clientServiceProphecy->getClient()->willReturn($this->clientProphecy->reveal());
-    $this->clientServiceProphecy->getQuery()->willReturn([]);
-    $this->clientServiceProphecy->getOptions()->willReturn([]);
     $this->logStreamManagerProphecy = $this->prophet->prophesize(LogstreamManager::class);
 
     $this->setIo($input, $output);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -32,6 +32,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
@@ -202,8 +203,7 @@ abstract class TestBase extends TestCase {
     $this->cloudCredentials = new CloudCredentials($this->datastoreCloud);
     $this->clientProphecy = $this->prophet->prophesize(Client::class);
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN', 'Accept' => 'application/json']);
-    $this->clientProphecy->getQuery()->willReturn([]);
-    $this->clientProphecy->getOptions()->willReturn([]);
+    $this->clientProphecy->addOption('debug', Argument::type(OutputInterface::class));
     $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
     $this->clientServiceProphecy->getClient()->willReturn($this->clientProphecy->reveal());
     $this->logStreamManagerProphecy = $this->prophet->prophesize(LogstreamManager::class);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #542

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
For api:* commands, print request info at debug verbosity level.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. `./bin/acli api:applications:find -vvv`
4. Validate output contains curl debug output. E.g.,
```
./bin/acli api:applications:task-list [uuid] --limit=2 --offset=1 -vvv
Acquia CLI version: @package_version@
*   Trying 104.19.229.55:443...
* TCP_NODELAY set
* Connected to cloud.acquia.com (104.19.229.55) port 443 (#0)
[...lots more...]
* Connection #0 to host cloud.acquia.com left intact
```

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
