### PR TITLE
Allow git url and branch to be passed to push:artifact.

### DIFF
--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -55,7 +55,7 @@ class PushArtifactCommand extends PullCommandBase {
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL
       . 'To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events')
       ->addUsage('--no-sanitize --dry-run # skip sanitization and Git push')
-      ->addUsage('--source-git-url=./git --source-git-url=example@svn-1.prod.hosting.acquia.com:example.git --git-branch=feature-source-branch');
+      ->addUsage('--dest-git-url=./git --dest-git-url=example@svn-1.prod.hosting.acquia.com:example.git --git-branch=main-build');
   }
 
   /**

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -215,7 +215,7 @@ class PushArtifactCommand extends PullCommandBase {
     $output_callback('out', 'Installing Composer production dependencies');
     $process = $this->localMachineHelper->execute(['composer', 'install', '--no-dev', '--no-interaction', '--optimize-autoloader'], $output_callback, $artifact_dir, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
     if (!$process->isSuccessful()) {
-      throw new AcquiaCliException("Unable to install composer dependencies: {message}", ['message' => $process->getOutput()]);
+      throw new AcquiaCliException("Unable to install composer dependencies: {message}", ['message' => $process->getOutput() . $process->getErrorOutput()]);
     }
   }
 

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -141,13 +141,15 @@ class PushArtifactCommand extends PullCommandBase {
 
     $output_callback('out', "Initializing Git in $artifact_dir");
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
+    // @todo Don't fetch anything? Start with bare repo?
     $process = $this->localMachineHelper->execute(['git', 'clone', '--depth=1', $vcs_url, $artifact_dir], $output_callback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Failed to clone repository from the Cloud Platform: {message}', ['message' => $process->getErrorOutput()]);
     }
-    $process = $this->localMachineHelper->execute(['git', 'fetch', 'depth=1', 'origin', $vcs_path], $output_callback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
+    $process = $this->localMachineHelper->execute(['git', 'fetch', '--depth=1', $vcs_url, $vcs_path], $output_callback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
     if (!$process->isSuccessful()) {
-      // Remote branch does not exist. just create it locally.
+      // Remote branch does not exist. Just create it locally. This will create
+      // the new branch off of the current commit.
       $process = $this->localMachineHelper->execute(['git', 'checkout', '-b', $vcs_path], $output_callback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
       if (!$process->isSuccessful()) {
         throw new AcquiaCliException("Could not checkout $vcs_path branch locally: {message}", ['message' => $process->getErrorOutput()]);

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -55,7 +55,7 @@ class PushArtifactCommand extends PullCommandBase {
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL
       . 'To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events')
       ->addUsage('--no-sanitize --dry-run # skip sanitization and Git push')
-      ->addUsage('--dest-git-url=./git --dest-git-url=example@svn-1.prod.hosting.acquia.com:example.git --git-branch=main-build');
+      ->addUsage('--dest-git-url=example@svn-1.prod.hosting.acquia.com:example.git --git-branch=main-build');
   }
 
   /**

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -76,7 +76,7 @@ class PushArtifactCommand extends PullCommandBase {
     $this->checklist = new Checklist($output);
 
     // @todo If only one of these options is set, throw an error.
-    if ($input->getOption('dest-git-url') && $input->getOption('git-branch')) {
+    if ($input->getOption('dest-git-url') && $input->getOption('dest-branch')) {
       $dest_git_url = $input->getOption('dest-git-url');
       $git_branch = $input->getOption('dest-branch');
     }
@@ -89,6 +89,7 @@ class PushArtifactCommand extends PullCommandBase {
       $dest_git_url = $environment->vcs->url;
       $git_branch = $environment->vcs->path;
     }
+    $this->io->info("The contents of $this->dir will be compiled into an artifact and pushed to the $git_branch on the ${dest_git_url} git remote");
 
     $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $output_callback = $this->getOutputCallback($output, $this->checklist);

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -49,13 +49,13 @@ class PushArtifactCommand extends PullCommandBase {
       ->addOption('no-sanitize', NULL, InputOption::VALUE_NONE, 'Do not sanitize the build artifact')
       ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Do not push changes to Acquia Cloud')
       ->addOption('dest-git-url', NULL, InputOption::VALUE_REQUIRED, 'The URL of your git repository to which the artifact branch will be pushed')
-      ->addOption('git-branch', NULL, InputOption::VALUE_REQUIRED, 'The git source branch to generate an artifact from')
+      ->addOption('dest-branch', NULL, InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
       ->acceptEnvironmentId()
       ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL
       . 'To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events')
       ->addUsage('--no-sanitize --dry-run # skip sanitization and Git push')
-      ->addUsage('--dest-git-url=example@svn-1.prod.hosting.acquia.com:example.git --git-branch=main-build');
+      ->addUsage('--dest-git-url=example@svn-1.prod.hosting.acquia.com:example.git --dest-branch=main-build');
   }
 
   /**
@@ -70,8 +70,6 @@ class PushArtifactCommand extends PullCommandBase {
     $this->setDirAndRequireProjectCwd($input);
     $is_dirty = $this->isLocalGitRepoDirty();
     $commit_hash = $this->getLocalGitCommitHash();
-    // @todo Check if local repository is up to date. Given that this command uses the remote code as the source for a build,
-    // we should ensure that the local repo is in sync with remote.
     if ($is_dirty) {
       throw new AcquiaCliException('Pushing code was aborted because your local Git repository has uncommitted changes. Please either commit, reset, or stash your changes via git.');
     }
@@ -80,7 +78,7 @@ class PushArtifactCommand extends PullCommandBase {
     // @todo If only one of these options is set, throw an error.
     if ($input->getOption('dest-git-url') && $input->getOption('git-branch')) {
       $dest_git_url = $input->getOption('dest-git-url');
-      $git_branch = $input->getOption('git-branch');
+      $git_branch = $input->getOption('dest-branch');
     }
     else {
       $this->io->writeln('<info>You must select an environment with a Git branch deployed</info>');

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -283,7 +283,7 @@ class PushArtifactCommand extends PullCommandBase {
   protected function push(Closure $output_callback, string $artifact_dir, string $vcs_url, string $git_branch):void {
     $output_callback('out', "Pushing changes to Acquia Git ($vcs_url)");
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
-    $this->localMachineHelper->execute(['git', 'push', $vcs_url, $git_branch . '-branch'], $output_callback, $artifact_dir, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
+    $this->localMachineHelper->execute(['git', 'push', $vcs_url, $git_branch . '-build'], $output_callback, $artifact_dir, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
   }
 
   /**

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -79,7 +79,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
     $local_machine_helper->checkRequiredBinariesExist(['git'])->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'clone', '--depth', '1', '--branch', $vcs_path, $vcs_url, $artifact_dir], Argument::type('callable'), NULL, TRUE)
+    $local_machine_helper->execute(['git', 'clone', '--depth=1', '--branch', $vcs_path, $vcs_url, $artifact_dir], Argument::type('callable'), NULL, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -125,7 +125,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
       ->willReturn($process->reveal())->shouldBeCalled();
     $local_machine_helper->execute(['git', 'commit', '-m', "Automated commit by Acquia CLI (source commit: $commit_hash)"], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'push', $git_url, $git_branch . '-build'], Argument::type('callable'), $artifact_dir, TRUE)
+    $local_machine_helper->execute(['git', 'push', $git_url, $git_branch], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -47,7 +47,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $this->mockLocalGitConfig($local_machine_helper, $artifact_dir);
     $this->mockComposerInstall($local_machine_helper, $artifact_dir);
     $this->mockReadComposerJson($local_machine_helper, $artifact_dir);
-    $this->mockGitAddCommitPush($local_machine_helper, $artifact_dir, $commit_hash);
+    $this->mockGitAddCommitPush($local_machine_helper, $artifact_dir, $commit_hash, $selected_environment->vcs->url, $selected_environment->vcs->path);
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -109,8 +109,11 @@ class PushArtifactCommandTest extends PullCommandTestBase {
   /**
    * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
    * @param $artifact_dir
+   * @param $commit_hash
+   * @param $git_url
+   * @param $git_branch
    */
