### PR TITLE
Remove display artifact from pull commands.

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -859,7 +859,7 @@ abstract class PullCommandBase extends CommandBase {
    * @throws \Exception
    */
   protected function runDrushCacheClear(Closure $output_callback): void {
-    if ($this->getDrushDatabaseConnectionStatus($output_callback)) {
+    if ($this->getDrushDatabaseConnectionStatus()) {
       $this->checklist->addItem('Clearing Drupal caches via Drush');
       // @todo Add support for Drush 8.
       $process = $this->localMachineHelper->execute([
@@ -885,7 +885,7 @@ abstract class PullCommandBase extends CommandBase {
    * @throws \Exception
    */
   protected function runDrushSqlSanitize(Closure $output_callback): void {
-    if ($this->getDrushDatabaseConnectionStatus($output_callback)) {
+    if ($this->getDrushDatabaseConnectionStatus()) {
       $this->checklist->addItem('Sanitizing database via Drush');
       $process = $this->localMachineHelper->execute([
         'drush',

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -59,7 +59,7 @@ abstract class PullCommandTestBase extends CommandTestBase {
         '--fields=db-status,drush-version',
         '--format=json',
         '--no-interaction',
-      ], Argument::type('callable'), $dir, FALSE)
+      ], Argument::any(), $dir, FALSE)
       ->willReturn($drush_status_process->reveal())
       ->shouldBeCalled();
   }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Removes an errant `}` from display output in pull commands. This was caused by an output callback emitting output when no checklist item was active, causing the artifact to never be cleared.

**Proposed changes**
Don't use an output callback when checking for a db connection in the pull commands.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Add a checklist item before the check for a db connection.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `pull:db`.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
