### PR TITLE
[pull:db] --no-import option

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -133,7 +133,7 @@ abstract class PullCommandBase extends CommandBase {
     $this->checklist->completePreviousItem();
 
     if ($no_import) {
-      $output->writeln('Database backup downloaded to ' . $local_filepath);
+      $this->io->success('Database backup downloaded to ' . $local_filepath);
     } else {
       $this->checklist->addItem('Importing Drupal database download');
       $this->importRemoteDatabase($local_filepath,

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -271,7 +271,7 @@ abstract class PullCommandBase extends CommandBase {
       $output_callback('out', "Downloading backup {$backup_response->id}");
     }
     // Filename roughly matches what you'd get with a manual download from Cloud UI.
-    $filename = implode('-', ['backup', $backup_response->completedAt, $database->name]) . '.sql.gz';
+    $filename = implode('-', [$environment->name, $database->name, trim(parse_url($database->url, PHP_URL_PATH), '/'), $backup_response->completedAt]) . '.sql.gz';
     $local_filepath = Path::join(sys_get_temp_dir(), $filename);
     if ($this->output instanceof ConsoleOutput) {
       $output = $this->output->section();

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -104,12 +104,13 @@ abstract class PullCommandBase extends CommandBase {
    * @param \Symfony\Component\Console\Input\InputInterface $input
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    * @param bool $on_demand Force on-demand backup.
-   * @param bool $download Skip import.
+   * @param bool $no_import Skip import.
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
+   * @throws \Exception
    */
-  protected function pullDatabase(InputInterface $input, OutputInterface $output, bool $on_demand, bool $download): void {
-    if (!$download) {
+  protected function pullDatabase(InputInterface $input, OutputInterface $output, bool $on_demand, bool $no_import): void {
+    if (!$no_import) {
       // Verify database connection.
       $this->connectToLocalDatabase($this->getLocalDbHost(), $this->getLocalDbUser(), $this->getLocalDbName(), $this->getLocalDbPassword(), $this->getOutputCallback($output, $this->checklist));
     }
@@ -131,10 +132,9 @@ abstract class PullCommandBase extends CommandBase {
     $local_filepath = $this->downloadDatabaseDump($source_environment, $database, $backup_response, $acquia_cloud_client, $this->getOutputCallback($output, $this->checklist));
     $this->checklist->completePreviousItem();
 
-    if ($download) {
+    if ($no_import) {
       $output->writeln('Database backup downloaded to ' . $local_filepath);
-    }
-    if (!$download) {
+    } else {
       $this->checklist->addItem('Importing Drupal database download');
       $this->importRemoteDatabase($local_filepath,
         $this->getOutputCallback($output, $this->checklist));

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -44,7 +44,7 @@ class PullDatabaseCommand extends PullCommandBase {
     parent::execute($input, $output);
     $no_scripts = $input->hasOption('no-scripts') && $input->getOption('no-scripts');
     $on_demand = $input->hasOption('on-demand') && $input->getOption('on-demand');
-    $no_import = $input->hasOption('no_import') && $input->getOption('no_import');
+    $no_import = $input->hasOption('no-import') && $input->getOption('no-import');
     // $no_import implies $no_scripts.
     $no_scripts = $no_import || $no_scripts;
     $this->pullDatabase($input, $output, $on_demand, $no_import);

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -28,7 +28,7 @@ class PullDatabaseCommand extends PullCommandBase {
         'Do not run any additional scripts after the database is pulled. E.g., drush cache-rebuild, drush sql-sanitize, etc.')
       ->addOption('on-demand', 'od', InputOption::VALUE_NONE,
         'Force creation of an on-demand backup. This takes much longer than using an existing backup (when one is available)')
-      ->addOption('download', NULL, InputOption::VALUE_NONE,
+      ->addOption('no-import', NULL, InputOption::VALUE_NONE,
       'Download the backup but do not import it (implies --no-scripts)')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
@@ -44,10 +44,10 @@ class PullDatabaseCommand extends PullCommandBase {
     parent::execute($input, $output);
     $no_scripts = $input->hasOption('no-scripts') && $input->getOption('no-scripts');
     $on_demand = $input->hasOption('on-demand') && $input->getOption('on-demand');
-    $download = $input->hasOption('download') && $input->getOption('download');
-    // $download implies $no_scripts.
-    $no_scripts = $download || $no_scripts;
-    $this->pullDatabase($input, $output, $on_demand, $download);
+    $no_import = $input->hasOption('no_import') && $input->getOption('no_import');
+    // $no_import implies $no_scripts.
+    $no_scripts = $no_import || $no_scripts;
+    $this->pullDatabase($input, $output, $on_demand, $no_import);
     if (!$no_scripts) {
       $this->runDrushCacheClear($this->getOutputCallback($output, $this->checklist));
     }

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -276,7 +276,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
   protected function mockDownloadMySqlDump(ObjectProphecy $local_machine_helper, $success): void {
     $process = $this->mockProcess($success);
     $local_machine_helper->writeFile(
-      Argument::containingString("backup-something-profserv2.sql.gz"),
+      Argument::containingString("dev-profserv2-profserv201dev-something.sql.gz"),
       'backupfilecontents'
     )
       ->shouldBeCalled();


### PR DESCRIPTION
**Motivation**
Fixes #596

**Proposed changes**
Add `--download` option that skips scripts and the db import.

**Alternatives considered**
Add a separate command, or have people use `api:environments:database-backup-download`

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. Run `pull:db` to verify that the MySQL import still works as before.
4. Run `pull:db --download` to verify that the MySQL import and scripts are skipped, and the file location is echoed.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
