### PR TITLE
Make `push:artifact` push to multiple git repos

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "composer/semver": "^3.2",
         "consolidation/self-update": "2.0.0-alpha1 as 1.1",
         "cweagans/composer-patches": "^1.7",
+        "grasmash/expander": "^1.0",
         "kevinrob/guzzle-cache-middleware": "^3.3",
         "loophp/phposinfo": "^1.7.2",
         "psr/log": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95b238401bb17f393b66da36b2a5cc7e",
+    "content-hash": "c3d2581e56cfdc3ace39b5984b54a67b",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -301,6 +301,69 @@
             "time": "2021-06-08T15:12:46+00:00"
         },
         {
+            "name": "dflydev/dot-access-data",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Dflydev\\DotAccessData": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                }
+            ],
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
+            "keywords": [
+                "access",
+                "data",
+                "dot",
+                "notation"
+            ],
+            "support": {
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/master"
+            },
+            "time": "2017-01-20T21:14:22+00:00"
+        },
+        {
             "name": "evenement/evenement",
             "version": "v3.0.1",
             "source": {
@@ -346,6 +409,57 @@
                 "source": "https://github.com/igorw/evenement/tree/master"
             },
             "time": "2017-07-23T21:35:13+00:00"
+        },
+        {
+            "name": "grasmash/expander",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grasmash/expander.git",
+                "reference": "95d6037344a4be1dd5f8e0b0b2571a28c397578f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grasmash/expander/zipball/95d6037344a4be1dd5f8e0b0b2571a28c397578f",
+                "reference": "95d6037344a4be1dd5f8e0b0b2571a28c397578f",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^1.1.0",
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "greg-1-anderson/composer-test-scenarios": "^1",
+                "phpunit/phpunit": "^4|^5.5.4",
+                "satooshi/php-coveralls": "^1.0.2|dev-master",
+                "squizlabs/php_codesniffer": "^2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Grasmash\\Expander\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Grasmick"
+                }
+            ],
+            "description": "Expands internal property references in PHP arrays file.",
+            "support": {
+                "issues": "https://github.com/grasmash/expander/issues",
+                "source": "https://github.com/grasmash/expander/tree/master"
+            },
+            "time": "2017-12-21T22:14:55+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -56,8 +56,8 @@ class PushArtifactCommand extends PullCommandBase {
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be pushed')
       ->addOption('no-sanitize', NULL, InputOption::VALUE_NONE, 'Do not sanitize the build artifact')
       ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Do not push changes to Acquia Cloud')
