### PR TITLE
Fixes #621: Skip progress if pv is not installed, show warning.

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -1017,7 +1017,14 @@ abstract class PullCommandBase extends CommandBase {
     if ($output_callback) {
       $output_callback('out', "Dumping MySQL database to $local_filepath on this machine");
     }
-    $command = "MYSQL_PWD={$db_password} mysqldump --host={$db_host} --user={$db_user} {$db_name} | pv --rate --bytes | gzip -9 > $local_filepath";
+    if ($this->localMachineHelper->commandExists('pv')) {
+      $command = "MYSQL_PWD={$db_password} mysqldump --host={$db_host} --user={$db_user} {$db_name} | pv --rate --bytes | gzip -9 > $local_filepath";
+    }
+    else {
+      $this->io->warning('Please install `pv` to see progress bar');
+      $command = "MYSQL_PWD={$db_password} mysqldump --host={$db_host} --user={$db_user} {$db_name} | gzip -9 > $local_filepath";
+    }
+
     $process = $this->localMachineHelper->executeFromCmd($command, $output_callback, NULL, $this->output->isVerbose());
     if (!$process->isSuccessful() || $process->getOutput()) {
       throw new AcquiaCliException('Unable to create a dump of the local database. {message}', ['message' => $process->getErrorOutput()]);

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -382,6 +382,18 @@ abstract class CommandTestBase extends TestBase {
   }
 
   /**
+   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
+   */
+  protected function mockExecutePvExists(
+        ObjectProphecy $local_machine_helper
+    ): void {
+    $local_machine_helper
+            ->commandExists('pv')
+            ->willReturn(TRUE)
+            ->shouldBeCalled();
+  }
+
+  /**
    * Mock guzzle requests for update checks so we don't actually hit Github.
    *
    * @param int $status_code

--- a/tests/phpunit/src/Commands/Archive/ArchiveExporterCommandTest.php
+++ b/tests/phpunit/src/Commands/Archive/ArchiveExporterCommandTest.php
@@ -29,6 +29,7 @@ class ArchiveExporterCommandTest extends PullCommandTestBase {
     $local_machine_helper = $this->mockLocalMachineHelper();
     $file_system = $this->mockFileSystem($destination_dir);
     $local_machine_helper->getFilesystem()->willReturn($file_system->reveal())->shouldBeCalled();
+    $this->mockExecutePvExists($local_machine_helper);
     $this->mockExecuteDrushExists($local_machine_helper);
     $this->mockExecuteDrushStatus($local_machine_helper, TRUE, $this->projectFixtureDir);
     $this->mockCreateMySqlDumpOnLocal($local_machine_helper);

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -28,18 +28,6 @@ abstract class PullCommandTestBase extends CommandTestBase {
   /**
    * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
    */
-  protected function mockExecutePvExists(
-        ObjectProphecy $local_machine_helper
-    ): void {
-    $local_machine_helper
-            ->commandExists('pv')
-            ->willReturn(TRUE)
-            ->shouldBeCalled();
-  }
-
-  /**
-   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
-   */
   protected function mockExecuteDrushExists(
     ObjectProphecy $local_machine_helper
   ): void {

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -28,6 +28,18 @@ abstract class PullCommandTestBase extends CommandTestBase {
   /**
    * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
    */
+  protected function mockExecutePvExists(
+        ObjectProphecy $local_machine_helper
+    ): void {
+    $local_machine_helper
+            ->commandExists('pv')
+            ->willReturn(TRUE)
+            ->shouldBeCalled();
+  }
+
+  /**
+   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
+   */
   protected function mockExecuteDrushExists(
     ObjectProphecy $local_machine_helper
   ): void {

--- a/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
@@ -39,6 +39,7 @@ class PushDatabaseCommandTest extends CommandTestBase {
     $local_machine_helper = $this->mockLocalMachineHelper();
 
     // Database.
+    $this->mockExecutePvExists($local_machine_helper);
     $this->mockCreateMySqlDumpOnLocal($local_machine_helper);
     $this->mockUploadDatabaseDump($local_machine_helper, $process);
     $this->mockImportDatabaseDumpOnRemote($ssh_helper, $selected_environment, $process);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #621.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Skip progress if pv is not installed, show warning.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Throw fatal error if pv is not installed.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Ensure `pv` does not exist, `which pv`. 
2. Execute `acli db:push`
3. Validate that warning "Please install `pv` to see progress bar'" appears and that DB pull completes successfully.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
