### PR TITLE
Stricter static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,7 +135,7 @@
             "@unit"
         ],
         "stan": [
-            "phpstan analyze src tests bin"
+            "phpstan analyze"
         ],
         "coveralls": [
             "php-coveralls -vvv"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,6 @@
+parameters:
+	level: 1
+	paths:
+		- src
+		- tests
+		- bin

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -250,11 +250,9 @@ class ApiCommandHelper {
       $input_definition = array_merge($input_definition, $body_input_definition);
     }
 
-    if (isset($input_definition)) {
-      $command->setDefinition(new InputDefinition($input_definition));
-      $command->addUsage(rtrim($usage));
-      $this->addAliasUsageExamples($command, $input_definition, rtrim($usage));
-    }
+    $command->setDefinition(new InputDefinition($input_definition));
+    $command->addUsage(rtrim($usage));
+    $this->addAliasUsageExamples($command, $input_definition, rtrim($usage));
   }
 
   /**
@@ -316,6 +314,7 @@ class ApiCommandHelper {
    * @return string
    */
   protected function addPostArgumentUsageToExample($request_body, $prop_key, $param_definition, $type, $usage): string {
+    $request_body_schema = [];
     if (array_key_exists('application/x-www-form-urlencoded', $request_body['content'])) {
       $request_body_schema = $request_body['content']['application/x-www-form-urlencoded'];
     }
@@ -602,6 +601,7 @@ class ApiCommandHelper {
    * @return array
    */
   protected function getRequestBodyFromParameterSchema($schema, $acquia_cloud_spec): array {
+    $request_body_schema = [];
     if (array_key_exists('application/json', $schema['requestBody']['content'])) {
       $request_body_schema = $schema['requestBody']['content']['application/json']['schema'];
     }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1136,6 +1136,9 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       $parts = explode(':', $site_id);
       $site_prefix = $parts[1];
     }
+    else {
+      throw new AcquiaCliException("No applications found");
+    }
 
     if ($site_prefix !== $application_alias) {
       throw new AcquiaCliException("Application not found matching the alias {alias}", ['alias' => $application_alias]);

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -131,7 +131,7 @@ class IdeCreateCommand extends IdeCommandBase {
         $this->logger->debug($e->getMessage());
       }
     });
-    LoopHelper::addTimeoutToLoop($loop, 45, $spinner, $this->output);
+    LoopHelper::addTimeoutToLoop($loop, 45, $spinner);
 
     // Start the loop.
     try {

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -384,7 +384,7 @@ abstract class PullCommandBase extends CommandBase {
         $this->logger->debug($e->getMessage());
       }
     });
-    LoopHelper::addTimeoutToLoop($loop, 45, $spinner, $this->output);
+    LoopHelper::addTimeoutToLoop($loop, 45, $spinner);
 
     // Start the loop.
     $loop->run();

--- a/src/Command/Ssh/SshKeyUploadCommand.php
+++ b/src/Command/Ssh/SshKeyUploadCommand.php
@@ -68,6 +68,7 @@ class SshKeyUploadCommand extends SshKeyCommandBase {
   /**
    * @return array
    * @throws \Acquia\Cli\Exception\AcquiaCliException
+   * @throws \Exception
    */
   protected function determinePublicSshKey(): array {
     if ($this->input->getOption('filepath')) {
@@ -150,7 +151,8 @@ class SshKeyUploadCommand extends SshKeyCommandBase {
    * @return string
    * @throws \Exception
    */
-  protected function getLocalSshKeyContents($local_keys, string $chosen_local_key) {
+  protected function getLocalSshKeyContents(array $local_keys, string $chosen_local_key): string {
+    $filepath = '';
     foreach ($local_keys as $local_key) {
       if ($local_key->getFilename() === $chosen_local_key) {
         $filepath = $local_key->getRealPath();
@@ -187,7 +189,7 @@ class SshKeyUploadCommand extends SshKeyCommandBase {
         }
       }
     });
-    LoopHelper::addTimeoutToLoop($loop, 10, $spinner, $output);
+    LoopHelper::addTimeoutToLoop($loop, 10, $spinner);
     $loop->run();
   }
 

--- a/src/Command/WizardCommandBase.php
+++ b/src/Command/WizardCommandBase.php
@@ -263,7 +263,7 @@ abstract class WizardCommandBase extends SshKeyCommandBase {
         $this->logger->debug($exception->getMessage());
       }
     });
-    LoopHelper::addTimeoutToLoop($loop, 15, $spinner, $output);
+    LoopHelper::addTimeoutToLoop($loop, 15, $spinner);
     $loop->run();
   }
 

--- a/src/Helpers/LoopHelper.php
+++ b/src/Helpers/LoopHelper.php
@@ -37,17 +37,17 @@ class LoopHelper {
 
   /**
    * @param \React\EventLoop\LoopInterface $loop
-   * @param int $minutes
+   * @param float $minutes
    * @param \Acquia\Cli\Output\Spinner\Spinner $spinner
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return \React\EventLoop\TimerInterface
    */
   public static function addTimeoutToLoop(
     LoopInterface $loop,
-    $minutes,
-    Spinner $spinner,
-    OutputInterface $output
+    float $minutes,
+    Spinner $spinner
   ): TimerInterface {
-    return $loop->addTimer($minutes * 60, function () use ($loop, $minutes, $spinner, $output) {
+    return $loop->addTimer($minutes * 60, function () use ($loop, $minutes, $spinner) {
       self::finishSpinner($spinner);
       $loop->stop();
       throw new AcquiaCliException("Timed out after $minutes minutes!");

--- a/src/Output/Checklist.php
+++ b/src/Output/Checklist.php
@@ -82,7 +82,7 @@ class Checklist {
 
     $message_lines = explode(PHP_EOL, $update_message);
     foreach ($message_lines as $line) {
-      if ($this->useSpinner() && $item['spinner']) {
+      if (isset($spinner) && $item['spinner']) {
         if (trim($line)) {
           $spinner->setMessage(str_repeat(' ', $this->indentLength * 2) . $line, 'detail');
         }
@@ -91,7 +91,7 @@ class Checklist {
     }
     // Ensure that the new message is displayed at least once. Sometimes it is
     // not displayed if the minimum redraw frequency is not met.
-    if ($this->useSpinner() && $item['spinner']) {
+    if (isset($spinner) && $item['spinner']) {
       $spinner->getProgressBar()->display();
     }
   }

--- a/tests/phpunit/src/Commands/ChecklistTest.php
+++ b/tests/phpunit/src/Commands/ChecklistTest.php
@@ -49,7 +49,7 @@ class ChecklistTest extends TestBase {
     $output = new BufferedOutput();
     $message = 'Waiting for the IDE to be ready. This can take up to 15 minutes...';
     $spinner = LoopHelper::addSpinnerToLoop($loop, $message, $output);
-    $timer = LoopHelper::addTimeoutToLoop($loop, .01, $spinner, $output);
+    $timer = LoopHelper::addTimeoutToLoop($loop, .01, $spinner);
     try {
       $loop->run();
     }


### PR DESCRIPTION
**Motivation**
phpstan is currently scanning at [level 0](https://phpstan.org/user-guide/rule-levels), which is essentially just syntax errors and deprecations. We can hold ourselves to a higher standard.

**Proposed changes**
Bump phpstan to level 1, and add `phpstan.neon` so it can be called consistent with other dev dependencies and via IDEs that don't use the composer scripts.

Level 2 throws 450 errors, so I think we'll hang out at level 1 😬 

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
