### PR TITLE
Fixes CLI-141: Support federated sign-on.

### DIFF
--- a/src/CloudApi/ClientService.php
+++ b/src/CloudApi/ClientService.php
@@ -19,10 +19,15 @@ class ClientService {
 
   private $connector;
   private $application;
+  private $organizationUuid;
 
   public function __construct(ConnectorFactory $connector_factory, Application $application) {
     $this->setConnector($connector_factory->createConnector());
     $this->setApplication($application);
+  }
+
+  public function setOrganizationUuid($uuid) {
+    $this->organizationUuid = $uuid;
   }
 
   public function setConnector(ConnectorInterface $connector): void {
@@ -42,6 +47,10 @@ class ClientService {
     $client->addOption('headers', [
       'User-Agent' => [$user_agent],
     ]);
+
+    if (isset($this->organizationUuid)) {
+      $client->addQuery('scope', 'organization:' . $this->organizationUuid);
+    }
 
     return $client;
   }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-141: Support federated sign-on

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Before executing a command, first try to load application data and see if it fails. If so, add organization scope to all future requests for the command.

Notable that:
* ACLI* env vars are not set in the IDE when fed auth is required, you _must_ manually run `acli login`.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
