### PR TITLE
Fixes #721: Add --destination-dir option to remote:aliases:download.

### DIFF
--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -7,6 +7,7 @@ use AcquiaCloudApi\Endpoints\Account;
 use PharData;
 use RecursiveIteratorIterator;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozart\PathUtil\Path;
 
@@ -32,7 +33,8 @@ class AliasesDownloadCommand extends SshCommand {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Download Drush aliases for the Cloud Platform');
+    $this->setDescription('Download Drush aliases for the Cloud Platform')
+      ->addOption('destination-dir', NULL, InputOption::VALUE_REQUIRED, 'The directory to which aliases will be downloaded');
   }
 
   /**
@@ -125,11 +127,16 @@ class AliasesDownloadCommand extends SshCommand {
   }
 
   /**
+   * @param string $version
+   *
    * @return string
-   * @throws \Exception
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function getDrushAliasesDir($version): string {
-    if (!isset($this->drushAliasesDir)) {
+  protected function getDrushAliasesDir(string $version): string {
+    if ($this->input->getOption('destination-dir')) {
+      $this->drushAliasesDir = $this->input->getOption('destination-dir');
+    }
+    elseif (!isset($this->drushAliasesDir)) {
       switch ($version) {
         case 8:
           $this->drushAliasesDir = $this->localMachineHelper

--- a/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
@@ -69,6 +69,7 @@ class AliasesDownloadCommandTest extends CommandTestBase {
     }
     else {
       $this->command->setDrushAliasesDir($drush_aliases_dir);
+      $destination_dir = $drush_aliases_dir;
       $args = [];
     }
 
@@ -80,8 +81,8 @@ class AliasesDownloadCommandTest extends CommandTestBase {
     $output = $this->getDisplay();
 
     $this->assertFileDoesNotExist($drush_archive_filepath);
-    $this->assertFileExists($drush_aliases_dir);
-    $this->assertStringContainsString('Cloud Platform Drush aliases installed into ' . $drush_aliases_dir, $output);
+    $this->assertFileExists($destination_dir);
+    $this->assertStringContainsString('Cloud Platform Drush aliases installed into ' . $destination_dir, $output);
 
   }
 

--- a/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
@@ -29,7 +29,11 @@ class AliasesDownloadCommandTest extends CommandTestBase {
    * Test all Drush alias versions.
    */
   public function providerTestRemoteAliasesDownloadCommand(): array {
-    return [[8], [9]];
+    return [
+      [8, NULL],
+      [9, NULL],
+      [9, 'testdir'],
+    ];
   }
 
   /**
@@ -41,7 +45,7 @@ class AliasesDownloadCommandTest extends CommandTestBase {
    *
    * @throws \Exception
    */
-  public function testRemoteAliasesDownloadCommand($alias_version): void {
+  public function testRemoteAliasesDownloadCommand($alias_version, $destination_dir): void {
     $drush_aliases_fixture = Path::canonicalize(__DIR__ . '/../../../../fixtures/drush-aliases');
     $drush_aliases_tarball_fixture_filepath = tempnam(sys_get_temp_dir(), 'AcquiaDrushAliases');
     $archive_fixture = new PharData($drush_aliases_tarball_fixture_filepath . '.tar');
@@ -59,10 +63,17 @@ class AliasesDownloadCommandTest extends CommandTestBase {
       $this->mockEnvironmentsRequest($applications);
       $this->mockApplicationRequest();
     }
-    $this->command->setDrushAliasesDir($drush_aliases_dir);
+    if ($destination_dir) {
+      $this->command->setDrushAliasesDir($destination_dir);
+      $args = ['--destination-dir' => $destination_dir];
+    }
+    else {
+      $this->command->setDrushAliasesDir($drush_aliases_dir);
+      $args = [];
+    }
 
     $inputs = [$alias_version];
-    $this->executeCommand([], $inputs);
+    $this->executeCommand($args, $inputs);
 
     // Assert.
     $this->prophet->checkPredictions();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #721

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Add --destination-dir option to remote:aliases:download. 

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `acli remote:aliases:download --destination-dir=mytestdir`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
