### PR TITLE
Fixes #641: Trigger custom scripts after acli pull commands

### DIFF
--- a/bin/acli
+++ b/bin/acli
@@ -20,6 +20,8 @@ use Acquia\Cli\Command\Api\ApiCommandHelper;
 use Acquia\Cli\Helpers\LocalMachineHelper;
 use SelfUpdate\SelfUpdateCommand;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\Filesystem\Filesystem;
@@ -58,7 +60,6 @@ if ($_SERVER['APP_DEBUG']) {
 if (!getenv('HOME')) {
     putenv('HOME=' . LocalMachineHelper::getHomeDir());
 }
-
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 
 // Handle a clear-kernel-cache pseudo command. This isn't implemented as a true console
@@ -78,10 +79,12 @@ $container = $kernel->getContainer();
 putenv("ACLI_REPO_ROOT=" . LocalMachineHelper::getProjectRoot());
 /** @var Application $application */
 $application = $container->get(Application::class);
+/** @var OutputInterface $output */
+$output = $container->get(OutputInterface::class);
 $application->setName('Acquia CLI');
 $application->setVersion('@package_version@');
-/** @var \Acquia\Cli\Command\Api\ApiCommandHelper $helper */
+/** @var ApiCommandHelper $helper */
 $helper = $container->get(ApiCommandHelper::class);
 $application->addCommands($helper->getApiCommands());
 $application->add(new SelfUpdateCommand($application->getName(), $application->getVersion(), 'acquia/cli'));
-$application->run();
+$application->run($input, $output);

--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -96,6 +96,9 @@ services:
   Symfony\Component\Console\Output\OutputInterface:
     alias: Symfony\Component\Console\Output\ConsoleOutput
   Symfony\Component\EventDispatcher\EventDispatcher: ~
+  Symfony\Component\Console\Logger\ConsoleLogger: ~
+  Psr\Log\LoggerInterface:
+    alias: Symfony\Component\Console\Logger\ConsoleLogger
 
   # Amplitude service.
   Zumba\Amplitude\Amplitude: ~

--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -46,6 +46,10 @@ services:
     tags:
       # @see Symfony\Component\Console\ConsoleEvents
       - { name: kernel.event_listener, event: console.error, method: onConsoleError}
+
+  Acquia\Cli\EventListener\TerminateListener:
+    tags:
+      # @see Symfony\Component\Console\ConsoleEvents
       - { name: kernel.event_listener, event: console.terminate, method: onConsoleTerminate}
 
   # We have multiple datastores using the same class, just different arguments.

--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -46,6 +46,7 @@ services:
     tags:
       # @see Symfony\Component\Console\ConsoleEvents
       - { name: kernel.event_listener, event: console.error, method: onConsoleError}
+      - { name: kernel.event_listener, event: console.terminate, method: onConsoleTerminate}
 
   # We have multiple datastores using the same class, just different arguments.
   datastore.cloud:

--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -47,10 +47,11 @@ services:
       # @see Symfony\Component\Console\ConsoleEvents
       - { name: kernel.event_listener, event: console.error, method: onConsoleError}
 
-  Acquia\Cli\EventListener\TerminateListener:
+  Acquia\Cli\EventListener\ComposerScriptsListener:
     tags:
       # @see Symfony\Component\Console\ConsoleEvents
       - { name: kernel.event_listener, event: console.terminate, method: onConsoleTerminate}
+      - { name: kernel.event_listener, event: console.command, method: onConsoleCommand}
 
   # We have multiple datastores using the same class, just different arguments.
   datastore.cloud:

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -15,6 +15,7 @@ use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Yaml\Yaml;
 use Webmozart\KeyValueStore\JsonFileStore;
 
@@ -38,7 +39,7 @@ class ApiCommandHelper {
   protected $formatter;
 
   /**
-   * @var \Acquia\Cli\Helpers\TelemetryHelper
+   * @var TelemetryHelper
    */
   protected $telemetryHelper;
 
@@ -53,12 +54,12 @@ class ApiCommandHelper {
   protected $datastoreCloud;
 
   /**
-   * @var \Webmozart\KeyValueStore\JsonFileStore
+   * @var JsonFileStore
    */
   protected $datastoreAcli;
 
   /**
-   * @var \Acquia\Cli\CloudApi\CloudCredentials
+   * @var CloudCredentials
    */
   protected $cloudCredentials;
 
@@ -75,17 +76,17 @@ class ApiCommandHelper {
   protected $repoRoot;
 
   /**
-   * @var \Acquia\Cli\CloudApi\ClientService
+   * @var ClientService
    */
   protected $cloudApiClientService;
 
   /**
-   * @var \AcquiaLogstream\LogstreamManager
+   * @var LogstreamManager
    */
   protected $logstreamManager;
 
   /**
-   * @var \Acquia\Cli\Helpers\SshHelper
+   * @var SshHelper
    */
   public $sshHelper;
 
@@ -95,20 +96,26 @@ class ApiCommandHelper {
   protected $sshDir;
 
   /**
+   * @var ConsoleLogger
+   */
+  private $logger;
+
+  /**
    * CommandBase constructor.
    *
    * @param string $cloudConfigFilepath
-   * @param \Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
-   * @param \Webmozart\KeyValueStore\JsonFileStore $datastoreCloud
-   * @param \Acquia\Cli\DataStore\YamlStore $datastoreAcli
-   * @param \Acquia\Cli\CloudApi\CloudCredentials $cloudCredentials
-   * @param \Acquia\Cli\Helpers\TelemetryHelper $telemetryHelper
+   * @param LocalMachineHelper $localMachineHelper
+   * @param JsonFileStore $datastoreCloud
+   * @param YamlStore $datastoreAcli
+   * @param CloudCredentials $cloudCredentials
+   * @param TelemetryHelper $telemetryHelper
    * @param string $acliConfigFilepath
    * @param string $repoRoot
-   * @param \Acquia\Cli\CloudApi\ClientService $cloudApiClientService
-   * @param \AcquiaLogstream\LogstreamManager $logstreamManager
-   * @param \Acquia\Cli\Helpers\SshHelper $sshHelper
+   * @param ClientService $cloudApiClientService
+   * @param LogstreamManager $logstreamManager
+   * @param SshHelper $sshHelper
    * @param string $sshDir
+   * @param ConsoleLogger $logger
    */
   public function __construct(
     string $cloudConfigFilepath,
@@ -122,7 +129,8 @@ class ApiCommandHelper {
     ClientService $cloudApiClientService,
     LogstreamManager $logstreamManager,
     SshHelper $sshHelper,
-    string $sshDir
+    string $sshDir,
+    ConsoleLogger $logger
   ) {
     $this->cloudConfigFilepath = $cloudConfigFilepath;
     $this->localMachineHelper = $localMachineHelper;
@@ -136,6 +144,7 @@ class ApiCommandHelper {
     $this->logstreamManager = $logstreamManager;
     $this->sshHelper = $sshHelper;
     $this->sshDir = $sshDir;
+    $this->logger = $logger;
   }
 
   /**
@@ -498,7 +507,8 @@ class ApiCommandHelper {
           $this->cloudApiClientService,
           $this->logstreamManager,
           $this->sshHelper,
-          $this->sshDir
+          $this->sshDir,
+          $this->logger
         );
         $command->setName($command_name);
         $command->setDescription($schema['summary']);
@@ -665,12 +675,21 @@ class ApiCommandHelper {
       }
       $namespace = $command_name_parts[1];
       if (!array_key_exists($namespace, $api_list_commands)) {
-        $command = new ApiListCommandBase($this->cloudConfigFilepath,
-          $this->localMachineHelper, $this->datastoreCloud,
-          $this->datastoreAcli, $this->cloudCredentials, $this->telemetryHelper,
-          $this->acliConfigFilepath, $this->repoRoot,
-          $this->cloudApiClientService, $this->logstreamManager,
-          $this->sshHelper, $this->sshDir);
+        $command = new ApiListCommandBase(
+            $this->cloudConfigFilepath,
+          $this->localMachineHelper,
+            $this->datastoreCloud,
+          $this->datastoreAcli,
+            $this->cloudCredentials,
+            $this->telemetryHelper,
+          $this->acliConfigFilepath,
+            $this->repoRoot,
+          $this->cloudApiClientService,
+            $this->logstreamManager,
+          $this->sshHelper,
+            $this->sshDir,
+            $this->logger
+        );
         $name = 'api:' . $namespace;
         $command->setName($name);
         $command->setNamespace($name);

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -677,16 +677,16 @@ class ApiCommandHelper {
       if (!array_key_exists($namespace, $api_list_commands)) {
         $command = new ApiListCommandBase(
             $this->cloudConfigFilepath,
-          $this->localMachineHelper,
+            $this->localMachineHelper,
             $this->datastoreCloud,
-          $this->datastoreAcli,
+            $this->datastoreAcli,
             $this->cloudCredentials,
             $this->telemetryHelper,
-          $this->acliConfigFilepath,
+            $this->acliConfigFilepath,
             $this->repoRoot,
-          $this->cloudApiClientService,
+            $this->cloudApiClientService,
             $this->logstreamManager,
-          $this->sshHelper,
+            $this->sshHelper,
             $this->sshDir,
             $this->logger
         );

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -211,6 +211,13 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->repoRoot = $repoRoot;
   }
 
+  /**
+   * @return string
+   */
+  public function getRepoRoot(): string {
+    return $this->repoRoot;
+  }
+
   protected function setLocalDbUser(): void {
     $this->localDbUser = 'drupal';
     if ($lando_info = self::getLandoInfo()) {

--- a/src/EventListener/ComposerScriptsListener.php
+++ b/src/EventListener/ComposerScriptsListener.php
@@ -3,16 +3,38 @@
 namespace Acquia\Cli\EventListener;
 
 use Acquia\Cli\Command\CommandBase;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozart\PathUtil\Path;
 
-class TerminateListener {
+class ComposerScriptsListener {
+
+  /**
+   * Before a console command is executed, execute a corresponding script from a local composer.json.
+   *
+   * @param ConsoleCommandEvent $event
+   */
+  public function onConsoleCommand(ConsoleCommandEvent $event): void {
+    $this->executeComposerScripts($event, 'pre');
+  }
 
   /**
    * When a console command terminates successfully, execute a corresponding script from a local composer.json.
+   *
+   * @param ConsoleTerminateEvent $event
    */
   public function onConsoleTerminate(ConsoleTerminateEvent $event): void {
+    if ($event->getExitCode() === 0) {
+      $this->executeComposerScripts($event, 'post');
+    }
+  }
+
+  /**
+   * @param ConsoleTerminateEvent|ConsoleCommandEvent $event
+   * @param string $prefix Added to the Composer script name. Expected values are 'pre' or 'post'.
+   */
+  private function executeComposerScripts($event, $prefix) {
     /** @var CommandBase $command */
     $command = $event->getCommand();
     // If a command has the --no-script option and it's passed, do not execute post scripts.
@@ -20,15 +42,15 @@ class TerminateListener {
       return;
     }
     // Only successful commands should be executed.
-    if (is_a($command, CommandBase::class) && $event->getExitCode() === 0) {
+    if (is_a($command, CommandBase::class)) {
       $composer_json_filepath = Path::join($command->getRepoRoot(), 'composer.json');
       if (file_exists($composer_json_filepath)) {
         $composer_json = json_decode($command->localMachineHelper->readFile($composer_json_filepath), TRUE);
         // Protect against invalid JSON.
         if ($composer_json) {
           $command_name = $command->getName();
-          // Replace colons with hypens. E.g., pull:db becomes pull-db.
-          $script_name = 'post-acli-' . str_replace(':', '-', $command_name);
+          // Replace colons with hyphens. E.g., pull:db becomes pull-db.
+          $script_name = $prefix . '-acli-' . str_replace(':', '-', $command_name);
           if (array_key_exists('scripts', $composer_json) && array_key_exists($script_name, $composer_json['scripts'])) {
             $event->getOutput()->writeln("Executing composer script `$script_name` defined in `$composer_json_filepath`", OutputInterface::VERBOSITY_VERBOSE);
             $event->getOutput()->writeln($script_name);

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -2,17 +2,12 @@
 
 namespace Acquia\Cli\EventListener;
 
-use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Exception\ApiErrorException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
-use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\RuntimeException;
-use Symfony\Component\Console\Output\OutputInterface;
-use Webmozart\PathUtil\Path;
 
 class ExceptionListener {
 
@@ -137,35 +132,6 @@ class ExceptionListener {
       }
       // This command may not exist during some testing.
     } catch (CommandNotFoundException $exception) {
-    }
-  }
-
-  /**
-   * When a console command terminates, execute a corresponding script from a local composer.json.
-   */
-  public function onConsoleTerminate(ConsoleTerminateEvent $event): void {
-    /** @var CommandBase $command */
-    $command = $event->getCommand();
-    if ($event->getInput()->hasOption('no-script') && $event->getInput()->getOption('no-scripts')) {
-      return;
-    }
-    if (is_a($command, CommandBase::class)) {
-      $composer_json_filepath = Path::join($command->getRepoRoot(), 'composer.json');
-      if (file_exists($composer_json_filepath)) {
-        $composer_json = json_decode($command->localMachineHelper->readFile($composer_json_filepath), TRUE);
-        if ($composer_json) {
-          $command_name = $command->getName();
-          $script_name = 'post-acli-' . $command_name;
-          if (array_key_exists('scripts', $composer_json) && array_key_exists($script_name, $composer_json['scripts'])) {
-            $event->getOutput()->writeln("Executing composer script `$script_name` defined in `$composer_json_filepath`", OutputInterface::VERBOSITY_VERBOSE);
-            $event->getOutput()->writeln($script_name);
-            $command->localMachineHelper->execute(['composer', 'run-script', $script_name]);
-          }
-          else {
-            $event->getOutput()->writeln("Composer script `$script_name` does not exist in `$composer_json_filepath`, skipping.", OutputInterface::VERBOSITY_VERBOSE);
-          }
-        }
-      }
     }
   }
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -158,6 +158,7 @@ class ExceptionListener {
           $script_name = 'post-acli-' . $command_name;
           if (array_key_exists('scripts', $composer_json) && array_key_exists($script_name, $composer_json['scripts'])) {
             $event->getOutput()->writeln("Executing composer script `$script_name` defined in `$composer_json_filepath`", OutputInterface::VERBOSITY_VERBOSE);
+            $event->getOutput()->writeln($script_name);
             $command->localMachineHelper->execute(['composer', 'run-script', $script_name]);
           }
           else {

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -2,13 +2,17 @@
 
 namespace Acquia\Cli\EventListener;
 
+use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Exception\ApiErrorException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\PathUtil\Path;
 
 class ExceptionListener {
 
@@ -133,6 +137,28 @@ class ExceptionListener {
       }
       // This command may not exist during some testing.
     } catch (CommandNotFoundException $exception) {
+    }
+  }
+
+  /**
+   * When a console command terminates, execute a corresponding script from a local composer.json.
+   */
+  public function onConsoleTerminate(ConsoleTerminateEvent $event): void {
+    /** @var CommandBase $command */
+    $command = $event->getCommand();
+    if (is_a($command, CommandBase::class)) {
+      $composer_json_filepath = Path::join($command->getRepoRoot(), 'composer.json');
+      if (file_exists($composer_json_filepath)) {
+        $composer_json = json_decode($command->localMachineHelper->readFile($composer_json_filepath), TRUE);
+        if ($composer_json) {
+          $command_name = $command->getName();
+          $script_name = 'post-acli-' . $command_name;
+          $event->getOutput()->writeln("Executing $script_name from $composer_json_filepath if it exists", OutputInterface::VERBOSITY_VERBOSE);
+          if (array_key_exists('scripts', $composer_json) && array_key_exists($script_name, $composer_json['scripts'])) {
+            $command->localMachineHelper->execute(['composer', 'run-script', $script_name]);
+          }
+        }
+      }
     }
   }
 

--- a/src/EventListener/TerminateListener.php
+++ b/src/EventListener/TerminateListener.php
@@ -9,32 +9,36 @@ use Webmozart\PathUtil\Path;
 
 class TerminateListener {
 
-    /**
-     * When a console command terminates, execute a corresponding script from a local composer.json.
-     */
-    public function onConsoleTerminate(ConsoleTerminateEvent $event): void {
-        /** @var CommandBase $command */
-        $command = $event->getCommand();
-        if ($event->getInput()->hasOption('no-script') && $event->getInput()->getOption('no-scripts')) {
-            return;
-        }
-        if (is_a($command, CommandBase::class)) {
-            $composer_json_filepath = Path::join($command->getRepoRoot(), 'composer.json');
-            if (file_exists($composer_json_filepath)) {
-                $composer_json = json_decode($command->localMachineHelper->readFile($composer_json_filepath), TRUE);
-                if ($composer_json) {
-                    $command_name = $command->getName();
-                    $script_name = 'post-acli-' . $command_name;
-                    if (array_key_exists('scripts', $composer_json) && array_key_exists($script_name, $composer_json['scripts'])) {
-                        $event->getOutput()->writeln("Executing composer script `$script_name` defined in `$composer_json_filepath`", OutputInterface::VERBOSITY_VERBOSE);
-                        $event->getOutput()->writeln($script_name);
-                        $command->localMachineHelper->execute(['composer', 'run-script', $script_name]);
-                    }
-                    else {
-                        $event->getOutput()->writeln("Composer script `$script_name` does not exist in `$composer_json_filepath`, skipping.", OutputInterface::VERBOSITY_VERBOSE);
-                    }
-                }
-            }
-        }
+  /**
+   * When a console command terminates successfully, execute a corresponding script from a local composer.json.
+   */
+  public function onConsoleTerminate(ConsoleTerminateEvent $event): void {
+    /** @var CommandBase $command */
+    $command = $event->getCommand();
+    // If a command has the --no-script option and it's passed, do not execute post scripts.
+    if ($event->getInput()->hasOption('no-script') && $event->getInput()->getOption('no-scripts')) {
+      return;
     }
+    // Only successful commands should be executed.
+    if (is_a($command, CommandBase::class) && $event->getExitCode() === 0) {
+      $composer_json_filepath = Path::join($command->getRepoRoot(), 'composer.json');
+      if (file_exists($composer_json_filepath)) {
+        $composer_json = json_decode($command->localMachineHelper->readFile($composer_json_filepath), TRUE);
+        // Protect against invalid JSON.
+        if ($composer_json) {
+          $command_name = $command->getName();
+          // Replace colons with hypens. E.g., pull:db becomes pull-db.
+          $script_name = 'post-acli-' . str_replace(':', '-', $command_name);
+          if (array_key_exists('scripts', $composer_json) && array_key_exists($script_name, $composer_json['scripts'])) {
+            $event->getOutput()->writeln("Executing composer script `$script_name` defined in `$composer_json_filepath`", OutputInterface::VERBOSITY_VERBOSE);
+            $event->getOutput()->writeln($script_name);
+            $command->localMachineHelper->execute(['composer', 'run-script', $script_name]);
+          }
+          else {
+            $event->getOutput()->writeln("Composer script `$script_name` does not exist in `$composer_json_filepath`, skipping.", OutputInterface::VERBOSITY_VERBOSE);
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/EventListener/TerminateListener.php
+++ b/src/EventListener/TerminateListener.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Acquia\Cli\EventListener;
+
+use Acquia\Cli\Command\CommandBase;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\PathUtil\Path;
+
+class TerminateListener {
+
+    /**
+     * When a console command terminates, execute a corresponding script from a local composer.json.
+     */
+    public function onConsoleTerminate(ConsoleTerminateEvent $event): void {
+        /** @var CommandBase $command */
+        $command = $event->getCommand();
+        if ($event->getInput()->hasOption('no-script') && $event->getInput()->getOption('no-scripts')) {
+            return;
+        }
+        if (is_a($command, CommandBase::class)) {
+            $composer_json_filepath = Path::join($command->getRepoRoot(), 'composer.json');
+            if (file_exists($composer_json_filepath)) {
+                $composer_json = json_decode($command->localMachineHelper->readFile($composer_json_filepath), TRUE);
+                if ($composer_json) {
+                    $command_name = $command->getName();
+                    $script_name = 'post-acli-' . $command_name;
+                    if (array_key_exists('scripts', $composer_json) && array_key_exists($script_name, $composer_json['scripts'])) {
+                        $event->getOutput()->writeln("Executing composer script `$script_name` defined in `$composer_json_filepath`", OutputInterface::VERBOSITY_VERBOSE);
+                        $event->getOutput()->writeln($script_name);
+                        $command->localMachineHelper->execute(['composer', 'run-script', $script_name]);
+                    }
+                    else {
+                        $event->getOutput()->writeln("Composer script `$script_name` does not exist in `$composer_json_filepath`, skipping.", OutputInterface::VERBOSITY_VERBOSE);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -5,6 +5,7 @@ namespace Acquia\Cli\Helpers;
 use Acquia\Cli\Exception\AcquiaCliException;
 use loophp\phposinfo\OsInfo;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -28,12 +29,17 @@ class LocalMachineHelper {
   private $installedBinaries = [];
 
   /**
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param InputInterface $input
+   * @param OutputInterface $output
    */
-  public function __construct(InputInterface $input, OutputInterface $output) {
+  public function __construct(
+      InputInterface $input,
+      OutputInterface $output,
+      LoggerInterface $logger
+  ) {
     $this->input = $input;
     $this->output = $output;
+    $this->setLogger($logger);
   }
 
   /**

--- a/src/Helpers/SshHelper.php
+++ b/src/Helpers/SshHelper.php
@@ -14,23 +14,28 @@ class SshHelper implements LoggerAwareInterface {
 
   use LoggerAwareTrait;
 
-  /** @var \Symfony\Component\Console\Output\OutputInterface */
+  /** @var OutputInterface */
   private $output;
 
   /**
-   * @var \Acquia\Cli\Helpers\LocalMachineHelper
+   * @var LocalMachineHelper
    */
   private $localMachineHelper;
 
   /**
    * SshHelper constructor.
    *
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   * @param \Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
+   * @param OutputInterface $output
+   * @param LocalMachineHelper $localMachineHelper
    */
-  public function __construct(OutputInterface $output, LocalMachineHelper $localMachineHelper) {
+  public function __construct(
+      OutputInterface $output,
+      LocalMachineHelper $localMachineHelper,
+      LoggerInterface $logger
+  ) {
     $this->output = $output;
     $this->localMachineHelper = $localMachineHelper;
+    $this->setLogger($logger);;
   }
 
   /**

--- a/src/Helpers/SshHelper.php
+++ b/src/Helpers/SshHelper.php
@@ -27,6 +27,7 @@ class SshHelper implements LoggerAwareInterface {
    *
    * @param OutputInterface $output
    * @param LocalMachineHelper $localMachineHelper
+   * @param LoggerInterface $logger
    */
   public function __construct(
       OutputInterface $output,
@@ -35,7 +36,7 @@ class SshHelper implements LoggerAwareInterface {
   ) {
     $this->output = $output;
     $this->localMachineHelper = $localMachineHelper;
-    $this->setLogger($logger);;
+    $this->setLogger($logger);
   }
 
   /**

--- a/tests/fixtures/project/composer.json
+++ b/tests/fixtures/project/composer.json
@@ -1,5 +1,8 @@
 {
   "scripts":{
+    "pre-acli-hello-world": [
+      "echo \"good morning world\""
+    ],
     "post-acli-hello-world": [
       "echo \"goodbye world\""
     ]

--- a/tests/fixtures/project/composer.json
+++ b/tests/fixtures/project/composer.json
@@ -1,4 +1,9 @@
 {
+  "scripts":{
+    "post-acli-hello-world": [
+      "echo \"goodbye world\""
+    ]
+  },
   "extra": {
     "drupal-scaffold": {
       "locations": {

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -4,8 +4,10 @@ namespace Acquia\Cli\Tests\Application;
 
 use Acquia\Cli\Application;
 use Acquia\Cli\CloudApi\ClientService;
+use Acquia\Cli\Helpers\LocalMachineHelper;
 use Acquia\Cli\Kernel;
 use Acquia\Cli\Tests\TestBase;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -45,6 +47,15 @@ class ExceptionApplicationTest extends TestBase {
     $input = new ArrayInput($args);
     $input->setInteractive(FALSE);
     $this->kernel->getContainer()->set(InputInterface::class, $input);
+  }
+
+  public function testPostScripts(): void {
+    $this->mockAccountRequest();
+    $this->setInput([
+          'command' => 'hello-world',
+      ]);
+    $buffer = $this->runApp();
+    self::assertStringContainsString('post-acli-hello-world', $buffer);
   }
 
   public function testInvalidApiCreds(): void {
@@ -115,8 +126,10 @@ class ExceptionApplicationTest extends TestBase {
    * @return string
    */
   protected function runApp(): string {
+    putenv("ACLI_REPO_ROOT=" . $this->projectFixtureDir);
     $input = $this->kernel->getContainer()->get(InputInterface::class);
     $output = $this->kernel->getContainer()->get(OutputInterface::class);
+    /** @var Application $application */
     $application = $this->kernel->getContainer()->get(Application::class);
     $application->setAutoExit(FALSE);
     // Set column width to prevent wrapping and string assertion failures.

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -49,6 +49,15 @@ class ExceptionApplicationTest extends TestBase {
     $this->kernel->getContainer()->set(InputInterface::class, $input);
   }
 
+  public function testPreScripts(): void {
+    $this->mockAccountRequest();
+    $this->setInput([
+          'command' => 'hello-world',
+      ]);
+    $buffer = $this->runApp();
+    self::assertStringContainsString('pre-acli-hello-world', $buffer);
+  }
+
   public function testPostScripts(): void {
     $this->mockAccountRequest();
     $this->setInput([

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -201,7 +201,6 @@ abstract class CommandTestBase extends TestBase {
    */
   protected function mockLocalMachineHelper(): ObjectProphecy {
     $local_machine_helper = $this->prophet->prophesize(LocalMachineHelper::class);
-    $local_machine_helper->setLogger(Argument::type(ConsoleLogger::class))->shouldBeCalled();
     $local_machine_helper->useTty()->willReturn(FALSE);
     $local_machine_helper->getLocalFilepath(Path::join($this->dataDir, 'acquia-cli.json'))->willReturn(Path::join($this->dataDir, 'acquia-cli.json'));
 
@@ -213,7 +212,6 @@ abstract class CommandTestBase extends TestBase {
    */
   protected function mockSshHelper(): ObjectProphecy {
     $ssh_helper = $this->prophet->prophesize(SshHelper::class);
-    $ssh_helper->setLogger(Argument::type(ConsoleLogger::class))->shouldBeCalled();
     return $ssh_helper;
   }
 

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -13,7 +13,6 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -364,7 +364,8 @@ class ApiCommandTest extends CommandTestBase {
       $this->clientServiceProphecy->reveal(),
       $this->logStreamManagerProphecy->reveal(),
       $this->sshHelper,
-      $this->sshDir
+      $this->sshDir,
+      $this->logger
     );
     $api_commands = $api_command_helper->getApiCommands();
     foreach ($api_commands as $api_command) {

--- a/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
@@ -25,7 +25,8 @@ class ApiListCommandTest extends CommandTestBase {
       $this->clientServiceProphecy->reveal(),
       $this->logStreamManagerProphecy->reveal(),
       $this->sshHelper,
-      $this->sshDir
+      $this->sshDir,
+      $this->logger
     );
     $this->application->addCommands($api_command_helper->getApiCommands());
   }

--- a/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
@@ -65,7 +65,7 @@ class IdeXdebugToggleCommandTest extends IdeRequiredTestBase {
     $this->assertFileExists($this->xdebugFilePath);
     $this->assertStringContainsString('zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath));
     $this->assertStringNotContainsString(';zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath));
-    $this->assertStringContainsString("Enabling Xdebug PHP extension in {$this->xdebugFilePath}...", $this->getDisplay());
+    $this->assertStringContainsString("Xdebug PHP extension enabled", $this->getDisplay());
   }
 
   /**
@@ -78,7 +78,7 @@ class IdeXdebugToggleCommandTest extends IdeRequiredTestBase {
     $this->executeCommand([], []);
     $this->assertFileExists($this->xdebugFilePath);
     $this->assertStringContainsString(';zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath));
-    $this->assertStringContainsString("Disabling Xdebug PHP extension in {$this->xdebugFilePath}...", $this->getDisplay());
+    $this->assertStringContainsString("Xdebug PHP extension disabled", $this->getDisplay());
   }
 
 }

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -26,12 +26,15 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     return $this->injectCommand(PullDatabaseCommand::class);
   }
 
+  /**
+   * @throws \Exception
+   */
   public function testPullDatabases(): void {
     $this->setupPullDatabase(TRUE, TRUE, TRUE, TRUE, TRUE);
     $inputs = $this->getInputs();
 
     $this->executeCommand([
-      '--no-scripts' => TRUE,
+    '--no-scripts' => TRUE,
     ], $inputs);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();

--- a/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
@@ -68,7 +68,7 @@ class DrushCommandTest extends SshCommandTestBase {
       ->willReturn($process->reveal())
       ->shouldBeCalled();
     $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->command->sshHelper = new SshHelper($this->output, $local_machine_helper->reveal());
+    $this->command->sshHelper = new SshHelper($this->output, $local_machine_helper->reveal(), $this->logger);
     $this->executeCommand($args);
 
     // Assert.

--- a/tests/phpunit/src/Commands/Remote/SshCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTest.php
@@ -44,7 +44,7 @@ class SshCommandTest extends SshCommandTestBase {
       ->willReturn($process->reveal())
       ->shouldBeCalled();
     $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->command->sshHelper = new SshHelper($this->output, $local_machine_helper->reveal());
+    $this->command->sshHelper = new SshHelper($this->output, $local_machine_helper->reveal(), $this->logger);
 
     $args = [
       'alias' => 'devcloud2.dev',

--- a/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
@@ -35,7 +35,6 @@ abstract class SshCommandTestBase extends CommandTestBase {
     $process->getExitCode()->willReturn(0);
     $local_machine_helper = $this->prophet->prophesize(LocalMachineHelper::class);
     $local_machine_helper->useTty()->willReturn(FALSE)->shouldBeCalled();
-    $local_machine_helper->setLogger(Argument::type(ConsoleLogger::class))->shouldBeCalled();
     return [$process, $local_machine_helper];
   }
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -313,7 +313,7 @@ abstract class TestBase extends TestCase {
       $this->logStreamManagerProphecy->reveal(),
       $this->sshHelper,
       $this->sshDir,
-        $this->logger
+      $this->logger
     );
   }
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -227,10 +227,8 @@ abstract class TestBase extends TestCase {
     $this->output = $output;
     $this->logger = new ConsoleLogger($output);
     $this->localMachineHelper = new LocalMachineHelper($input, $output, $this->logger);
-    $this->localMachineHelper->setLogger($this->logger);
     $this->telemetryHelper = new TelemetryHelper($input, $output, $this->clientServiceProphecy->reveal(), $this->datastoreAcli, $this->datastoreCloud);
     $this->sshHelper = new SshHelper($output, $this->localMachineHelper, $this->logger);
-    $this->sshHelper->setLogger($this->logger);
   }
 
   /**

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -226,10 +226,10 @@ abstract class TestBase extends TestCase {
     $this->input = $input;
     $this->output = $output;
     $this->logger = new ConsoleLogger($output);
-    $this->localMachineHelper = new LocalMachineHelper($input, $output);
+    $this->localMachineHelper = new LocalMachineHelper($input, $output, $this->logger);
     $this->localMachineHelper->setLogger($this->logger);
     $this->telemetryHelper = new TelemetryHelper($input, $output, $this->clientServiceProphecy->reveal(), $this->datastoreAcli, $this->datastoreCloud);
-    $this->sshHelper = new SshHelper($output, $this->localMachineHelper);
+    $this->sshHelper = new SshHelper($output, $this->localMachineHelper, $this->logger);
     $this->sshHelper->setLogger($this->logger);
   }
 
@@ -312,7 +312,8 @@ abstract class TestBase extends TestCase {
       $this->clientServiceProphecy->reveal(),
       $this->logStreamManagerProphecy->reveal(),
       $this->sshHelper,
-      $this->sshDir
+      $this->sshDir,
+        $this->logger
     );
   }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #641

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

After any ACLI command is run, ACLI will check `$(pwd)/composer.json` for a `post-acli-($command name)` script and execute it if present. E.g., `post-acli-db:pull`.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `cd` into a Drupal application directory containing a composer.json.
4. Add an entry to the `scripts` key in the composer.json:
```
        "post-acli-ide-list": [
            "echo \"Hello world\""
        ]
```
5. Run `[path to acli]/bin/acli ide-list -vvv`
6. Observe:
```
Executing composer script `post-acli-ide-list` defined in `/Users/matt.grasmick/Sites/projects/amad9/composer.json`
> echo "Hello world"
Hello world
[notice] Command: 'composer' 'run-script' 'post-acli-ide-list' [Exit: 0]
```

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [x] Manual testing by a reviewer
