### PR TITLE
Fix #722: Errors linking Cloud application when running non-interactively

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -812,16 +812,18 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    */
   protected function determineCloudApplication($prompt_link_app = FALSE): ?string {
     $application_uuid = $this->doDetermineCloudApplication();
-    if (isset($application_uuid)) {
-      $application = $this->getCloudApplication($application_uuid);
-      // No point in trying to link a directory that's not a repo.
-      if (!empty($this->repoRoot) && !$this->getCloudUuidFromDatastore()) {
-        if ($prompt_link_app) {
-          $this->saveCloudUuidToDatastore($application);
-        }
-        elseif (!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !$this->getCloudApplicationUuidFromBltYaml()) {
-          $this->promptLinkApplication($application);
-        }
+    if (!isset($application_uuid)) {
+      throw new AcquiaCliException("Could not determine Cloud Application. Run this command interactively or use `acli link` to link a Cloud Application before running non-interactively.");
+    }
+
+    $application = $this->getCloudApplication($application_uuid);
+    // No point in trying to link a directory that's not a repo.
+    if (!empty($this->repoRoot) && !$this->getCloudUuidFromDatastore()) {
+      if ($prompt_link_app) {
+        $this->saveCloudUuidToDatastore($application);
+      }
+      elseif (!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !$this->getCloudApplicationUuidFromBltYaml()) {
+        $this->promptLinkApplication($application);
       }
     }
 

--- a/src/Command/Ide/IdeOpenCommand.php
+++ b/src/Command/Ide/IdeOpenCommand.php
@@ -35,9 +35,6 @@ class IdeOpenCommand extends IdeCommandBase {
   protected function execute(InputInterface $input, OutputInterface $output) {
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $cloud_application_uuid = $this->determineCloudApplication();
-    if (!$cloud_application_uuid && !$input->isInteractive()) {
-      throw new RuntimeException('Not enough arguments (missing: "applicationUuid").');
-    }
     $ides_resource = new Ides($acquia_cloud_client);
     $ide = $this->promptIdeChoice("Please select the IDE you'd like to open:", $ides_resource, $cloud_application_uuid);
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -46,9 +46,6 @@ class ExceptionListener {
         case 'Not enough arguments (missing: "environmentUuid").':
           $this->writeSiteAliasHelp();
           break;
-        case 'Not enough arguments (missing: "applicationUuid").':
-          $this->writeApplicationAliasHelp();
-          break;
       }
     }
 

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -68,6 +68,7 @@ class ExceptionApplicationTest extends TestBase {
   public function testInvalidApiCreds(): void {
     $this->setInput([
       'command' => 'aliases',
+      'applicationUuid' => '2ed281d4-9dec-4cc3-ac63-691c3ba002c2',
     ]);
     $this->mockUnauthorizedRequest();
     $buffer = $this->runApp();
@@ -78,6 +79,7 @@ class ExceptionApplicationTest extends TestBase {
   public function testApiError(): void {
     $this->setInput([
       'command' => 'aliases',
+      'applicationUuid' => '2ed281d4-9dec-4cc3-ac63-691c3ba002c2',
     ]);
     $this->mockApiError();
     $buffer = $this->runApp();
@@ -87,6 +89,7 @@ class ExceptionApplicationTest extends TestBase {
   public function testNoAvailableIdes(): void {
     $this->setInput([
       'command' => 'aliases',
+      'applicationUuid' => '2ed281d4-9dec-4cc3-ac63-691c3ba002c2',
     ]);
     $this->mockNoAvailableIdes();
     $buffer = $this->runApp();
@@ -116,7 +119,7 @@ class ExceptionApplicationTest extends TestBase {
       'command' => 'ide:open',
     ]);
     $buffer = $this->runApp();
-    self::assertStringContainsString('can also be an application alias.', $buffer);
+    self::assertStringContainsString('Could not determine Cloud Application.', $buffer);
   }
 
   public function testInvalidApplicationUuid(): void {


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #722

**Proposed changes**
Throw an exception any time a command requires a linked application, but no application is provided or found.

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Find a Drupal site that's _not_ linked to a Cloud app
4. Run a command requiring a linked application non-interactively, i.e. `acli remote:aliases:download -n -vvv`
5. Expect a clear exception rather than a bunch of PHP errors.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
