### PR TITLE
Do not throw exception when update check fails.

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1211,7 +1211,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    *
    * @throws \Exception|\GuzzleHttp\Exception\GuzzleException
    * @todo unify with consolidation/self-update and support unstable channels
-   *
    */
   protected function hasUpdate() {
     $client = $this->getUpdateClient();

--- a/src/Command/HelloWorldCommand.php
+++ b/src/Command/HelloWorldCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Acquia\Cli\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class HelloWorldCommand.
+ */
+class HelloWorldCommand extends CommandBase {
+
+  protected static $defaultName = 'hello-world';
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure() {
+    $this->setDescription('Test command used for asserting core functionality')
+      ->setHidden(TRUE);
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return int
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->io->success('Hello world!');
+
+    return 0;
+  }
+
+}

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -61,6 +61,7 @@ abstract class CommandTestBase extends TestBase {
     /** @var \Prophecy\Prophecy\ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzle_response */
     $guzzle_response = $this->prophet->prophesize(Response::class);
     $guzzle_response->getBody()->willReturn();
+    $guzzle_response->getStatusCode()->willReturn(200);
     $guzzle_client = $this->prophet->prophesize(Client::class);
     $guzzle_client->get('https://api.github.com/repos/acquia/cli/releases')->willReturn($guzzle_response->reveal());
     $this->command->setUpdateClient($guzzle_client->reveal());

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -57,14 +57,7 @@ abstract class CommandTestBase extends TestBase {
     if (!isset($this->command)) {
       $this->command = $this->createCommand();
     }
-    // Mock guzzle requests for update checks so we don't actually hit Github.
-    /** @var \Prophecy\Prophecy\ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzle_response */
-    $guzzle_response = $this->prophet->prophesize(Response::class);
-    $guzzle_response->getBody()->willReturn();
-    $guzzle_response->getStatusCode()->willReturn(200);
-    $guzzle_client = $this->prophet->prophesize(Client::class);
-    $guzzle_client->get('https://api.github.com/repos/acquia/cli/releases')->willReturn($guzzle_response->reveal());
-    $this->command->setUpdateClient($guzzle_client->reveal());
+    $this->setUpdateClient();
     $this->printTestName();
   }
 
@@ -386,6 +379,22 @@ abstract class CommandTestBase extends TestBase {
     $command = 'MYSQL_PWD=drupal mysqldump --host=localhost --user=drupal drupal | pv --rate --bytes | gzip -9 > ' . sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz';
     $local_machine_helper->executeFromCmd($command, Argument::type('callable'), NULL, TRUE)->willReturn($process->reveal())
       ->shouldBeCalled();
+  }
+
+  /**
+   * Mock guzzle requests for update checks so we don't actually hit Github.
+   *
+   * @param int $status_code
+   */
+  protected function setUpdateClient($status_code = 200): void {
+    /** @var \Prophecy\Prophecy\ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzle_response */
+    $guzzle_response = $this->prophet->prophesize(Response::class);
+    $guzzle_response->getBody()->willReturn();
+    $guzzle_response->getStatusCode()->willReturn($status_code);
+    $guzzle_client = $this->prophet->prophesize(Client::class);
+    $guzzle_client->get('https://api.github.com/repos/acquia/cli/releases')
+      ->willReturn($guzzle_response->reveal());
+    $this->command->setUpdateClient($guzzle_client->reveal());
   }
 
 }

--- a/tests/phpunit/src/Commands/UpdateCommandTest.php
+++ b/tests/phpunit/src/Commands/UpdateCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Acquia\Cli\Tests\Commands;
+
+use Acquia\Cli\Command\HelloWorldCommand;
+use Acquia\Cli\Tests\CommandTestBase;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Class UpdateCommandTest.
+ *
+ * @package Acquia\Cli\Tests\Commands
+ * @property \Acquia\Cli\Command\HelloWorldCommand $command
+ */
+class UpdateCommandTest extends CommandTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function createCommand(): Command {
+    return $this->injectCommand(HelloWorldCommand::class);
+  }
+
+  public function testSelfUpdate() {
+    $this->setUpdateClient(403);
+    $this->executeCommand([], []);
+    self::assertEquals(0, $this->getStatusCode());
+  }
+
+}


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes the following error:
```
acli self-update
Warning: file_get_contents(https://api.github.com/repos/acquia/cli/releases): failed to open stream: HTTP request failed! HTTP/1.1 403 rate limit exceeded
in phar:///opt/local/acli/vendor/consolidation/self-update/src/SelfUpdateCommand.php on line 70
Warning: file_get_contents(https://api.github.com/repos/acquia/cli/releases): failed to open stream: HTTP request failed! HTTP/1.1 403 rate limit exceeded
in phar:///opt/local/acli/vendor/consolidation/self-update/src/SelfUpdateCommand.php on line 70
In SelfUpdateCommand.php line 74:
API error - no release found at GitHub repository acquia/cli
```

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Do not throw an exception when an update check fails. Instead, return FALSE (as if there is no update) and log error at debug verbosity.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Completely disable the check. Did not seem necessary.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Download phar file from build
4. Run `acli.phar api:applications:find -vvv` and validate that no GitHub related error is thrown.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
