### PR TITLE
Fixes #790: add --all option to remote:aliases:download (CLI-629)

### DIFF
--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -99,7 +99,7 @@ class AliasesDownloadCommand extends SshCommand {
         $drushFiles[] = $base_dir . '/' . $file->getFileName();
       }
     }
-    $archive->extractTo(dirname($drush_aliases_dir), $drushFiles, TRUE);
+    $archive->extractTo($drush_aliases_dir, $drushFiles, TRUE);
     $this->output->writeln(sprintf(
       'Cloud Platform Drush aliases installed into <options=bold>%s</>',
       $drush_aliases_dir
@@ -158,7 +158,7 @@ class AliasesDownloadCommand extends SshCommand {
               ->getLocalFilepath('~') . '/.drush';
           break;
         case 9:
-          $this->drushAliasesDir = Path::join($this->dir, 'drush', 'sites');
+          $this->drushAliasesDir = Path::join($this->dir, 'drush');
           break;
         default:
           throw new AcquiaCliException("Unknown Drush version");

--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -35,7 +35,7 @@ class AliasesDownloadCommand extends SshCommand {
   protected function configure() {
     $this->setDescription('Download Drush aliases for the Cloud Platform')
       ->addOption('destination-dir', NULL, InputOption::VALUE_REQUIRED, 'The directory to which aliases will be downloaded')
-      ->addOption('all-applications', 'all', InputOption::VALUE_NONE, 'Download the aliases for all applications that you have access to, not just the current one.');
+      ->addOption('all', NULL, InputOption::VALUE_NONE, 'Download the aliases for all applications that you have access to, not just the current one.');
     $this->acceptApplicationUuid();
   }
 
@@ -49,14 +49,16 @@ class AliasesDownloadCommand extends SshCommand {
     $alias_version = $this->promptChooseDrushAliasVersion();
     $site_prefix = '';
     $all = $input->getOption('all');
-    $application_uuid_argument = $input->getOption('applicationUuid');
+    $application_uuid_argument = $input->getArgument('applicationUuid');
     $single_application = !$all || $application_uuid_argument;
-    if ($alias_version === 9 && $single_application) {
+    if ($alias_version === 9) {
       $this->setDirAndRequireProjectCwd($input);
-      $cloud_application_uuid = $this->determineCloudApplication();
-      $cloud_application = $this->getCloudApplication($cloud_application_uuid);
-      $parts = explode(':', $cloud_application->hosting->id);
-      $site_prefix = $parts[1];
+      if ($single_application) {
+        $cloud_application_uuid = $this->determineCloudApplication();
+        $cloud_application = $this->getCloudApplication($cloud_application_uuid);
+        $parts = explode(':', $cloud_application->hosting->id);
+        $site_prefix = $parts[1];
+      }
     }
     $acquia_cloud_client->addQuery('version', $alias_version);
     $account_adapter = new Account($acquia_cloud_client);

--- a/tests/fixtures/project/testdir/sites/devcloud2.site.yml
+++ b/tests/fixtures/project/testdir/sites/devcloud2.site.yml
@@ -1,0 +1,14 @@
+# Application 'eemgrasmick', environment 'prod'.
+prod:
+  root: /var/www/html/eemgrasmick.prod/docroot
+  ac-site: eemgrasmick
+  ac-env: prod
+  ac-realm: prod
+  uri: eemgrasmick.prod.acquia-sites.com
+  prod.livedev:
+    parent: '@eemgrasmick.prod'
+    root: /mnt/gfs/eemgrasmick.prod/livedev/docroot
+  host: eemgrasmick.ssh.prod.acquia-sites.com
+  user: eemgrasmick.prod
+  paths:
+    drush-script: drush9


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #790: add --all option to remote:aliases:download.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Add --all option to remote:aliases:download.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `acli remote:aliases:download --all`
4. Validate all aliases were downloaded to drush/sites.
5. Run `acli remote:aliases:download`
6. Validate only one alias file was created in drush/sites.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
