### PR TITLE
Fix #731: Incorrect sites/files directory on ACN

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1431,7 +1431,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
   protected function getCloudSitesPath($cloud_environment, $sitegroup) {
     if ($cloud_environment->platform === 'cloud-next') {
-      $path = "/mnt/gfs/$sitegroup.{$cloud_environment->name}/sites";
+      $path = "/mnt/data/{$cloud_environment->uuid}-real-shared/sites";
     }
     else {
       $path = "/mnt/files/$sitegroup.{$cloud_environment->name}/sites";


### PR DESCRIPTION
**Motivation**
Fixes #731

**Proposed changes**
Fixes the canonical sites directory in ACN applications. Seems like ACN changed this recently.

**Alternatives considered**
This is an alternative to #739 

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `acli pull:files` against an ACN app.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer

I'm unable to test this at a moment as I try to set up a multisite ACN app. But if everyone's happy with the approach I'll do further testing and fix tests.
