### PR TITLE
Transform project name into asciii safe slugs.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Process;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 
 /**
  * Class CodeStudioWizardCommand.
@@ -574,8 +575,9 @@ class CodeStudioWizardCommand extends WizardCommandBase {
       $parameters['namespace_id'] = $project_group['id'];
     }
 
-    $project = $this->gitLabClient->projects()
-      ->create($cloud_application->name, $parameters);
+    $slugger = new AsciiSlugger();
+    $project_name = $slugger->slug($cloud_application->name);
+    $project = $this->gitLabClient->projects()->create($project_name, $parameters);
     $this->gitLabClient->projects()->uploadAvatar($project['id'], __DIR__ . '/drupal_icon.png');
     $this->io->success("Created {$project['path_with_namespace']} project in Code Studio.");
     return $project;


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Cloud applications with special characters in the name will cause a failure in cs:wizard.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Strip non alpha numeric characters from project names.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
