### PR TITLE
Pull command fails due to missing variable default values

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -127,7 +127,7 @@ abstract class PullCommandBase extends CommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  protected function pullDatabase(InputInterface $input, OutputInterface $output, bool $on_demand, bool $no_import): void {
+  protected function pullDatabase(InputInterface $input, OutputInterface $output, bool $on_demand = FALSE, bool $no_import = FALSE): void {
     if (!$no_import) {
       // Verify database connection.
       $this->connectToLocalDatabase($this->getLocalDbHost(), $this->getLocalDbUser(), $this->getLocalDbName(), $this->getLocalDbPassword(), $this->getOutputCallback($output, $this->checklist));


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->

```
acli pull --no-code --no-files
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Acquia\Cli\Command\Pull\PullCommandBase::pullDatabase(), 2 passed in phar:///usr/local/bin/acli/src/Command/Pull/PullCommand.php on line 59 and exactly 4 expected in phar:///usr/local/bin/acli/src/Command/Pull/PullCommandBase.php:112
Stack trace:
#0 phar:///usr/local/bin/acli/src/Command/Pull/PullCommand.php(59): Acquia\Cli\Command\Pull\PullCommandBase->pullDatabase(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#1 phar:///usr/local/bin/acli/vendor/symfony/console/Command/Command.php(299): Acquia\Cli\Command\Pull\PullCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 phar:///usr/local/bin/acli/src/Command/CommandBase.php(409): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 phar:///usr/local/bin/acli/vendor/symfony/console/Application.php(996): Acquia\Cli\Command\CommandBase->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 phar:///usr/local/bin/acli/vendor/symfony/console/Application.php(295): Symfony\Component\Console\Application->doRunCommand(Object(Acquia\Cli\Command\Pull\PullCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 phar:///usr/local/bin/acli/vendor/symfony/console/Application.php(167): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 phar:///usr/local/bin/acli/bin/acli(86): Symfony\Component\Console\Application->run()
#7 /usr/local/bin/acli(14): require('phar:///usr/loc...')
#8 {main}
  thrown in phar:///usr/local/bin/acli/src/Command/Pull/PullCommandBase.php on line 112
```

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

We could instead add `--on-demand` and `--no-import` options to the `acli pull` command.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `acli pull --no-code --no-files`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
