### PR TITLE
Change IDE SSH key generation

### DIFF
--- a/src/Command/Ide/Wizard/IdeWizardCommandBase.php
+++ b/src/Command/Ide/Wizard/IdeWizardCommandBase.php
@@ -78,7 +78,7 @@ abstract class IdeWizardCommandBase extends SshKeyCommandBase {
    * @return string
    */
   public function getSshKeyFilename(string $ide_uuid): string {
-    return 'id_rsa_acquia_ide_' . $ide_uuid;
+    return 'id_rsa';
   }
 
 }

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -298,6 +298,7 @@ EOT
     $return_code = $this->executeAcliCommand('ssh-key:create', [
        '--filename' => $private_ssh_key_filename,
        '--password' => $password,
+       '--is-wizard' => TRUE,
      ]);
     if ($return_code !== 0) {
       throw new AcquiaCliException('Unable to generate a local SSH key.');

--- a/src/Command/Ssh/SshKeyCreateCommand.php
+++ b/src/Command/Ssh/SshKeyCreateCommand.php
@@ -90,7 +90,7 @@ class SshKeyCreateCommand extends SshKeyCommandBase {
       $this->validateFilename($filename);
     }
     else {
-      $default = 'id_rsa_acquia';
+      $default = 'id_rsa';
       $question = new Question("Please enter a filename for your new local SSH key. Press enter to use default value", $default);
       $question->setNormalizer(static function ($value) {
         return $value ? trim($value) : '';

--- a/src/Command/Ssh/SshKeyCreateCommand.php
+++ b/src/Command/Ssh/SshKeyCreateCommand.php
@@ -128,18 +128,21 @@ class SshKeyCreateCommand extends SshKeyCommandBase {
    * @throws \Exception
    */
   protected function determinePassword(InputInterface $input, OutputInterface $output): string {
+    $password = "";
     if ($input->getOption('password')) {
       $password = $input->getOption('password');
       $this->validatePassword($password);
     }
     else {
-      $question = new Question('Enter a password for your SSH key');
-      $question->setHidden($this->localMachineHelper->useTty());
-      $question->setNormalizer(static function ($value) {
-        return $value ? trim($value) : '';
-      });
-      $question->setValidator(Closure::fromCallable([$this, 'validatePassword']));
-      $password = $this->io->askQuestion($question);
+      if ($input->getOption('password') !== "") {
+        $question = new Question('Enter a password for your SSH key');
+        $question->setHidden($this->localMachineHelper->useTty());
+        $question->setNormalizer(static function ($value) {
+          return $value ? trim($value) : '';
+        });
+        $question->setValidator(Closure::fromCallable([$this, 'validatePassword']));
+        $password = $this->io->askQuestion($question);
+      }
     }
 
     return $password;
@@ -152,8 +155,7 @@ class SshKeyCreateCommand extends SshKeyCommandBase {
    */
   protected function validatePassword($password) {
     $violations = Validation::createValidator()->validate($password, [
-      new Length(['min' => 5]),
-      new NotBlank(),
+      new Length(['min' => 0])
     ]);
     if (count($violations)) {
       throw new ValidatorException($violations->get(0)->getMessage());

--- a/src/Command/Ssh/SshKeyCreateUploadCommand.php
+++ b/src/Command/Ssh/SshKeyCreateUploadCommand.php
@@ -21,7 +21,8 @@ class SshKeyCreateUploadCommand extends SshKeyCreateCommand {
     $this->setDescription('Create an SSH key on your local machine and upload it to the Cloud Platform')
       ->addOption('filename', NULL, InputOption::VALUE_REQUIRED, 'The filename of the SSH key')
       ->addOption('password', NULL, InputOption::VALUE_REQUIRED, 'The password for the SSH key')
-    ->addOption('no-wait', NULL, InputOption::VALUE_NONE, "Don't wait for the SSH key to be uploaded to the Cloud Platform");
+      ->addOption('no-wait', NULL, InputOption::VALUE_NONE, "Don't wait for the SSH key to be uploaded to the Cloud Platform")
+      ->addOption('is-wizard', FALSE, InputOption::VALUE_REQUIRED, 'The flag for IDE wizard');
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes the broken GIT UI for Cloud IDE

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

- Temporarily support SSH key generation without passphrase key
- Static file name for all SSH keys in the IDE. [ Dynamic in Cloud Platform ]

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

- File support ticket on Theia to consider passphrase keys for Git UI

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

- Apply this PR on any of the existing IDE.
- Remove the existing Keys for the IDE from ~/.ssh, ssh-add -D and Cloud platform.
- Authenticate the IDE against `acli`
- Create a new Key using `{path to acli}/bin/acli ide:wizard:ssh-key:create-upload`
- Clone the Code from Cloud Platform.
- Try to use Git UI in the IDE to pull/push the committed code.

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
- [X] Manual testing by a reviewer
