### PR TITLE
CLI-532: Enable api:ide:delete

### DIFF
--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -547,7 +547,6 @@ class ApiCommandHelper {
       'accounts:drush-aliases',
       // Skip any command that has a duplicative corresponding ACLI command.
       'ide:create',
-      'ide:delete',
       'log:tail',
       'ssh-key:create',
       'ssh-key:create-upload',


### PR DESCRIPTION
Enable `api:ide:delete`. It is the only method of deleting an IDE via the command line using only the IDE uuid. `ide:delete` by comparison requires knowing the application UUID.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
There is currently no way to delete an IDE via IDE uuid.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Enable `api:ide:delete`.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
None.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `acli api:ide:delete --help`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
