### PR TITLE
Do not check source dir for core dir.

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -513,16 +513,20 @@ abstract class PullCommandBase extends CommandBase {
   protected function isLocalGitRepoDirty(): bool {
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
     $process = $this->localMachineHelper->execute([
+      // Problem with this is that it stages changes for the user. They may
+      // not want that.
       'git',
-      'status',
-      '--short',
+      'add',
+      '.',
+      '&&',
+      'git',
+      'diff-index',
+      '--cached',
+      '--quiet',
+      'HEAD',
     ], NULL, $this->dir, FALSE);
 
-    if (!$process->isSuccessful()) {
-      throw new AcquiaCliException("Unable to determine if local git repository is dirty.");
-    }
-
-    return (bool) $process->getOutput();
+    return !$process->isSuccessful();
   }
 
   protected function getLocalGitCommitHash(): string {

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -512,19 +512,11 @@ abstract class PullCommandBase extends CommandBase {
    */
   protected function isLocalGitRepoDirty(): bool {
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
-    $process = $this->localMachineHelper->execute([
+    $process = $this->localMachineHelper->executeFromCmd(
       // Problem with this is that it stages changes for the user. They may
       // not want that.
-      'git',
-      'add',
-      '.',
-      '&&',
-      'git',
-      'diff-index',
-      '--cached',
-      '--quiet',
-      'HEAD',
-    ], NULL, $this->dir, FALSE);
+      'git add . && git diff-index --cached --quiet HEAD',
+     NULL, $this->dir, FALSE);
 
     return !$process->isSuccessful();
   }

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -51,6 +51,11 @@ class PushArtifactCommand extends PullCommandBase {
   private $drupalCorePath;
 
   /**
+   * @var string
+   */
+  private $docrootPath;
+
+  /**
    * {inheritdoc}.
    */
   protected function configure(): void {
@@ -79,7 +84,8 @@ class PushArtifactCommand extends PullCommandBase {
     $this->setDirAndRequireProjectCwd($input);
     $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $this->composerJsonPath = Path::join($this->dir, 'composer.json');
-    $this->drupalCorePath = Path::join($this->dir, 'docroot', 'core');
+    $this->docrootPath = Path::join($this->dir, 'docroot');
+    $this->drupalCorePath = Path::join($this->docrootPath, 'core');
     $this->validateSourceCode();
 
     $is_dirty = $this->isLocalGitRepoDirty();
@@ -373,7 +379,7 @@ class PushArtifactCommand extends PullCommandBase {
   protected function validateSourceCode(): void {
     $required_paths = [
       $this->composerJsonPath,
-      $this->drupalCorePath
+      $this->docrootPath
     ];
     foreach ($required_paths as $required_path) {
       if (!file_exists($required_path)) {

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -158,11 +158,16 @@ abstract class PullCommandTestBase extends CommandTestBase {
   ): void {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(!$failed)->shouldBeCalled();
-    $process->getOutput()->willReturn('')->shouldBeCalled();
     $local_machine_helper->execute([
       'git',
-      'status',
-      '--short',
+      'add',
+      '.',
+      '&&',
+      'git',
+      'diff-index',
+      '--cached',
+      '--quiet',
+      'HEAD',
     ], NULL, $cwd, FALSE)->willReturn($process->reveal())->shouldBeCalled();
   }
 

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -158,17 +158,7 @@ abstract class PullCommandTestBase extends CommandTestBase {
   ): void {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(!$failed)->shouldBeCalled();
-    $local_machine_helper->execute([
-      'git',
-      'add',
-      '.',
-      '&&',
-      'git',
-      'diff-index',
-      '--cached',
-      '--quiet',
-      'HEAD',
-    ], NULL, $cwd, FALSE)->willReturn($process->reveal())->shouldBeCalled();
+    $local_machine_helper->executeFromCmd('git add . && git diff-index --cached --quiet HEAD', NULL, $cwd, FALSE)->willReturn($process->reveal())->shouldBeCalled();
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Sometimes the `docroot/core` directory does not exist in the source because `composer install` was not run, and this is ok.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Check for only `docroot`.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
