### PR TITLE
Unfork consolidation/self-update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,25 +60,6 @@ To test changes in production mode, build and run `acli.phar` using this process
 1. Install Box (only need to do this once): `composer box-install`
 1. Compile phar: `composer box-compile`
 
-### Testing changes to consolidation/self-update
-
-If you are testing a change to `consolidation/self-update`, start by linking it to ACLI. Modify the repositories key in composer.json so that the url is the path to your working copy of `self-update` on your local machine, and optionally disable symlinking if Composer has autoloading complaints:
-```
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "../self-update",
-      "options": {
-        "symlink": false
-      }
-    }
-  ],
-```
-
-In the `composer.json` requirements section, then change the version string to match your locally checked-out branch. For instance: `"consolidation/self-update": "dev-foo as 1.1",` 
-
-Finally, run `composer update` and ensure your development copy of self-update is linked. Then follow the steps below to test the update command.
-
 ### Testing the `update` command
 
 Any changes to the `acli update` command should be manually tested using the following steps:

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,12 @@
         }
     ],
     "minimum-stability": "dev",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/danepowell/self-update.git"
-        }
-    ],
     "require": {
         "php": "^7.3 | ^8.0",
         "ext-json": "*",
         "acquia/drupal-environment-detector": "^1.2.0",
         "composer/semver": "^3.2",
-        "consolidation/self-update": "dev-allow-unstable as 1.1",
+        "consolidation/self-update": "2.0.0-alpha1 as 1.1",
         "cweagans/composer-patches": "^1.7",
         "kevinrob/guzzle-cache-middleware": "^3.3",
         "loophp/phposinfo": "^1.7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b17f0694cd38f668c30bbceca1441ae5",
+    "content-hash": "7367313ba7e490f4c97ee342025be317",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -199,20 +199,20 @@
         },
         {
             "name": "consolidation/self-update",
-            "version": "dev-allow-unstable",
+            "version": "2.0.0-alpha1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/danepowell/self-update.git",
-                "reference": "e3c4ce3290ac165fed97f6711e90c9550307e2d1"
+                "url": "https://github.com/consolidation/self-update.git",
+                "reference": "965cf22b9ac3bb994cd48d8706d92a89a8fcc877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/danepowell/self-update/zipball/e3c4ce3290ac165fed97f6711e90c9550307e2d1",
-                "reference": "e3c4ce3290ac165fed97f6711e90c9550307e2d1",
+                "url": "https://api.github.com/repos/consolidation/self-update/zipball/965cf22b9ac3bb994cd48d8706d92a89a8fcc877",
+                "reference": "965cf22b9ac3bb994cd48d8706d92a89a8fcc877",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1|^3.2",
+                "composer/semver": "^3.2",
                 "php": ">=5.5.0",
                 "symfony/console": "^2.8|^3|^4|^5",
                 "symfony/filesystem": "^2.5|^3|^4|^5"
@@ -231,11 +231,7 @@
                     "SelfUpdate\\": "src"
                 }
             },
-            "scripts": {
-                "release": [
-                    "./scripts/release VERSION"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -251,9 +247,10 @@
             ],
             "description": "Provides a self:update command for Symfony Console applications.",
             "support": {
-                "source": "https://github.com/danepowell/self-update/tree/allow-unstable"
+                "issues": "https://github.com/consolidation/self-update/issues",
+                "source": "https://github.com/consolidation/self-update/tree/2.0.0-alpha1"
             },
-            "time": "2021-05-26T12:32:45+00:00"
+            "time": "2021-10-05T04:23:36+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -8943,7 +8940,7 @@
     "aliases": [
         {
             "package": "consolidation/self-update",
-            "version": "dev-allow-unstable",
+            "version": "2.0.0.0-alpha1",
             "alias": "1.1",
             "alias_normalized": "1.1.0.0"
         },
@@ -8956,7 +8953,6 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "consolidation/self-update": 20,
         "symfony/filesystem": 20,
         "symfony/yaml": 20,
         "typhonius/acquia-php-sdk-v2": 20


### PR DESCRIPTION
**Motivation**
Upstream PR was merged: https://github.com/consolidation/self-update/pull/5

**Proposed changes**
Stop using our own fork of consolidation/self-update

We have to keep it aliased to 1.1 because of a conflict with https://github.com/typhonius/acquia-logstream

**Testing steps**

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Follow the steps to [test the update command](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#testing-the-update-command)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
