### PR TITLE
Fixes #757: Support binary data arguments for Cloud API.

### DIFF
--- a/src/Command/Api/ApiCommandBase.php
+++ b/src/Command/Api/ApiCommandBase.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\Command\Api;
 
 use Acquia\Cli\Command\CommandBase;
 use AcquiaCloudApi\Exception\ApiErrorException;
+use GuzzleHttp\Psr7\Utils;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -85,7 +86,17 @@ class ApiCommandBase extends CommandBase {
           if ($param_spec) {
             $param = $this->castParamType($param_spec, $param);
           }
-          $acquia_cloud_client->addOption('json', [$param_name => $param]);
+          if ($param_spec["format"] === 'binary') {
+            $acquia_cloud_client->addOption('multipart', [
+              [
+                'name'     => $param_name,
+                'contents' => Utils::tryFopen($param, 'r'),
+              ],
+            ]);
+          }
+          else {
+            $acquia_cloud_client->addOption('json', [$param_name => $param]);
+          }
         }
       }
     }

--- a/src/Command/Api/ApiCommandBase.php
+++ b/src/Command/Api/ApiCommandBase.php
@@ -86,7 +86,7 @@ class ApiCommandBase extends CommandBase {
           if ($param_spec) {
             $param = $this->castParamType($param_spec, $param);
           }
-          if ($param_spec["format"] === 'binary') {
+          if ($param_spec && array_key_exists('format', $param_spec) && $param_spec["format"] === 'binary') {
             $acquia_cloud_client->addOption('multipart', [
               [
                 'name'     => $param_name,

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1325,7 +1325,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
           $customer_application = $this->getApplicationFromAlias($alias);
           $input->setArgument('applicationUuid', $customer_application->uuid);
         } catch (AcquiaCliException $exception) {
-          throw new AcquiaCliException("No applications found using `$alias`. The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.");
+          throw new AcquiaCliException("The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.");
         }
       }
     }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1325,7 +1325,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
           $customer_application = $this->getApplicationFromAlias($alias);
           $input->setArgument('applicationUuid', $customer_application->uuid);
         } catch (AcquiaCliException $exception) {
-          throw new AcquiaCliException("{applicationUuid} must be a valid UUID or application alias.");
+          throw new AcquiaCliException("No applications found using `$alias`. The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.");
         }
       }
     }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -51,7 +51,7 @@ class ExceptionListener {
 
     if ($error instanceof AcquiaCliException) {
       switch ($errorMessage) {
-        case '{applicationUuid} must be a valid UUID or application alias.':
+        case 'No applications found using `$alias`. The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.':
           $this->writeApplicationAliasHelp();
           break;
         case '{environmentId} must be a valid UUID or site alias.':

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -51,7 +51,7 @@ class ExceptionListener {
 
     if ($error instanceof AcquiaCliException) {
       switch ($errorMessage) {
-        case 'No applications found using `$alias`. The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.':
+        case 'The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.':
           $this->writeApplicationAliasHelp();
           break;
         case '{environmentId} must be a valid UUID or site alias.':

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -151,7 +151,7 @@ class ApiCommandTest extends CommandTestBase {
       $this->executeCommand(['applicationUuid' => $alias], []);
     }
     catch (AcquiaCliException $exception) {
-      $this->assertEquals('No applications found using `$alias`. The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.', $exception->getMessage());
+      $this->assertEquals("No applications found using `$alias`. The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.", $exception->getMessage());
     }
     $this->prophet->checkPredictions();
   }

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -151,7 +151,7 @@ class ApiCommandTest extends CommandTestBase {
       $this->executeCommand(['applicationUuid' => $alias], []);
     }
     catch (AcquiaCliException $exception) {
-      $this->assertEquals("No applications found using `$alias`. The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.", $exception->getMessage());
+      $this->assertEquals("The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.", $exception->getMessage());
     }
     $this->prophet->checkPredictions();
   }

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -151,7 +151,7 @@ class ApiCommandTest extends CommandTestBase {
       $this->executeCommand(['applicationUuid' => $alias], []);
     }
     catch (AcquiaCliException $exception) {
-      $this->assertEquals('{applicationUuid} must be a valid UUID or application alias.', $exception->getMessage());
+      $this->assertEquals('No applications found using `$alias`. The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.', $exception->getMessage());
     }
     $this->prophet->checkPredictions();
   }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #757: Support binary data arguments for Cloud API.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Send binary data as multipart form data via Guzzle.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. ` ./bin/acli api:applications:search:configuration-set-create eemgrasmick [zip file path]`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
