### PR TITLE
Fix #609: Uncaught error during update check

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1181,17 +1181,21 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   public function checkForNewVersion() {
+    // Input not set if called from an exception listener.
+    if (!isset($this->input)) {
+      return FALSE;
+    }
     // Running on API commands would corrupt JSON output.
     if (strpos($this->input->getArgument('command'), 'api:') !== FALSE) {
-      return;
+      return FALSE;
     }
     // Bail for development builds.
-    if ($this->getApplication()->getVersion() == '@package_version@') {
-      return;
+    if ($this->getApplication()->getVersion() === '@package_version@') {
+      return FALSE;
     }
     // Bail in Cloud IDEs to avoid hitting Github API rate limits.
     if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
-      return;
+      return FALSE;
     }
     try {
       if ($latest = $this->hasUpdate()) {
@@ -1223,6 +1227,9 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       return FALSE;
     }
 
+    /**
+     * @var $version string
+     */
     $version = $releases[0]->tag_name;
     $versionStability = VersionParser::parseStability($version);
     $versionIsNewer = version_compare($version, $this->getApplication()->getVersion());


### PR DESCRIPTION
**Motivation**
Fixes #609 

**Proposed changes**
Check that $input is set before accessing it.

**Alternatives considered**
I feel like we should do more to stop this kind of thing from happening again, but I'm not sure what.
- Calling the command class from within an exception listener feels dirty. I'd prefer to move update functionality into a separate helper, but it would add a lot of complexity.
- We already catch some types of exceptions during update checks, could we check more? Just adding a catch for null pointer wouldn't necessarily prevent the next bug, we should probably catch everything or nothing.

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `acli ckc`
3. `acli pull:db --acsf`, verify you get a nicely formatted error about `--asdf` not existing.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
