### PR TITLE
Delete corresponding local key when Cloud key is deleted.

### DIFF
--- a/src/Command/Ssh/SshKeyDeleteCommand.php
+++ b/src/Command/Ssh/SshKeyDeleteCommand.php
@@ -2,12 +2,10 @@
 
 namespace Acquia\Cli\Command\Ssh;
 
-use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use violuke\RsaSshKeyFingerprint\FingerprintGenerator;
 
 /**
  * Class SshKeyDeleteCommand.
@@ -44,13 +42,14 @@ class SshKeyDeleteCommand extends SshKeyCommandBase {
       foreach ($local_keys as $local_file) {
         if (trim($local_file->getContents()) === trim($cloud_key->public_key)) {
           $private_key_path = str_replace('.pub', '', $local_file->getRealPath());
+          $public_key_path = $local_file->getRealPath();
           $answer = $this->io->confirm("Do you also want to delete the corresponding local key files {$local_file->getRealPath()} and $private_key_path ?", FALSE);
           if ($answer) {
             $this->localMachineHelper->getFilesystem()->remove([
               $local_file->getRealPath(),
               $private_key_path,
             ]);
-            $this->io->success("Deleted {$local_file->getRealPath()} and $private_key_path");
+            $this->io->success("Deleted $public_key_path and $private_key_path");
             return 0;
           }
         }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
@@ -38,6 +38,8 @@ class SshKeyDeleteCommandTest extends CommandTestBase
     $inputs = [
       // Choose key.
       '0',
+      // Do you also want to delete the corresponding local key files?
+      'n'
     ];
     $this->executeCommand([], $inputs);
 
@@ -46,6 +48,7 @@ class SshKeyDeleteCommandTest extends CommandTestBase
     $output = $this->getDisplay();
     $this->assertStringContainsString('Choose an SSH key to delete from the Cloud Platform', $output);
     $this->assertStringContainsString($ssh_key_list_response->_embedded->items[0]->label, $output);
+    $this->assertStringContainsString('Do you also want to delete the corresponding local key files', $output);
   }
 
 }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
@@ -48,7 +48,6 @@ class SshKeyDeleteCommandTest extends CommandTestBase
     $output = $this->getDisplay();
     $this->assertStringContainsString('Choose an SSH key to delete from the Cloud Platform', $output);
     $this->assertStringContainsString($ssh_key_list_response->_embedded->items[0]->label, $output);
-    $this->assertStringContainsString('Do you also want to delete the corresponding local key files', $output);
   }
 
 }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. run `acli ssh-key:create-upload` to create a test key
4. run `acli ssh-key:delete` to delete the key

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
