### PR TITLE
Calm down Violinist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,13 +91,41 @@
             "symfony/filesystem": "-p5"
         },
         "violinist": {
-            "allow_updates_beyond_constraint": 1,
+            "allow_updates_beyond_constraint": 0,
             "assignees": [],
-            "blacklist": [],
-            "bundled_packages": [],
+            "blocklist": [
+                "symfony/cache",
+                "symfony/config",
+                "symfony/dependency-injection",
+                "symfony/dotenv",
+                "symfony/event-dispatcher",
+                "symfony/expression-language",
+                "symfony/filesystem",
+                "symfony/finder",
+                "symfony/http-kernel",
+                "symfony/process",
+                "symfony/validator",
+                "symfony/yaml"
+            ],
+            "bundled_packages": {
+                "symfony/console": [
+                    "symfony/cache",
+                    "symfony/config",
+                    "symfony/dependency-injection",
+                    "symfony/dotenv",
+                    "symfony/event-dispatcher",
+                    "symfony/expression-language",
+                    "symfony/filesystem",
+                    "symfony/finder",
+                    "symfony/http-kernel",
+                    "symfony/process",
+                    "symfony/validator",
+                    "symfony/yaml"
+                ]
+            },
             "default_branch": "master",
-            "number_of_concurrent_updates": 1,
-            "one_pull_request_per_package": 0,
+            "number_of_concurrent_updates": 2,
+            "one_pull_request_per_package": 1,
             "security_updates_only": 0,
             "timeframe_disallowed": "0",
             "timezone": "+0000",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70c108e6f7acee0b60dcc72886fddb2e",
+    "content-hash": "95b238401bb17f393b66da36b2a5cc7e",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -8559,7 +8559,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {


### PR DESCRIPTION
A few common-sense config tweaks:

- Don't allow updating beyond constraints (why would anyone allow this? Aren't predictable version constraints the whole point of Composer and Semver?)
- Configure Symfony packages to update all at the same time, instead of in dozens of separate PRs.
- Increase concurrency (we were still on old versions of several Symfony packages because the cycle time of opening and merging Violinist PRs was too slow)
- Only have one PR per package (i.e. one PR to go from Symfony 5.3.7 to 5.3.10, instead of separate PRs for 5.3.7 to 5.3.8, 5.3.8 to 5.3.9, and 5.3.9 to 5.3.10)

In case you don't trust my judgement: https://docs.violinist.io/