-      ->addOption('dest-git-url', NULL, InputOption::VALUE_REQUIRED, 'The URL of your git repository to which the artifact branch will be pushed')
-      ->addOption('dest-git-branch', NULL, InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
+      ->addOption('destination-git-urls', 'dest-git-urls', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The URL(s) of your git repository to which the artifact branch will be pushed')
+      ->addOption('destination-git-branch', 'dest-git-branch', InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
       ->acceptEnvironmentId()
       ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL
@@ -87,13 +87,13 @@ class PushArtifactCommand extends PullCommandBase {
       throw new AcquiaCliException('Pushing code was aborted because your local Git repository has uncommitted changes. Please either commit, reset, or stash your changes via git.');
     }
     $this->checklist = new Checklist($output);
+    $destination_git_urls = $this->determineDestinationGitUrls();
 
-    if ($input->getOption('dest-git-url') && !$input->getOption('dest-git-branch') ||
-      !$input->getOption('dest-git-url') && $input->getOption('dest-git-branch')) {
+    if ($destination_git_urls && !$input->getOption('dest-git-branch') ||
+      !$destination_git_urls && $input->getOption('dest-git-branch')) {
       throw new AcquiaCliException('You must set both --dest-git-url and --dest-git-branch or neither.');
     }
-    if ($input->getOption('dest-git-url') && $input->getOption('dest-git-branch')) {
-      $dest_git_url = $input->getOption('dest-git-url');
+    if ($destination_git_urls && $input->getOption('dest-git-branch')) {
       $dest_git_branch = $input->getOption('dest-git-branch');
     }
     else {
@@ -103,14 +103,17 @@ class PushArtifactCommand extends PullCommandBase {
         throw new AcquiaCliException("You cannot push to an environment that has a git tag deployed to it. Environment {$environment->name} has {$environment->vcs->path} deployed. Please select a different environment.");
       }
       $dest_git_url = $environment->vcs->url;
+      $dest_git_urls = [$dest_git_url];
       $dest_git_branch = $environment->vcs->path;
     }
-    $this->io->info("The contents of $this->dir will be compiled into an artifact and pushed to the $dest_git_branch branch on the $dest_git_url git remote");
+    $destination_git_urls_string = implode(',', $destination_git_urls);
+    $this->io->info("The contents of $this->dir will be compiled into an artifact and pushed to the $dest_git_branch branch on the $destination_git_urls_string git remote(s)");
 
     $output_callback = $this->getOutputCallback($output, $this->checklist);
 
     $this->checklist->addItem('Preparing artifact directory');
-    $this->cloneDestinationBranch($output_callback, $artifact_dir, $dest_git_url, $dest_git_branch);
+    // @todo Output which git url we will pull from.
+    $this->cloneDestinationBranch($output_callback, $artifact_dir, $destination_git_urls[0], $dest_git_branch);
     $this->checklist->completePreviousItem();
 
     $this->checklist->addItem('Generating build artifact');
@@ -129,7 +132,7 @@ class PushArtifactCommand extends PullCommandBase {
 
     if (!$input->getOption('dry-run')) {
       $this->checklist->addItem("Pushing changes to <options=bold>{$dest_git_branch}</> branch.");
-      $this->pushArtifact($output_callback, $artifact_dir, $dest_git_url, $dest_git_branch);
+      $this->pushArtifact($output_callback, $artifact_dir, $destination_git_urls, $dest_git_branch);
       $this->checklist->completePreviousItem();
     }
     else {
@@ -137,6 +140,20 @@ class PushArtifactCommand extends PullCommandBase {
     }
 
     return 0;
+  }
+
+  /**
+   * @return false|mixed|null
+   */
+  protected function determineDestinationGitUrls() {
+    if ($this->input->getOption('dest-git-url')) {
+      return $this->input->getOption('dest-git-url');
+    }
+    if ($this->datastoreAcli->get('push.artifact.destination_urls')) {
+      return $this->datastoreAcli->get('push.artifact.destination_urls');
+    }
+
+    return NULL;
   }
 
   /**
@@ -317,18 +334,24 @@ class PushArtifactCommand extends PullCommandBase {
    *
    * @param \Closure $output_callback
    * @param string $artifact_dir
-   * @param string $vcs_url
+   * @param array $vcs_urls
    * @param string $dest_git_branch
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function pushArtifact(Closure $output_callback, string $artifact_dir, string $vcs_url, string $dest_git_branch):void {
-    $output_callback('out', "Pushing changes to Acquia Git ($vcs_url)");
-    $this->localMachineHelper->checkRequiredBinariesExist(['git']);
-    // @todo Push to multiple git remotes. Read from .acquia-cli.yml?
-    $process = $this->localMachineHelper->execute(['git', 'push', $vcs_url, $dest_git_branch . ':' . $dest_git_branch], $output_callback, $artifact_dir, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
-    if (!$process->isSuccessful()) {
-      throw new AcquiaCliException("Unable to push artifact: {message}", ['message' => $process->getOutput() . $process->getErrorOutput()]);
+  protected function pushArtifact(Closure $output_callback, string $artifact_dir, array $vcs_urls, string $dest_git_branch):void {
+    foreach ($vcs_urls as $vcs_url) {
+      $output_callback('out', "Pushing changes to Acquia Git ($vcs_url)");
+      $this->localMachineHelper->checkRequiredBinariesExist(['git']);
+      $process = $this->localMachineHelper->execute([
+        'git',
+        'push',
+        $vcs_url,
+        $dest_git_branch . ':' . $dest_git_branch
+      ], $output_callback, $artifact_dir, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
+      if (!$process->isSuccessful()) {
+        throw new AcquiaCliException("Unable to push artifact: {message}", ['message' => $process->getOutput() . $process->getErrorOutput()]);
+      }
     }
   }
 

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -62,7 +62,7 @@ class PushArtifactCommand extends PullCommandBase {
       ->addOption('no-sanitize', NULL, InputOption::VALUE_NONE, 'Do not sanitize the build artifact')
       ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Do not push changes to Acquia Cloud')
       ->addOption('destination-git-urls', 'dest-git-urls', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The URL(s) of your git repository to which the artifact branch will be pushed')
-      ->addOption('destination-git-branch', 'destination-git-branch', InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
+      ->addOption('destination-git-branch', 'dest-git-branch', InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
       ->acceptEnvironmentId()
       ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -325,6 +325,7 @@ class PushArtifactCommand extends PullCommandBase {
   protected function pushArtifact(Closure $output_callback, string $artifact_dir, string $vcs_url, string $dest_git_branch):void {
     $output_callback('out', "Pushing changes to Acquia Git ($vcs_url)");
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
+    // @todo Push to multiple git remotes. Read from .acquia-cli.yml?
     $process = $this->localMachineHelper->execute(['git', 'push', $vcs_url, $dest_git_branch . ':' . $dest_git_branch], $output_callback, $artifact_dir, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException("Unable to push artifact: {message}", ['message' => $process->getOutput() . $process->getErrorOutput()]);

--- a/symfony.lock
+++ b/symfony.lock
@@ -44,6 +44,9 @@
     "dealerdirect/phpcodesniffer-composer-installer": {
         "version": "v0.6.2"
     },
+    "dflydev/dot-access-data": {
+        "version": "v1.1.0"
+    },
     "doctrine/collections": {
         "version": "1.6.7"
     },
@@ -58,6 +61,9 @@
     },
     "gitonomy/gitlib": {
         "version": "v1.2.2"
+    },
+    "grasmash/expander": {
+        "version": "1.0.0"
     },
     "guzzlehttp/guzzle": {
         "version": "6.5.4"

--- a/tests/fixtures/.acquia-cli.yml
+++ b/tests/fixtures/.acquia-cli.yml
@@ -1,3 +1,4 @@
+cloud_app_uuid: test
 push:
   artifact:
     destination-git-url:

--- a/tests/fixtures/.acquia-cli.yml
+++ b/tests/fixtures/.acquia-cli.yml
@@ -1,0 +1,6 @@
+push:
+  artifact:
+    destination-git-url:
+      - https://github.com/example/cli.git
+      - https://github.com/example2/cli.git
+    destination-git-branch: master

--- a/tests/fixtures/.acquia-cli.yml
+++ b/tests/fixtures/.acquia-cli.yml
@@ -1,7 +1,0 @@
-cloud_app_uuid: test
-push:
-  artifact:
-    destination-git-url:
-      - https://github.com/example/cli.git
-      - https://github.com/example2/cli.git
-    destination-git-branch: master

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -53,6 +53,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
+    $this->assertStringContainsString('Pushing changes to Acquia Git (site@svn-3.hosted.acquia-sites.com:site.git)', $output);
   }
 
   public function testPushArtifactWithAcquiaCliFile() {
@@ -66,8 +67,8 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
 
-    $this->assertStringContainsString('will be compiled into an artifact', $output);
-    $this->assertStringContainsString('https://github.com/example1/cli.git,https://github.com/example2/cli.git', $output);
+    $this->assertStringContainsString('Pushing changes to Acquia Git (https://github.com/example1/cli.git)', $output);
+    $this->assertStringContainsString('Pushing changes to Acquia Git (https://github.com/example2/cli.git)', $output);
   }
 
   /**
@@ -86,8 +87,8 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
 
-    $this->assertStringContainsString('will be compiled into an artifact', $output);
-    $this->assertStringContainsString('https://github.com/example1/cli.git,https://github.com/example2/cli.git', $output);
+    $this->assertStringContainsString('Pushing changes to Acquia Git (https://github.com/example1/cli.git)', $output);
+    $this->assertStringContainsString('Pushing changes to Acquia Git (https://github.com/example2/cli.git)', $output);
   }
 
   /**

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -62,17 +62,27 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     ]);
     $this->datastoreAcli->set('push.artifact.destination-git-branch', 'master');
     $this->setUpPushArtifact('master', $this->datastoreAcli->get('push.artifact.destination-git-urls'));
-    $inputs = [
-      // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
-      'n',
-      // Please select a Cloud Platform application:
-      0,
-      // Would you like to link the project at ... ?
-      'n',
-      // Please choose an Acquia environment:
-      0,
+    $this->executeCommand([], []);
+    $this->prophet->checkPredictions();
+    $output = $this->getDisplay();
+
+    $this->assertStringContainsString('The contents of /Users/matt.grasmick/Sites/acquia/cli/tests/fixtures/project will be compiled into an artifact', $output);
+    $this->assertStringContainsString('and pushed to the master branch on the https://github.com/example1/cli.git,https://github.com/example2/cli.git', $output);
+  }
+
+  /**
+   * @throws \Exception
+   */
+  public function testPushArtifactWithArgs() {
+    $destination_git_urls = [
+      'https://github.com/example1/cli.git',
+      'https://github.com/example2/cli.git',
     ];
-    $this->executeCommand([], $inputs);
+    $this->setUpPushArtifact('master', $destination_git_urls);
+    $this->executeCommand([
+      '--destination-git-urls' => $destination_git_urls,
+      '--destination-git-branch' => 'master',
+    ], []);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
 

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Tests\Commands\Push;
 
 use Acquia\Cli\Command\Push\PushArtifactCommand;
+use Acquia\Cli\Helpers\DataStoreContract;
 use Acquia\Cli\Tests\Commands\Pull\PullCommandTestBase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -25,30 +26,15 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     return $this->injectCommand(PushArtifactCommand::class);
   }
 
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
   public function testPushArtifact(): void {
-    $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $applications_response = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
     $environments_response = $this->mockEnvironmentsRequest($applications_response);
     $selected_environment = $environments_response->_embedded->items[0];
-    $this->createMockGitConfigFile();
-
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $finder = $this->mockFinder();
-    $local_machine_helper->getFinder()->willReturn($finder->reveal());
-    $fs = $this->prophet->prophesize(Filesystem::class);
-    $local_machine_helper->getFilesystem()->willReturn($fs)->shouldBeCalled();
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
-
-    $commit_hash = 'abc123';
-    $this->mockExecuteGitStatus(FALSE, $local_machine_helper, $this->projectFixtureDir);
-    $this->mockGetLocalCommitHash($local_machine_helper, $this->projectFixtureDir, $commit_hash);
-    $this->mockCloneShallow($local_machine_helper, $selected_environment->vcs->path, $selected_environment->vcs->url, $artifact_dir);
-    $this->mockLocalGitConfig($local_machine_helper, $artifact_dir);
-    $this->mockComposerInstall($local_machine_helper, $artifact_dir);
-    $this->mockReadComposerJson($local_machine_helper, $artifact_dir);
-    $this->mockGitAddCommitPush($local_machine_helper, $artifact_dir, $commit_hash, $selected_environment->vcs->url, $selected_environment->vcs->path);
-
+    $this->setUpPushArtifact($selected_environment->vcs->path, [$selected_environment->vcs->url]);
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
       'n',
@@ -67,6 +53,56 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
+  }
+
+  public function testPushArtifactWithAcquiaCliFile() {
+    $this->datastoreAcli->set('push.artifact.destination-git-urls', [
+      'https://github.com/example1/cli.git',
+      'https://github.com/example2/cli.git',
+    ]);
+    $this->datastoreAcli->set('push.artifact.destination-git-branch', 'master');
+    $this->setUpPushArtifact('master', $this->datastoreAcli->get('push.artifact.destination-git-urls'));
+    $inputs = [
+      // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
+      'n',
+      // Please select a Cloud Platform application:
+      0,
+      // Would you like to link the project at ... ?
+      'n',
+      // Please choose an Acquia environment:
+      0,
+    ];
+    $this->executeCommand([], $inputs);
+    $this->prophet->checkPredictions();
+    $output = $this->getDisplay();
+
+    $this->assertStringContainsString('The contents of /Users/matt.grasmick/Sites/acquia/cli/tests/fixtures/project will be compiled into an artifact', $output);
+    $this->assertStringContainsString('and pushed to the master branch on the https://github.com/example1/cli.git,https://github.com/example2/cli.git', $output);
+  }
+
+  /**
+   * @param $vcs_path
+   * @param $vcs_url
+   */
+  protected function setUpPushArtifact($vcs_path, $vcs_urls) {
+    $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
+    $this->createMockGitConfigFile();
+
+    $local_machine_helper = $this->mockLocalMachineHelper();
+    $finder = $this->mockFinder();
+    $local_machine_helper->getFinder()->willReturn($finder->reveal());
+    $fs = $this->prophet->prophesize(Filesystem::class);
+    $local_machine_helper->getFilesystem()->willReturn($fs)->shouldBeCalled();
+    $this->command->localMachineHelper = $local_machine_helper->reveal();
+
+    $commit_hash = 'abc123';
+    $this->mockExecuteGitStatus(FALSE, $local_machine_helper, $this->projectFixtureDir);
+    $this->mockGetLocalCommitHash($local_machine_helper, $this->projectFixtureDir, $commit_hash);
+    $this->mockCloneShallow($local_machine_helper, $vcs_path, $vcs_urls[0], $artifact_dir);
+    $this->mockLocalGitConfig($local_machine_helper, $artifact_dir);
+    $this->mockComposerInstall($local_machine_helper, $artifact_dir);
+    $this->mockReadComposerJson($local_machine_helper, $artifact_dir);
+    $this->mockGitAddCommitPush($local_machine_helper, $artifact_dir, $commit_hash, $vcs_urls, $vcs_path);
   }
 
   /**
@@ -118,7 +154,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
    * @param $git_url
    * @param $git_branch
    */
-  protected function mockGitAddCommitPush(ObjectProphecy $local_machine_helper, $artifact_dir, $commit_hash, $git_url, $git_branch): void {
+  protected function mockGitAddCommitPush(ObjectProphecy $local_machine_helper, $artifact_dir, $commit_hash, $git_urls, $git_branch): void {
     $process =  $this->mockProcess();
     $local_machine_helper->execute(['git', 'add', '-A'], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
@@ -132,8 +168,15 @@ class PushArtifactCommandTest extends PullCommandTestBase {
       ->willReturn($process->reveal())->shouldBeCalled();
     $local_machine_helper->execute(['git', 'commit', '-m', "Automated commit by Acquia CLI (source commit: $commit_hash)"], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'push', $git_url, $git_branch . ':' . $git_branch], Argument::type('callable'), $artifact_dir, TRUE)
-      ->willReturn($process->reveal())->shouldBeCalled();
+    foreach ($git_urls as $git_url) {
+      $local_machine_helper->execute([
+        'git',
+        'push',
+        $git_url,
+        $git_branch . ':' . $git_branch
+      ], Argument::type('callable'), $artifact_dir, TRUE)
+          ->willReturn($process->reveal())->shouldBeCalled();
+    }
   }
 
   /**

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -66,8 +66,8 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
 
-    $this->assertStringContainsString('The contents of /Users/matt.grasmick/Sites/acquia/cli/tests/fixtures/project will be compiled into an artifact', $output);
-    $this->assertStringContainsString('and pushed to the master branch on the https://github.com/example1/cli.git,https://github.com/example2/cli.git', $output);
+    $this->assertStringContainsString('will be compiled into an artifact', $output);
+    $this->assertStringContainsString('https://github.com/example1/cli.git,https://github.com/example2/cli.git', $output);
   }
 
   /**
@@ -86,8 +86,8 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
 
-    $this->assertStringContainsString('The contents of /Users/matt.grasmick/Sites/acquia/cli/tests/fixtures/project will be compiled into an artifact', $output);
-    $this->assertStringContainsString('and pushed to the master branch on the https://github.com/example1/cli.git,https://github.com/example2/cli.git', $output);
+    $this->assertStringContainsString('will be compiled into an artifact', $output);
+    $this->assertStringContainsString('https://github.com/example1/cli.git,https://github.com/example2/cli.git', $output);
   }
 
   /**


### PR DESCRIPTION
**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Add options to `acli push:artifact`:
* --destination-git-urls, an array of git urls to push to
* --destination-git-branch, the git branch to push to.

Allow same options to be defined in .acquia-cli.yml:
```
push:
  artifact:
    destination-git-url:
      - https://github.com/example/cli.git
      - https://github.com/example2/cli.git
    destination-git-branch: master
```

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
