### PR TITLE
CLI-520: [pull:files] not enough free disk space

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -631,13 +631,10 @@ abstract class PullCommandBase extends CommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   private function checkDiskSpace($environment, $destination_directory, $source_directory): void {
-    $process = $this->localMachineHelper->execute(['du', '-s', $destination_directory], NULL, NULL, FALSE);
-    $local_size = explode("\t", $process->getOutput())[0];
-    $process = $this->sshHelper->executeCommand($environment, ['du', '-s', $source_directory], FALSE);
-    $remote_size = explode("\t", $process->getOutput())[0];
+    $local_size = $this->localMachineHelper->getDirectoryUsage($destination_directory);
+    $remote_size = $this->sshHelper->getDirectoryUsage($environment, $source_directory);
     $delta = $remote_size - $local_size;
-    $process = $this->localMachineHelper->execute(['df', '--output=avail', '-k', $destination_directory], NULL, NULL, FALSE);
-    $local_free_space = explode("\n", $process->getOutput())[1];
+    $local_free_space = $this->localMachineHelper->getFreeSpace($destination_directory);
     // Apply a 10% safety margin.
     if ($delta * 1.1 > $local_free_space) {
       throw new AcquiaCliException('Not enough free space to pull files from the {environment} environment.

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -433,4 +433,43 @@ class LocalMachineHelper {
     return FALSE;
   }
 
+  /**
+   * @param $directory
+   *
+   * @return int
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   */
+  public function getFreeSpace($directory): int {
+    $this->getFilesystem()->mkdir($directory);
+    $process = $this->execute([
+      'df',
+      '--output=avail',
+      '-k',
+      $directory
+    ], NULL, NULL, FALSE);
+    if (!$process->isSuccessful()) {
+      throw new AcquiaCliException('Failed to get local free space: {error}', ['error' => $process->getErrorOutput()]);
+    }
+    return explode("\n", $process->getOutput())[1];
+  }
+
+  /**
+   * @param $directory
+   *
+   * @return int
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   */
+  public function getDirectoryUsage($directory): int {
+    $this->getFilesystem()->mkdir($directory);
+    $process = $this->execute([
+      'du',
+      '-s',
+      $directory
+    ], NULL, NULL, FALSE);
+    if (!$process->isSuccessful()) {
+      throw new AcquiaCliException('Failed to get usage of local files directory: {error}', ['error' => $process->getErrorOutput()]);
+    }
+    return explode("\t", $process->getOutput())[0];
+  }
+
 }

--- a/src/Helpers/SshHelper.php
+++ b/src/Helpers/SshHelper.php
@@ -70,6 +70,25 @@ class SshHelper implements LoggerAwareInterface {
   }
 
   /**
+   * @param $environment
+   * @param $directory
+   *
+   * @return int
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   */
+  public function getDirectoryUsage($environment, $directory): int {
+    $process = $this->executeCommand($environment, [
+      'du',
+      '-s',
+      $directory
+    ], FALSE);
+    if (!$process->isSuccessful()) {
+      throw new AcquiaCliException('Failed to get usage of remote files directory: {error}', ['error' => $process->getErrorOutput()]);
+    }
+    return explode("\t", $process->getOutput())[0];
+  }
+
+  /**
    * Sends a command to an environment via SSH.
    *
    * @param \AcquiaCloudApi\Response\EnvironmentResponse $environment

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -201,6 +201,8 @@ abstract class CommandTestBase extends TestBase {
     $local_machine_helper = $this->prophet->prophesize(LocalMachineHelper::class);
     $local_machine_helper->useTty()->willReturn(FALSE);
     $local_machine_helper->getLocalFilepath(Path::join($this->dataDir, 'acquia-cli.json'))->willReturn(Path::join($this->dataDir, 'acquia-cli.json'));
+    $local_machine_helper->getFreeSpace(Argument::any())->willReturn(12345);
+    $local_machine_helper->getDirectoryUsage(Argument::any())->willReturn(123);
 
     return $local_machine_helper;
   }
@@ -210,6 +212,7 @@ abstract class CommandTestBase extends TestBase {
    */
   protected function mockSshHelper(): ObjectProphecy {
     $ssh_helper = $this->prophet->prophesize(SshHelper::class);
+    $ssh_helper->getDirectoryUsage(Argument::any(), Argument::any())->willReturn(123);
     return $ssh_helper;
   }
 

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -133,6 +133,9 @@ class PullFilesCommandTest extends PullCommandTestBase {
     string $source_dir,
     string $destination_dir
   ): void {
+    // @todo restore these methods
+    // @see https://github.com/acquia/cli/issues/714
+    /**
     $process = $this->mockProcess();
     $process->getOutput()->willReturn("123\tfiles")->shouldBeCalled();
     $local_machine_helper->execute(['du', '-s', $destination_dir . 'files'], NULL, NULL, FALSE)
@@ -145,8 +148,10 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $process->getOutput()->willReturn("\tAvail\n12345")->shouldBeCalled();
     $local_machine_helper->execute(['df', '--output=avail', '-k', $destination_dir . 'files'], NULL, NULL, FALSE)
       ->willReturn($process->reveal())->shouldBeCalled();
+     **/
 
     $local_machine_helper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
+    $process = $this->mockProcess();
     $command = [
       'rsync',
       '-rltDvPhe',


### PR DESCRIPTION
**Motivation**
If the files directory doesn't exist, the shell commands don't exit cleanly and the whole process fails.

**Proposed changes**

- Ensure files directory exists before trying to read it
- Capture and rethrow any process errors

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Delete files directory locally, or create a brand new IDE (which will be missing the files directory) and run `acli pull`.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
