### PR TITLE
Fixes #676: Force commit docroot/autoload.php with push:artifact.

### DIFF
--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -306,7 +306,6 @@ class PushArtifactCommand extends PullCommandBase {
       throw new AcquiaCliException("Could not add files to artifact via git: {message}", ['message' => $process->getErrorOutput() . $process->getOutput()]);
     }
     foreach (array_merge($this->vendorDirs($artifact_dir), $this->scaffoldFiles($artifact_dir)) as $file) {
-
       $this->logger->debug("Forcibly adding $file");
       $this->localMachineHelper->execute(['git', 'add', '-f', $file], NULL, $artifact_dir, FALSE);
       if (!$process->isSuccessful()) {
@@ -384,6 +383,8 @@ class PushArtifactCommand extends PullCommandBase {
         $this->scaffoldFiles[] = str_replace('[web-root]', 'docroot/core', $file);
       }
     }
+    $this->scaffoldFiles[] = 'docroot/autoload.php';
+
     return $this->scaffoldFiles;
   }
 

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -124,6 +124,8 @@ class PushArtifactCommandTest extends PullCommandTestBase {
       ->willReturn($process->reveal())->shouldBeCalled();
     $local_machine_helper->execute(['git', 'add', '-f', 'docroot/core/index.php'], NULL, $artifact_dir, FALSE)
       ->willReturn($process->reveal())->shouldBeCalled();
+    $local_machine_helper->execute(['git', 'add', '-f', 'docroot/autoload.php'], NULL, $artifact_dir, FALSE)
+      ->willReturn($process->reveal())->shouldBeCalled();
     $local_machine_helper->execute(['git', 'add', '-f', 'docroot/core'], NULL, $artifact_dir, FALSE)
       ->willReturn($process->reveal())->shouldBeCalled();
     $local_machine_helper->execute(['git', 'add', '-f', 'vendor'], NULL, $artifact_dir, FALSE)


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Force add `docroot/autoload.php`.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Force add `docroot/autoload.php`.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Figure out why some codebases have a `docroot/.gitignore` with a line entry for `autoload.php`.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `push:artifact -vvv`.
4. Validate that `git add -f docroot/autoload.php` appears in the output.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
