### PR TITLE
Fixes #731: Compress files for push:files and pull:files commands

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1466,6 +1466,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @throws AcquiaCliException
    */
   protected function promptChooseCloudSite($cloud_environment) {
+    // @todo Handle no sites.
     $sites = $this->getCloudSites($cloud_environment);
     if (count($sites) === 1) {
       $site = reset($sites);

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -651,7 +651,14 @@ abstract class PullCommandBase extends CommandBase {
     $this->localMachineHelper->getFilesystem()->mkdir($destination);
     $command = [
       'rsync',
-      '-rltDvPhe',
+      // -a archive mode; same as -rlptgoD.
+      // -z compress file data during the transfer.
+      // -v increase verbosity.
+      // -P show progress during transfer.
+      // -k transform symlink to a dir into referent dir.
+      // -h output numbers in a human-readable format.
+      // -e specify the remote shell to use.
+      '-avPhekz',
       'ssh -o StrictHostKeyChecking=no',
       $chosen_environment->sshUrl . ':' . $source_dir,
       $destination,

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -658,7 +658,7 @@ abstract class PullCommandBase extends CommandBase {
       // -k transform symlink to a dir into referent dir.
       // -h output numbers in a human-readable format.
       // -e specify the remote shell to use.
-      '-avPhekz',
+      '-avPhkze',
       'ssh -o StrictHostKeyChecking=no',
       $chosen_environment->sshUrl . ':' . $source_dir,
       $destination,

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -655,10 +655,9 @@ abstract class PullCommandBase extends CommandBase {
       // -z compress file data during the transfer.
       // -v increase verbosity.
       // -P show progress during transfer.
-      // -k transform symlink to a dir into referent dir.
       // -h output numbers in a human-readable format.
       // -e specify the remote shell to use.
-      '-avPhkze',
+      '-avPhze',
       'ssh -o StrictHostKeyChecking=no',
       $chosen_environment->sshUrl . ':' . $source_dir,
       $destination,

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -78,7 +78,7 @@ class PushFilesCommand extends PullCommandBase {
     $this->localMachineHelper->checkRequiredBinariesExist(['rsync']);
     $command = [
       'rsync',
-      '-rltDvPhe',
+      '-avPhekz',
       'ssh -o StrictHostKeyChecking=no',
       $source,
       $chosen_environment->sshUrl . ':' . $dest_dir,

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -78,7 +78,14 @@ class PushFilesCommand extends PullCommandBase {
     $this->localMachineHelper->checkRequiredBinariesExist(['rsync']);
     $command = [
       'rsync',
-      '-avPhekz',
+      // -a archive mode; same as -rlptgoD.
+      // -z compress file data during the transfer.
+      // -v increase verbosity.
+      // -P show progress during transfer.
+      // -k transform symlink to a dir into referent dir.
+      // -h output numbers in a human-readable format.
+      // -e specify the remote shell to use.
+      '-avPhkze',
       'ssh -o StrictHostKeyChecking=no',
       $source,
       $chosen_environment->sshUrl . ':' . $dest_dir,

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -82,7 +82,6 @@ class PushFilesCommand extends PullCommandBase {
       // -z compress file data during the transfer.
       // -v increase verbosity.
       // -P show progress during transfer.
-      // -k transform symlink to a dir into referent dir.
       // -h output numbers in a human-readable format.
       // -e specify the remote shell to use.
       '-avPhkze',

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -84,7 +84,7 @@ class PushFilesCommand extends PullCommandBase {
       // -P show progress during transfer.
       // -h output numbers in a human-readable format.
       // -e specify the remote shell to use.
-      '-avPhkze',
+      '-avPhze',
       'ssh -o StrictHostKeyChecking=no',
       $source,
       $chosen_environment->sshUrl . ':' . $dest_dir,

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -105,6 +105,7 @@ class TelemetryHelper {
       'ah_realm' => getenv('AH_REALM'),
       'ah_non_production' => getenv('AH_NON_PRODUCTION'),
       'php_version' => PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
+      'CI' => getenv('CI'),
     ];
     try {
       $user = $this->getUserData();

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -149,7 +149,7 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $local_machine_helper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
     $command = [
       'rsync',
-      '-avPhkze',
+      '-avPhze',
       'ssh -o StrictHostKeyChecking=no',
       $environment->ssh_url . ':' . $source_dir,
       $destination_dir

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -149,7 +149,7 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $local_machine_helper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
     $command = [
       'rsync',
-      '-avPhekz',
+      '-avPhkze',
       'ssh -o StrictHostKeyChecking=no',
       $environment->ssh_url . ':' . $source_dir,
       $destination_dir

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -149,7 +149,7 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $local_machine_helper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
     $command = [
       'rsync',
-      '-rltDvPhe',
+      '-avPhekz',
       'ssh -o StrictHostKeyChecking=no',
       $environment->ssh_url . ':' . $source_dir,
       $destination_dir

--- a/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
@@ -114,7 +114,7 @@ class PushFilesCommandTest extends CommandTestBase {
     $sitegroup = CommandBase::getSiteGroupFromSshUrl($environment->ssh_url);
     $command = [
       'rsync',
-      '-rltDvPhe',
+      '-avPhekz',
       'ssh -o StrictHostKeyChecking=no',
       $this->projectFixtureDir . '/docroot/sites/default/files/',
       $environment->ssh_url . ':/mnt/files/' . $sitegroup . '.' . $environment->name . '/sites/bar/files',

--- a/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
@@ -114,7 +114,7 @@ class PushFilesCommandTest extends CommandTestBase {
     $sitegroup = CommandBase::getSiteGroupFromSshUrl($environment->ssh_url);
     $command = [
       'rsync',
-      '-avPhekz',
+      '-avPhkze',
       'ssh -o StrictHostKeyChecking=no',
       $this->projectFixtureDir . '/docroot/sites/default/files/',
       $environment->ssh_url . ':/mnt/files/' . $sitegroup . '.' . $environment->name . '/sites/bar/files',

--- a/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
@@ -114,7 +114,7 @@ class PushFilesCommandTest extends CommandTestBase {
     $sitegroup = CommandBase::getSiteGroupFromSshUrl($environment->ssh_url);
     $command = [
       'rsync',
-      '-avPhkze',
+      '-avPhze',
       'ssh -o StrictHostKeyChecking=no',
       $this->projectFixtureDir . '/docroot/sites/default/files/',
       $environment->ssh_url . ':/mnt/files/' . $sitegroup . '.' . $environment->name . '/sites/bar/files',

--- a/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
@@ -135,7 +135,7 @@ class PushFilesCommandTest extends CommandTestBase {
     $local_machine_helper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
     $command = [
       'rsync',
-      '-rltDvPhe',
+      '-avPhze',
       'ssh -o StrictHostKeyChecking=no',
       $this->projectFixtureDir . '/docroot/sites/default/files/',
       'profserv2.01dev@profserv201dev.ssh.enterprise-g1.acquia-sites.com:/mnt/files/profserv2.dev/sites/g/files/jxr5000596dev/files',

--- a/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
@@ -39,7 +39,7 @@ class AliasesDownloadCommandTest extends CommandTestBase {
    *
    * Tests the 'remote:aliases:download' commands.
    *
-   * @throws \Exception
+   * @throws \Exception|\Psr\Cache\InvalidArgumentException
    */
   public function testRemoteAliasesDownloadCommand($alias_version): void {
     $drush_aliases_fixture = Path::canonicalize(__DIR__ . '/../../../../fixtures/drush-aliases');


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #731

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Add the -z option to rsync to compress the files prior to transfer.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `acli pull:files`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