-  protected function mockGitAddCommitPush(ObjectProphecy $local_machine_helper, $artifact_dir, $commit_hash): void {
+  protected function mockGitAddCommitPush(ObjectProphecy $local_machine_helper, $artifact_dir, $commit_hash, $git_url, $git_branch): void {
     $process = $this->prophet->prophesize(Process::class);
     $local_machine_helper->execute(['git', 'add', '-A'], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
@@ -122,7 +125,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
       ->willReturn($process->reveal())->shouldBeCalled();
     $local_machine_helper->execute(['git', 'commit', '-m', "Automated commit by Acquia CLI (source commit: $commit_hash)"], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'push'], Argument::type('callable'), $artifact_dir, TRUE)
+    $local_machine_helper->execute(['git', 'push', $git_url, $git_branch . '-build'], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -79,7 +79,9 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
     $local_machine_helper->checkRequiredBinariesExist(['git'])->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'clone', '--depth=1', '--branch', $vcs_path, $vcs_url, $artifact_dir], Argument::type('callable'), NULL, TRUE)
+    $local_machine_helper->execute(['git', 'clone', '--depth=1', $vcs_url, $artifact_dir], Argument::type('callable'), NULL, TRUE)
+      ->willReturn($process->reveal())->shouldBeCalled();
+    $local_machine_helper->execute(['git', 'fetch', '--depth=1', $vcs_url, $vcs_path], Argument::type('callable'), NULL, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -81,7 +81,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $local_machine_helper->checkRequiredBinariesExist(['git'])->shouldBeCalled();
     $local_machine_helper->execute(['git', 'clone', '--depth=1', $vcs_url, $artifact_dir], Argument::type('callable'), NULL, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'fetch', '--depth=1', $vcs_url, $vcs_path], Argument::type('callable'), NULL, TRUE)
+    $local_machine_helper->execute(['git', 'fetch', '--depth=1', $vcs_url, $vcs_path], Argument::type('callable'), Argument::type('string'), TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 
@@ -104,6 +104,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
   protected function mockComposerInstall(ObjectProphecy $local_machine_helper, $artifact_dir): void {
     $local_machine_helper->checkRequiredBinariesExist(['composer'])->shouldBeCalled();
     $process = $this->prophet->prophesize(Process::class);
+    $process->isSuccessful()->willReturn(TRUE);
     $local_machine_helper->execute(['composer', 'install', '--no-dev', '--no-interaction', '--optimize-autoloader'], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
@@ -148,7 +149,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
         ]
       ]
     ]);
-    $local_machine_helper->readFile(Path::join($artifact_dir, 'composer.json'))
+    $local_machine_helper->readFile(Path::join($this->projectFixtureDir, 'composer.json'))
       ->willReturn($composer_json);
     $local_machine_helper->readFile(Path::join($artifact_dir, 'docroot', 'core', 'composer.json'))
       ->willReturn($composer_json);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Allow `push:artifact` to be used non-interactively by adding options for dest-git-url and dest-git-branch.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
* Add new options to `push:artifact` command

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer:
- `acli push:artifact --source-git-url=[something] --dest-git-url=[something] --git-branch=[something]`
