### PR TITLE
Fix 769: remove the "format" definition for the VCS URI parameter.

### DIFF
--- a/assets/acquia-spec.yaml
+++ b/assets/acquia-spec.yaml
@@ -3166,7 +3166,6 @@ components:
         url:
           type: string
           description: The VCS url.
-          format: uri
     DeployCodeRequest:
       type: object
       required:


### PR DESCRIPTION
**Motivation**
Fixes [#769](https://github.com/acquia/cli/issues/769)

**Proposed changes**
Removes the `format` specification for the VCS URL parameter in the OpenAPI spec.
This stops clients auto-generated from the OpenAPI specification from raising an error when environments are listed. 

**Alternatives considered**
- Change the upstream API to output URIs. This is not recommended as its a breaking change.
- Replace `format: uri` with `pattern: ` followed by a regex. See [OpenAPI pattern documentation](https://swagger.io/docs/specification/data-models/data-types/#pattern). Not implemented because it's not clear whether the backend response is expected to be consistent for all users.

NB: this may not be relevant to the `acquia/cli` repository, if the canonical source of the OpenAPI spec is managed elsewhere.