### PR TITLE
Fixes #599: Autoselect db and files if site is selected.

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -53,12 +53,12 @@ abstract class PullCommandBase extends CommandBase {
   private $site;
 
   /**
- * @param $environment
- * @param $database
- * @param $backup_response
- *
- * @return string
- */
+   * @param $environment
+   * @param $database
+   * @param $backup_response
+   *
+   * @return string
+   */
   public static function getBackupPath($environment, $database, $backup_response): string {
     // Filename roughly matches what you'd get with a manual download from Cloud UI.
     $filename = implode('-', [
@@ -176,7 +176,7 @@ abstract class PullCommandBase extends CommandBase {
     $this->setDirAndRequireProjectCwd($input);
     $source_environment = $this->determineEnvironment($input, $output, TRUE);
     $this->checklist->addItem('Copying Drupal\'s public files from the Cloud Platform');
-    $site= $this->determineSite($source_environment, $input);
+    $site = $this->determineSite($source_environment, $input);
     $this->rsyncFilesFromCloud($source_environment, $this->getOutputCallback($output, $this->checklist), $site);
     $this->checklist->completePreviousItem();
   }
@@ -604,11 +604,11 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   /**
-   * @param callable $output_callback
+   * @param callable|null $output_callback
    *
    * @throws \Exception
    */
-  protected function runComposerScripts($output_callback = NULL): void {
+  protected function runComposerScripts(callable $output_callback = NULL): void {
     if (file_exists($this->dir . '/composer.json') && $this->localMachineHelper->commandExists('composer')) {
       $this->checklist->addItem("Installing Composer dependencies");
       $this->composerInstall($output_callback);
@@ -621,23 +621,25 @@ abstract class PullCommandBase extends CommandBase {
 
   /**
    * @param $environment
-   * @return mixed
-   * @throws AcquiaCliException
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   *
+   * @return mixed|string
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   protected function determineSite($environment, InputInterface $input) {
     if (isset($this->site)) {
       return $this->site;
     }
+
     if ($input->hasArgument('site') && $input->getArgument('site')) {
       return $input->getArgument('site');
     }
-    if ($this->isAcsfEnv($environment)) {
+    elseif ($this->isAcsfEnv($environment)) {
       $site = $this->promptChooseAcsfSite($environment);
     }
     else {
       $site = $this->promptChooseCloudSite($environment);
     }
-
     $this->site = $site;
 
     return $site;
@@ -658,7 +660,6 @@ abstract class PullCommandBase extends CommandBase {
     else {
       $source_dir = $this->getCloudSitesPath($chosen_environment, $sitegroup) . "/$site/files";
     }
-    $this->site = $site;
     $destination = $this->dir . '/docroot/sites/' . $site . '/';
     $this->localMachineHelper->checkRequiredBinariesExist(['rsync']);
     $this->localMachineHelper->getFilesystem()->mkdir($destination);
@@ -1013,8 +1014,7 @@ abstract class PullCommandBase extends CommandBase {
     $database
   ) {
     $database_backups = new DatabaseBackups($acquia_cloud_client);
-    $backups_response = $database_backups->getAll($environment->uuid,
-      $database->name);
+    $backups_response = $database_backups->getAll($environment->uuid, $database->name);
     if (!count($backups_response)) {
       $this->logger->warning('No existing backups found, creating an on-demand backup now. This will take some time depending on the size of the database.');
       $this->createBackup($environment, $database, $acquia_cloud_client);

--- a/tests/phpunit/src/Commands/InferApplicationTest.php
+++ b/tests/phpunit/src/Commands/InferApplicationTest.php
@@ -61,7 +61,6 @@ class InferApplicationTest extends CommandTestBase {
    *
    */
   public function testInferFailure(): void {
-
     $applications_response = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
 

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -40,6 +40,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
+    $this->assertStringContainsString('Choose a site [jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)]:', $output);
     $this->assertStringContainsString('jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)', $output);
   }
 
@@ -58,6 +59,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
+    $this->assertStringContainsString('Choose a site [jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)]:', $output);
     $this->assertStringContainsString('jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)', $output);
   }
 

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -40,9 +40,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
-    $this->assertStringContainsString('Choose a database', $output);
     $this->assertStringContainsString('jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)', $output);
-    $this->assertStringContainsString('profserv2 (default)', $output);
   }
 
   public function testPullDatabasesOnDemand(): void {
@@ -60,9 +58,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
-    $this->assertStringContainsString('Choose a database', $output);
     $this->assertStringContainsString('jxr5000596dev (oracletest1.dev-profserv2.acsitefactory.com)', $output);
-    $this->assertStringContainsString('profserv2 (default)', $output);
   }
 
   public function testPullDatabasesSiteArgument(): void {
@@ -70,7 +66,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $inputs = $this->getInputs();
 
     $this->executeCommand([
-      'site' => 'default',
+      'site' => 'jxr5000596dev',
       '--no-scripts' => TRUE,
     ], $inputs);
     $this->prophet->checkPredictions();
@@ -150,7 +146,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $selected_environment = $environments_response->_embedded->items[0];
     $this->createMockGitConfigFile();
     $databases_response = $this->mockDatabasesResponse($selected_environment);
-    $selected_database = $databases_response[array_search('profserv2', array_column($databases_response, 'name'))];
+    $selected_database = $databases_response[array_search('jxr5000596dev', array_column($databases_response, 'name'))];
     $database_backups_response = $this->mockDatabaseBackupsResponse($selected_environment, $selected_database->name, 1);
     $selected_backup = $database_backups_response->_embedded->items[0];
     $this->mockDownloadBackupResponse($selected_environment, $selected_database->name, 1);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #599 

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
When a user selects an ACSF site database, save that choice and re-use it for the files prompt.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
