### PR TITLE
Remove plugin prompts from `acli new` command. (#784)

### DIFF
--- a/src/Command/NewCommand.php
+++ b/src/Command/NewCommand.php
@@ -85,6 +85,7 @@ class NewCommand extends CommandBase {
       'create-project',
       $project,
       $dir,
+      '--no-interaction',
     ]);
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException("Unable to create new project.");

--- a/tests/phpunit/src/Commands/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/NewCommandTest.php
@@ -96,6 +96,7 @@ class NewCommandTest extends CommandTestBase {
       'create-project',
       $project,
       $project_dir,
+      '--no-interaction',
     ];
     $local_machine_helper
       ->execute($command)


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
As of Composer 2.2, running `acli new` will ask to grant permissions to plugins. 

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Run `composer create-project` with a `--no-interaction` flag.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `acli new`
4. Validate that there are no prompts to allow plugins.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
