### PR TITLE
Fix acli new failing due to ACMS patch

### DIFF
--- a/src/Command/NewCommand.php
+++ b/src/Command/NewCommand.php
@@ -20,9 +20,9 @@ class NewCommand extends CommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Create a new Drupal project')
-      ->addOption('distribution', NULL, InputOption::VALUE_REQUIRED, 'The composer package name of the Drupal distribution to download')
+      ->addOption('distribution', NULL, InputOption::VALUE_REQUIRED, 'The Composer package name of the Drupal distribution to download')
       ->addArgument('directory', InputArgument::OPTIONAL, 'The destination directory');
   }
 
@@ -33,7 +33,7 @@ class NewCommand extends CommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->output->writeln('Acquia recommends most customers use <options=bold>acquia/drupal-recommended-project</>, which includes useful utilities such as Acquia Connector.');
     $this->output->writeln('<options=bold>acquia/drupal-minimal-project</> is the most minimal application that will run on the Cloud Platform.');
     $distros = [
@@ -52,21 +52,10 @@ class NewCommand extends CommandBase {
       $dir = Path::makeAbsolute('drupal', getcwd());
     }
 
-    $output->writeln('<info>Creating project. This may take a few minutes</info>');
+    $output->writeln('<info>Creating project. This may take a few minutes.</info>');
     $this->localMachineHelper->checkRequiredBinariesExist(['composer']);
     $this->createProject($project, $dir);
 
-    if (strpos($project, 'acquia/drupal-minimal-project') !== FALSE) {
-      $this->requireDrush($dir);
-    }
-
-    // We've deferred all installation until now.
-    $this->localMachineHelper->execute([
-      'composer',
-      'update',
-    ], NULL, $dir);
-
-    // @todo Add a .gitignore and other recommended default files.
     $this->initializeGitRepository($dir);
 
     $output->writeln('');
@@ -85,22 +74,6 @@ class NewCommand extends CommandBase {
   }
 
   /**
-   * @param string $dir
-   *
-   * @throws \Exception
-   */
-  protected function requireDrush(string $dir): void {
-    $this->localMachineHelper->checkRequiredBinariesExist(['composer']);
-    $this->localMachineHelper->execute([
-      'composer',
-      'require',
-      'drush/drush',
-      '--no-update',
-    ], NULL, $dir);
-    // @todo Check that this was successful!
-  }
-
-  /**
    * @param $project
    * @param string $dir
    *
@@ -110,7 +83,6 @@ class NewCommand extends CommandBase {
     $process = $this->localMachineHelper->execute([
       'composer',
       'create-project',
-      '--no-install',
       $project,
       $dir,
     ]);

--- a/tests/phpunit/src/Commands/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/NewCommandTest.php
@@ -26,7 +26,7 @@ class NewCommandTest extends CommandTestBase {
     return $this->injectCommand(NewCommand::class);
   }
 
-  public function provideTestNewCommand() {
+  public function provideTestNewCommand(): array {
     return [
       ['acquia/drupal-recommended-project'],
       ['acquia/drupal-minimal-project'],
@@ -44,7 +44,7 @@ class NewCommandTest extends CommandTestBase {
    *
    * @throws \Exception
    */
-  public function testNewCommand($project, $directory = 'drupal'): void {
+  public function testNewCommand(string $project, string $directory = 'drupal'): void {
     $this->newProjectDir = Path::makeAbsolute($directory, $this->projectFixtureDir);
 
     $process = $this->prophet->prophesize(Process::class);
@@ -56,23 +56,10 @@ class NewCommandTest extends CommandTestBase {
     $this->mockGetFilesystem($local_machine_helper);
     $local_machine_helper->checkRequiredBinariesExist(["composer"])->shouldBeCalled();
     $this->mockExecuteComposerCreate($this->newProjectDir, $local_machine_helper, $process, $project);
-    $this->mockExecuteComposerUpdate($local_machine_helper, $this->newProjectDir, $process);
     $local_machine_helper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
     $this->mockExecuteGitInit($local_machine_helper, $this->newProjectDir, $process);
     $this->mockExecuteGitAdd($local_machine_helper, $this->newProjectDir, $process);
     $this->mockExecuteGitCommit($local_machine_helper, $this->newProjectDir, $process);
-
-    if ($project === 'acquia/drupal-minimal-project') {
-      $local_machine_helper
-        ->execute([
-          'composer',
-          'require',
-          'drush/drush',
-          '--no-update',
-        ], NULL, $this->newProjectDir)
-        ->willReturn($process->reveal())
-        ->shouldBeCalled();
-    }
 
     $this->command->localMachineHelper = $local_machine_helper->reveal();
     $inputs = [
@@ -107,34 +94,11 @@ class NewCommandTest extends CommandTestBase {
     $command = [
       'composer',
       'create-project',
-      '--no-install',
       $project,
       $project_dir,
     ];
     $local_machine_helper
       ->execute($command)
-      ->willReturn($process->reveal())
-      ->shouldBeCalled();
-  }
-
-  /**
-   * @param \Prophecy\Prophecy\ObjectProphecy $local_machine_helper
-   * @param string $project_dir
-   * @param \Prophecy\Prophecy\ObjectProphecy $process
-   *
-   * @return void
-  */
-  protected function mockExecuteComposerUpdate(
-    ObjectProphecy $local_machine_helper,
-    string $project_dir,
-    ObjectProphecy $process
-  ) {
-    $command = [
-      'composer',
-      'update',
-    ];
-    $local_machine_helper
-      ->execute($command, NULL, $project_dir)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }
@@ -172,7 +136,7 @@ class NewCommandTest extends CommandTestBase {
     ObjectProphecy $local_machine_helper,
     string $project_dir,
     ObjectProphecy $process
-  ) {
+  ): void {
     $command = [
       'git',
       'add',


### PR DESCRIPTION
**Motivation**
`acli new` is failing because it tries to install Drupal 9.3, but ACMS includes a patch that fails to apply to Drupal 9.3

**Proposed changes**
Stop running `composer update` so that we get the known-good dependencies provided by the project templates. As soon as ACMS (and all other packages) are compatible with Drupal 9.3, the templates will update their dependencies to match.

As a happy side effect, this should make `acli new` an order of magnitude faster.

**Testing steps**

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `acli new`, verify that you get Drupal 9.2 + ACMS with the recommended template.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
