### PR TITLE
Avoid GitHub rate limiting.

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -124,20 +124,15 @@ class ExceptionListener {
   protected function writeUpdateHelp(ConsoleErrorEvent $event): void {
     try {
       $command = $event->getCommand();
-      if ($command) {
-        /** @var \SelfUpdate\SelfUpdateCommand $self_update_command */
-        $self_update_command = $command->getApplication()->find('self-update');
-        [$latest, $downloadUrl] = $self_update_command->getLatest(FALSE);
-        // This will always be TRUE during dev because the package version is set to '@package_version@'.
-        $current_version = $event->getCommand()->getApplication()->getVersion();
-        if ($latest !== $current_version && !AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      if ($command
+        && method_exists($command, 'checkForNewVersion')
+        && $latest = $command->checkForNewVersion()
+      ) {
           $message = "Acquia CLI {$latest} is available. Try updating via <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>acli self-update</> and then run the command again.";
           $this->helpMessages[] = $message;
-        }
       }
       // This command may not exist during some testing.
     } catch (CommandNotFoundException $exception) {
-
     }
   }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
```
acli pull:db [] -vvv

Box Requirements Checker
========================

> Using PHP 7.4.15
> PHP is using the following php.ini file:
/usr/local/php7.4/etc/cli/php.ini

> Checking Box requirements:
✔ The application requires the version "^7.3 | ^8.0" or greater.
✔ The application requires the extension "json".
✔ The package "brick/math" requires the extension "json".
✔ The package "guzzlehttp/guzzle" requires the extension "json".
✔ The package "ramsey/uuid" requires the extension "json".
✔ The package "zumba/amplitude-php" requires the extension "curl".


[OK] Your system is ready to run the application.
Acquia CLI version: 1.12.0

Warning: file_get_contents(https://api.github.com/repos/acquia/cli/releases): failed to open stream: HTTP request failed! HTTP/1.1 403 rate limit exceeded
in phar:///opt/local/acli/vendor/consolidation/self-update/src/SelfUpdateCommand.php on line 70

In SelfUpdateCommand.php line 74:

[Exception]
API error - no release found at GitHub repository acquia/cli
Exception trace:
at phar:///opt/local/acli/vendor/consolidation/self-update/src/SelfUpdateCommand.php:74
SelfUpdate\SelfUpdateCommand->getReleasesFromGithub() at phar:///opt/local/acli/vendor/consolidation/self-update/src/SelfUpdateCommand.php:93
SelfUpdate\SelfUpdateCommand->getLatestStableReleaseFromGithub() at phar:///opt/local/acli/vendor/consolidation/self-update/src/SelfUpdateCommand.php:115
SelfUpdate\SelfUpdateCommand->getLatest() at phar:///opt/local/acli/src/EventListener/ExceptionListener.php:130
Acquia\Cli\EventListener\ExceptionListener->writeUpdateHelp() at phar:///opt/local/acli/src/EventListener/ExceptionListener.php:80
Acquia\Cli\EventListener\ExceptionListener->onConsoleError() at phar:///opt/local/acli/vendor/symfony/event-dispatcher/EventDispatcher.php:270
Symfony\Component\EventDispatcher\EventDispatcher::Symfony\Component\EventDispatcher\{closure}() at phar:///opt/local/acli/vendor/symfony/event-dispatcher/EventDispatcher.php:230
Symfony\Component\EventDispatcher\EventDispatcher->callListeners() at phar:///opt/local/acli/vendor/symfony/event-dispatcher/EventDispatcher.php:59
Symfony\Component\EventDispatcher\EventDispatcher->dispatch() at phar:///opt/local/acli/vendor/symfony/console/Application.php:995
Symfony\Component\Console\Application->doRunCommand() at phar:///opt/local/acli/vendor/symfony/console/Application.php:290
Symfony\Component\Console\Application->doRun() at phar:///opt/local/acli/vendor/symfony/console/Application.php:166
Symfony\Component\Console\Application->run() at phar:///opt/local/acli/bin/acli:86
require() at /opt/local/acli:14

pull:database [--no-scripts] [-od|--on-demand] [--] [<environmentId> [<site>]]
```

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

When an exception is thrown and version is checked, use same conditions as during command bootstrap.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`. 
3. Disconnect from wifi.
4. Run acli.phar api:applications:find -vvv and validate that no GitHub related error is thrown.


**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [x] Manual testing by a reviewer
