### PR TITLE
Automated release failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
   build-release:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2


### PR DESCRIPTION
**Motivation**
Our last release failed because the Action did not have sufficient permissions to create a release: https://github.com/acquia/cli/runs/3634954570?check_suite_focus=true

This was missed in testing. I did verify that Actions releases worked on my fork, but didn't realize that Actions as a whole had entirely different permissions between my personal and Acquia orgs. I've since fixed that.

**Proposed changes**
Add necessary permissions.

**Testing steps**
See that the release succeeds on my fork, now that permissions are synced between the orgs: https://github.com/danepowell/cli/releases/tag/actions5

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
