### PR TITLE
CLI-662: Add open:app command.

### DIFF
--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -1,19 +1,18 @@
 <?php
 
-namespace Acquia\Cli\Command;
+namespace Acquia\Cli\Command\App;
 
+use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Helpers\LocalMachineHelper;
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
-use AcquiaCloudApi\Endpoints\Logs;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class OpenCommand.
+ * Class AppOpenCommand.
  */
-class OpenCommand extends CommandBase {
+class AppOpenCommand extends CommandBase {
 
-  protected static $defaultName = 'open:application';
+  protected static $defaultName = 'app:open';
 
   /**
    * {inheritdoc}.
@@ -22,7 +21,7 @@ class OpenCommand extends CommandBase {
     $this->setDescription('Opens your browser to view a given Cloud application')
       ->acceptApplicationUuid()
       ->setHidden(!LocalMachineHelper::isBrowserAvailable())
-      ->setAliases(['open', 'open:app', 'o']);
+      ->setAliases(['open', 'o']);
   }
 
   /**

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -430,6 +430,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       ->addUsage(self::getDefaultName() . ' [<applicationAlias>]')
       ->addUsage(self::getDefaultName() . ' myapp')
       ->addUsage(self::getDefaultName() . ' abcd1234-1111-2222-3333-0e02b2c3d470');
+
+    return $this;
   }
 
   /**

--- a/src/Command/OpenCommand.php
+++ b/src/Command/OpenCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Acquia\Cli\Command;
+
+use Acquia\Cli\Helpers\LocalMachineHelper;
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
+use AcquiaCloudApi\Endpoints\Logs;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class OpenCommand.
+ */
+class OpenCommand extends CommandBase {
+
+  protected static $defaultName = 'open:application';
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure() {
+    $this->setDescription('Opens your browser to view a given Cloud application')
+      ->acceptApplicationUuid()
+      ->setHidden(!LocalMachineHelper::isBrowserAvailable())
+      ->setAliases(['open', 'open:app', 'o']);
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return int 0 if everything went fine, or an exit code
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $application_uuid = $this->determineCloudApplication();
+    $this->localMachineHelper->startBrowser('https://cloud.acquia.com/a/applications/' . $application_uuid);
+
+    return 0;
+  }
+
+}

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Helpers;
 
 use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use loophp\phposinfo\OsInfo;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
@@ -374,6 +375,26 @@ class LocalMachineHelper {
   }
 
   /**
+   * Determines if a browser is available on the local machine.
+   *
+   * @return bool
+   *   TRUE if a browser is available.
+   */
+  public static function isBrowserAvailable(): bool {
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+      return FALSE;
+    }
+    if (getenv('DISPLAY')) {
+      return TRUE;
+    }
+    if (OsInfo::isWindows() || OsInfo::isApple()) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
    * Starts a background browser/tab for the current site or a specified URL.
    *
    * @param $uri
@@ -389,7 +410,7 @@ class LocalMachineHelper {
   public function startBrowser($uri = NULL, $browser = NULL): bool {
     // We can only open a browser if we have a DISPLAY environment variable on
     // POSIX or are running Windows or OS X.
-    if (!getenv('DISPLAY') && !OsInfo::isWindows() && !OsInfo::isApple()) {
+    if (!self::isBrowserAvailable()) {
       $this->logger->info('No graphical display appears to be available, not starting browser.');
       return FALSE;
     }

--- a/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
+++ b/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Acquia\Cli\Tests\Commands\App;
+
+use Acquia\Cli\Command\App\AppOpenCommand;
+use Acquia\Cli\Tests\CommandTestBase;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Class AppOpenCommandTest.
+ *
+ * @property \Acquia\Cli\Command\App\AppOpenCommand $command
+ */
+class AppOpenCommandTest extends CommandTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function createCommand(): Command {
+    return $this->injectCommand(AppOpenCommand::class);
+  }
+
+  /**
+   * Tests the 'app:open' command.
+   *
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \Exception
+   */
+  public function testAppOpenCommand(): void {
+    $application_uuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
+    $local_machine_helper = $this->mockLocalMachineHelper();
+    $local_machine_helper->startBrowser('https://cloud.acquia.com/a/applications/' . $application_uuid)->shouldBeCalled();
+    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $this->createMockAcliConfigFile($application_uuid);
+    $this->mockApplicationRequest();
+    $this->executeCommand([], []);
+
+    // Assert.
+    $this->prophet->checkPredictions();
+    $output = $this->getDisplay();
+  }
+
+}


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Enable users to easily open a Cloud application in Cloud UI via `app:open` command.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Add `app:open` command.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `cd` into a Drupal project directory.
4. Run `acli app:open`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
