### PR TITLE
CLI-632: Add variables to scheduled jobs.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -549,11 +549,19 @@ class CodeStudioWizardCommand extends WizardCommandBase {
 
     if (!$this->getGitLabScheduleByDescription($project, $scheduled_pipeline_description)) {
       $this->checklist->addItem("Creating scheduled pipeline <comment>$scheduled_pipeline_description</comment>");
-      $this->gitLabClient->schedules()->create($project['id'], [
+      $pipeline = $this->gitLabClient->schedules()->create($project['id'], [
         'description' => $scheduled_pipeline_description,
         'ref' => $project['default_branch'],
         # Every Thursday at midnight.
         'cron' => '0 0 * * 4',
+      ]);
+      $this->gitLabClient->schedules()->addVariable($project['id'], $pipeline['id'], [
+        'key' => 'ACQUIA_JOBS_DEPRECATED_UPDATE',
+        'value' => 'true',
+      ]);
+      $this->gitLabClient->schedules()->addVariable($project['id'], $pipeline['id'], [
+        'key' => 'ACQUIA_JOBS_COMPOSER_UPDATE',
+        'value' => 'true',
       ]);
     }
     else {

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -196,7 +196,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->mockGitLabVariables($this::$application_uuid, $projects);
     $schedules = $this->prophet->prophesize(Schedules::class);
     $schedules->showAll($this->gitLabProjectId)->willReturn([]);
-    $schedules->create($this->gitLabProjectId, Argument::type('array'));
+    $pipeline = ['id' => 1];
+    $schedules->create($this->gitLabProjectId, Argument::type('array'))->willReturn($pipeline);
+    $schedules->addVariable($this->gitLabProjectId, $pipeline['id'], Argument::type('array'));
     $gitlab_client->schedules()->willReturn($schedules->reveal());
     $gitlab_client->projects()->willReturn($projects);
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
This enables code studio to set ACQUIA_JOBS_DEPRECATED_UPDATE and ACQUIA_JOBS_COMPOSER_UPDATE to "false."

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Each pipeline gets these variables set to true for the pipeline.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
