### PR TITLE
Default dir to /home/ide/project in IDE for new command.

### DIFF
--- a/src/Command/NewCommand.php
+++ b/src/Command/NewCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Command;
 
 use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -45,7 +46,9 @@ class NewCommand extends CommandBase {
       $dir = Path::canonicalize($input->getArgument('directory'));
       $dir = Path::makeAbsolute($dir, getcwd());
     }
-    else {
+    else if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      $dir = '/home/ide/project';
+    } else {
       $dir = Path::makeAbsolute('drupal', getcwd());
     }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Login to IDE.
4. Run `acli new`
5. Validate that /home/ide/project is default dir.

**Merge requirements**
- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
