### PR TITLE
Parse GitLab hostname from url.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -384,7 +384,8 @@ class CodeStudioWizardCommand extends WizardCommandBase {
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException("Could not determine GitLab host: {error_message}", ['error_message' => $process->getErrorOutput()]);
     }
-    return trim($process->getOutput());
+    $url = trim($process->getOutput());
+    return parse_url($url, PHP_URL_HOST);
   }
 
   /**

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -384,8 +384,14 @@ class CodeStudioWizardCommand extends WizardCommandBase {
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException("Could not determine GitLab host: {error_message}", ['error_message' => $process->getErrorOutput()]);
     }
-    $url = trim($process->getOutput());
-    return parse_url($url, PHP_URL_HOST);
+    $output = trim($process->getOutput());
+    $url_parts = parse_url($output);
+    if (!array_key_exists('scheme', $url_parts) && !array_key_exists('host', $url_parts)) {
+      // $output looks like code.cloudservices.acquia.io.
+      return $output;
+    }
+    // $output looks like http://code.cloudservices.acquia.io/.
+    return $url_parts['host'];
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Cloud IDE has the GITLAB_HOST set to an absolute URL rather than a host name. This breaks `cs:wizard`.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Parse the hostname from the URL.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Fix the variable in Cloud IDE.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
