### PR TITLE
Allow push:artifact args to be passed via env var.

### DIFF
--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -317,10 +317,24 @@ class PushArtifactCommand extends PullCommandBase {
         $this->io->warning("Unable to forcibly add $file to new branch");
       }
     }
-    $this->localMachineHelper->execute(['git', 'commit', '-m', "Automated commit by Acquia CLI (source commit: $commit_hash)"], $output_callback, $artifact_dir, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
+    $commit_message = $this->generateCommitMessage($commit_hash);
+    $this->localMachineHelper->execute(['git', 'commit', '-m', $commit_message], $output_callback, $artifact_dir, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException("Could not commit via git: {message}", ['message' => $process->getErrorOutput() . $process->getOutput()]);
     }
+  }
+
+  /**
+   * @param string $commit_hash
+   *
+   * @return array|false|string
+   */
+  public function generateCommitMessage(string $commit_hash) {
+    if ($env_var = getenv('ACLI_PUSH_ARTIFACT_COMMIT_MSG')) {
+      return $env_var;
+    }
+
+    return "Automated commit by Acquia CLI (source commit: $commit_hash)";
   }
 
   /**

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -138,6 +138,9 @@ class PushArtifactCommand extends PullCommandBase {
     if ($this->input->getOption('destination-git-urls')) {
       return $this->input->getOption('destination-git-urls');
     }
+    if ($env_var = getenv('ACLI_PUSH_ARTIFACT_DESTINATION_GIT_URLS')) {
+      return $env_var;
+    }
     if ($this->datastoreAcli->get('push.artifact.destination-git-urls')) {
       return $this->datastoreAcli->get('push.artifact.destination-git-urls');
     }
@@ -419,6 +422,9 @@ class PushArtifactCommand extends PullCommandBase {
   protected function determineDestinationGitBranch() {
     if ($this->input->getOption('destination-git-branch')) {
       return $this->input->getOption('destination-git-branch');
+    }
+    if ($env_var = getenv('ACLI_PUSH_ARTIFACT_DESTINATION_GIT_BRANCH')) {
+      return $env_var;
     }
     if ($this->datastoreAcli->get('push.artifact.destination-git-branch')) {
       return $this->datastoreAcli->get('push.artifact.destination-git-branch');


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Enable CI/CD jobs to more easily use `artifact:push` command by setting options via environmental variables.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Add ACLI_PUSH_ARTIFACT_COMMIT_MSG, ACLI_PUSH_ARTIFACT_DESTINATION_GIT_BRANCH, AND ACLI_PUSH_ARTIFACT_DESTINATION_GIT_URLS env var support.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
