### PR TITLE
Fixes #774: acli push:artifact does not force add scaffold files.

### DIFF
--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -406,7 +406,7 @@ class PushArtifactCommand extends PullCommandBase {
     $composer_json = json_decode($this->localMachineHelper->readFile(Path::join($artifact_dir, 'docroot', 'core', 'composer.json')), TRUE);
     foreach ($composer_json['extra']['drupal-scaffold']['file-mapping'] as $file => $asset_path) {
       if (strpos($file, '[web-root]') === 0) {
-        $this->scaffoldFiles[] = str_replace('[web-root]', 'docroot/core', $file);
+        $this->scaffoldFiles[] = str_replace('[web-root]', 'docroot', $file);
       }
     }
     $this->scaffoldFiles[] = 'docroot/autoload.php';

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -170,7 +170,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $process =  $this->mockProcess();
     $local_machine_helper->execute(['git', 'add', '-A'], Argument::type('callable'), $artifact_dir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'add', '-f', 'docroot/core/index.php'], NULL, $artifact_dir, FALSE)
+    $local_machine_helper->execute(['git', 'add', '-f', 'docroot/index.php'], NULL, $artifact_dir, FALSE)
       ->willReturn($process->reveal())->shouldBeCalled();
     $local_machine_helper->execute(['git', 'add', '-f', 'docroot/autoload.php'], NULL, $artifact_dir, FALSE)
       ->willReturn($process->reveal())->shouldBeCalled();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #774: acli push:artifact does not force add scaffold files.

**Proposed changes**
Correctly define the web root.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
