### PR TITLE
Fix PHPCS

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,9 @@
 
   <file>.</file>
 
-  <exclude-pattern>build/</exclude-pattern>
+  <!-- Danger! Exclude patterns apply to the full file path, including parent directories of the current repository. -->
+  <!-- Don't exclude common directory names like `build`, which will fail on Travis CI because of /home/travis/build/acquia/<project>. -->
+  <!-- @see https://github.com/squizlabs/PHP_CodeSniffer/issues/981 -->
   <exclude-pattern>var/</exclude-pattern>
   <exclude-pattern>vendor/*</exclude-pattern>
   <exclude-pattern>tests/fixtures/*</exclude-pattern>

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -606,7 +606,7 @@ class ApiCommandHelper {
    */
   protected function getPropertySpecFromRequestBodyParam(array $request_body_schema, $parameter_definition) {
     if (array_key_exists($parameter_definition->getName(), $request_body_schema['properties'])) {
-     return $request_body_schema['properties'][$parameter_definition->getName()];
+      return $request_body_schema['properties'][$parameter_definition->getName()];
     }
 
     return NULL;

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -215,16 +215,16 @@ EOT
   protected function userHasUploadedIdeKeyToCloud(): bool {
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
-      foreach ($cloud_keys as $index => $cloud_key) {
-        if (
-          $cloud_key->label === $this::getIdeSshKeyLabel($this->ide)
-          // Assert that a corresponding local key exists.
-          && $this->localIdeSshKeyExists()
-          // Assert local public key contents match Cloud public key contents.
-          && $this->normalizePublicSshKey($cloud_key->public_key) === $this->normalizePublicSshKey(file_get_contents($this->publicSshKeyFilepath))
-        ) {
-          return TRUE;
-        }
+    foreach ($cloud_keys as $index => $cloud_key) {
+      if (
+        $cloud_key->label === $this::getIdeSshKeyLabel($this->ide)
+        // Assert that a corresponding local key exists.
+        && $this->localIdeSshKeyExists()
+        // Assert local public key contents match Cloud public key contents.
+        && $this->normalizePublicSshKey($cloud_key->public_key) === $this->normalizePublicSshKey(file_get_contents($this->publicSshKeyFilepath))
+      ) {
+        return TRUE;
+      }
     }
     return FALSE;
   }
@@ -296,7 +296,7 @@ EOT
    * @throws \Exception
    */
   protected function createLocalSshKey(string $private_ssh_key_filename, string $password): int {
-     $return_code = $this->executeAcliCommand('ssh-key:create', [
+    $return_code = $this->executeAcliCommand('ssh-key:create', [
        '--filename' => $private_ssh_key_filename,
        '--password' => $password,
      ]);

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -50,7 +50,7 @@ class PushArtifactCommand extends PullCommandBase {
       ->addOption('no-sanitize', NULL, InputOption::VALUE_NONE, 'Do not sanitize the build artifact')
       ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Do not push changes to Acquia Cloud')
       ->acceptEnvironmentId()
-    ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
+      ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL
       . 'To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events')
       ->addUsage('--no-sanitize --dry-run # skip sanitization and Git push');

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -125,10 +125,10 @@ class PushDatabaseCommand extends PullCommandBase {
    * @return string
    */
   protected function getNameFromDatabaseResponse($database): string {
-     $db_url_parts = explode('/', $database->url);
-     $db_name = end($db_url_parts);
+    $db_url_parts = explode('/', $database->url);
+    $db_name = end($db_url_parts);
 
-     return $db_name;
+    return $db_name;
   }
 
 }

--- a/src/Command/Ssh/SshKeyCreateUploadCommand.php
+++ b/src/Command/Ssh/SshKeyCreateUploadCommand.php
@@ -21,7 +21,7 @@ class SshKeyCreateUploadCommand extends SshKeyCreateCommand {
     $this->setDescription('Create an SSH key on your local machine and upload it to the Cloud Platform')
       ->addOption('filename', NULL, InputOption::VALUE_REQUIRED, 'The filename of the SSH key')
       ->addOption('password', NULL, InputOption::VALUE_REQUIRED, 'The password for the SSH key')
-    ->addOption('no-wait', NULL, InputOption::VALUE_NONE, "Don't wait for the SSH key to be uploaded to the Cloud Platform");
+      ->addOption('no-wait', NULL, InputOption::VALUE_NONE, "Don't wait for the SSH key to be uploaded to the Cloud Platform");
   }
 
   /**

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -128,8 +128,8 @@ class ExceptionListener {
         && method_exists($command, 'checkForNewVersion')
         && $latest = $command->checkForNewVersion()
       ) {
-          $message = "Acquia CLI {$latest} is available. Try updating via <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>acli self-update</> and then run the command again.";
-          $this->helpMessages[] = $message;
+        $message = "Acquia CLI {$latest} is available. Try updating via <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>acli self-update</> and then run the command again.";
+        $this->helpMessages[] = $message;
       }
       // This command may not exist during some testing.
     } catch (CommandNotFoundException $exception) {

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -95,8 +95,8 @@ abstract class CommandTestBase extends TestBase {
     }
     catch (Exception $e) {if (getenv('ACLI_PRINT_COMMAND_OUTPUT')) {
         print $this->getDisplay();
-      }
-      throw $e;
+    }
+    throw $e;
     }
 
     if (getenv('ACLI_PRINT_COMMAND_OUTPUT')) {

--- a/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
@@ -136,7 +136,7 @@ class PullCodeCommandTest extends PullCommandTestBase {
     ];
 
     try {
-    $this->executeCommand([
+      $this->executeCommand([
       '--no-scripts' => TRUE,
     ], $inputs);
     } catch (AcquiaCliException $exception) {


### PR DESCRIPTION
**Motivation**
PHPCS is not catching errors in Travis CI

**Proposed changes**
Remove the problematic exclude-pattern (see https://github.com/squizlabs/PHP_CodeSniffer/issues/981 )

**Testing steps**
See that the first commit fails because it properly enables PHPCS, then the second commit passes after fixing the style issues.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
