### PR TITLE
Fixes #611: When the --no-interaction flag is passed, fail informatively.

### DIFF
--- a/src/Command/Ssh/SshKeyCreateCommand.php
+++ b/src/Command/Ssh/SshKeyCreateCommand.php
@@ -162,18 +162,19 @@ class SshKeyCreateCommand extends SshKeyCommandBase {
     if ($input->getOption('password')) {
       $password = $input->getOption('password');
       $this->validatePassword($password);
+      return $password;
     }
-    else {
+    if ($input->isInteractive()) {
       $question = new Question('Enter a password for your SSH key');
       $question->setHidden($this->localMachineHelper->useTty());
       $question->setNormalizer(static function ($value) {
         return $value ? trim($value) : '';
       });
       $question->setValidator(Closure::fromCallable([$this, 'validatePassword']));
-      $password = $this->io->askQuestion($question);
+      return $this->io->askQuestion($question);
     }
 
-    return $password;
+    throw new AcquiaCliException('Could not determine the SSH key password. Either use the --password option or else run this command in an interactive shell.');
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #611

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
The `ssh-key:create` command will fail with an informative error if both `--password` is not used and a non-interactive shell is used.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
