### PR TITLE
CLI-685: Set up email:info command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ tests/fixtures/project/.acquia-cli.yml
 ###< phpunit/phpunit ###
 
 cx-api-spec
+
+# Generated files from Platform Email configuration/info commands
 dns-records.yaml
 dns-records.json
-
 subscription-*/

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ tests/fixtures/project/.acquia-cli.yml
 cx-api-spec
 dns-records.yaml
 dns-records.json
+
+domain-info-*/

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ cx-api-spec
 dns-records.yaml
 dns-records.json
 
-domain-info-*/
+subscription-*/

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "guzzlehttp/guzzle": "^7.4",
         "http-interop/http-factory-guzzle": "^1.0",
         "kevinrob/guzzle-cache-middleware": "^3.3",
+        "league/csv": "^9.8",
         "loophp/phposinfo": "^1.7.2",
         "m4tthumphrey/php-gitlab-api": "^11.5",
         "psr/log": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a26d5098604d3e968a73cf4be4d7663",
+    "content-hash": "1289a1109b3672d2a5c0cf340f0dba4e",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -138,12 +138,12 @@
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "Clue\\StreamFilter\\": "src/"
-                }
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1062,6 +1062,84 @@
             "time": "2022-01-04T16:40:46+00:00"
         },
         {
+            "name": "league/csv",
+            "version": "9.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "friendsofphp/php-cs-fixer": "^v3.4.0",
+                "phpstan/phpstan": "^1.3.0",
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.5.11"
+            },
+            "suggest": {
+                "ext-dom": "Required to use the XMLConverter and or the HTMLConverter classes",
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CSV data manipulation made easy in PHP",
+            "homepage": "https://csv.thephpleague.com",
+            "keywords": [
+                "convert",
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "transform",
+                "write"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-01-04T00:13:07+00:00"
+        },
+        {
             "name": "league/oauth2-client",
             "version": "2.6.1",
             "source": {
@@ -1659,10 +1737,6 @@
                 "message",
                 "psr-7"
             ],
-            "support": {
-                "issues": "https://github.com/php-http/message/issues",
-                "source": "https://github.com/php-http/message/tree/1.13.0"
-            },
             "time": "2022-02-11T13:41:14+00:00"
         },
         {
@@ -2820,10 +2894,6 @@
                 "promise",
                 "promises"
             ],
-            "support": {
-                "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.9.0"
-            },
             "funding": [
                 {
                     "url": "https://github.com/WyriHaximus",
@@ -3226,9 +3296,6 @@
                 "caching",
                 "psr6"
             ],
-            "support": {
-                "source": "https://github.com/symfony/cache/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3483,9 +3550,6 @@
                 "console",
                 "terminal"
             ],
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3572,9 +3636,6 @@
             ],
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3710,9 +3771,6 @@
                 "env",
                 "environment"
             ],
-            "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4048,6 +4106,11 @@
                 "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
+            "extra": {
+                "patches_applied": [
+                    "symfony-fs-mirror.patch"
+                ]
+            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
@@ -4072,9 +4135,6 @@
             ],
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4199,10 +4259,6 @@
                 }
             ],
             "description": "Composer plugin for Symfony",
-            "support": {
-                "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v1.18.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4273,9 +4329,6 @@
             ],
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4385,9 +4438,6 @@
             ],
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4507,12 +4557,12 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
                 "psr-4": {
                     "Symfony\\Polyfill\\Ctype\\": ""
-                }
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4754,12 +4804,12 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
                 "psr-4": {
                     "Symfony\\Polyfill\\Mbstring\\": ""
-                }
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5087,9 +5137,6 @@
             ],
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5222,12 +5269,12 @@
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
                 "psr-4": {
                     "Symfony\\Component\\String\\": ""
                 },
+                "files": [
+                    "Resources/functions.php"
+                ],
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -5447,9 +5494,6 @@
             ],
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/validator/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5536,9 +5580,6 @@
                 "debug",
                 "dump"
             ],
-            "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.5"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -7536,10 +7577,6 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "support": {
-                "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.2.1"
-            },
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
@@ -8303,10 +8340,6 @@
                 "testing",
                 "xunit"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.14"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -8643,10 +8676,6 @@
                 "testing",
                 "xunit"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.16"
-            },
             "funding": [
                 {
                     "url": "https://phpunit.de/sponsors.html",
@@ -9215,10 +9244,6 @@
             "keywords": [
                 "global state"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -9908,10 +9933,10 @@
     ],
     "aliases": [
         {
-            "package": "consolidation/self-update",
-            "version": "2.0.0.0-alpha1",
             "alias": "1.1",
-            "alias_normalized": "1.1.0.0"
+            "alias_normalized": "1.1.0.0",
+            "version": "2.0.0.0-alpha1",
+            "package": "consolidation/self-update"
         }
     ],
     "minimum-stability": "dev",
@@ -9929,5 +9954,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -168,7 +168,7 @@ class CodeStudioWizardCommand extends WizardCommandBase {
       "",
       "Next, you should use git to push code to your Code Studio project. E.g.,",
       "  git remote add codestudio {$project['http_url_to_repo']}",
-      "  git remote push codestudio",
+      "  git push codestudio",
     ]);
     $this->io->note(["If the {$account->mail} Cloud account is deleted in the future, this Code Studio project will need to be re-configured."]);
 

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -62,7 +62,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
 
       $this->renderApplicationAssociations($output, $client, $subscription, $subscription_applications);
 
-      $this->io->info("CSV files with these tables have been exported to ./subscription-{$subscription->uuid}-domains. A detailed breakdown of each domain's DNS records has been exported there as well.");
+      $this->io->info("CSV files with these tables have been exported to <options=bold>/subscription-{$subscription->uuid}-domains</>. A detailed breakdown of each domain's DNS records has been exported there as well.");
     }
     else {
       $this->io->info("No email domains registered in {$subscription->name}.");

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Acquia\Cli\Command\Email;
+
+use Acquia\Cli\Command\CommandBase;
+use Acquia\Cli\Exception\AcquiaCliException;
+use AcquiaCloudApi\Endpoints\Applications;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Helper\TableCellStyle;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
+
+/**
+ * Class EmailInfoForSubscriptionCommand.
+ */
+class EmailInfoForSubscriptionCommand extends CommandBase {
+
+  protected static $defaultName = 'email:info';
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure() {
+    $this->setDescription('Print information related to Platform Email set up in a subscription.')
+      ->addArgument('subscriptionUuid', InputArgument::OPTIONAL, 'The subscription UUID whose Platform Email configuration is to be checked.')
+      ->setHelp('This command lists information related to Platform Email for a subscription, including which domains have been validated, which have not, and which applications have Platform Email domains associated.');
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return int
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+
+    $client = $this->cloudApiClientService->getClient();
+    $subscription = $this->determineCloudSubscription();
+
+    $response = $client->request('get', "/subscriptions/{$subscription->uuid}/domains");
+
+    if (count($response)) {
+      $all_domains_table = $this->createTotalDomainTable($output, "Subscription {$subscription->name} - All Domains");
+      $verified_domains_table = $this->createDomainStatusTable($output, "Subscription {$subscription->name} - Verified Domains");
+      $pending_domains_table = $this->createDomainStatusTable($output, "Subscription {$subscription->name} - Pending Domains");
+      $failed_domains_table = $this->createDomainStatusTable($output, "Subscription {$subscription->name} - Failed Domains");
+
+      foreach ($response as $domain) {
+        if ($domain->health->code === '200') {
+          $verified_domains_table->addRow([
+            $domain->domain_name,
+            $domain->uuid,
+            'none'
+          ]);
+        }
+        else if ($domain->health->code === '202') {
+          $pending_domains_table->addRow([
+            $domain->domain_name,
+            $domain->uuid,
+            'none'
+          ]);
+        }
+        else {
+          $failed_domains_table->addRow([
+            $domain->domain_name,
+            $domain->uuid,
+            $domain->health->summary
+          ]);
+        }
+
+        $all_domains_table->addRow([
+          $domain->domain_name,
+          $domain->uuid,
+          $this->showHumanReadableStatus($domain->health->code) . ' - ' . $domain->health->code
+        ]);
+      }
+
+      $all_domains_table->render();
+      $this->io->newLine();
+
+      $verified_domains_table->render();
+      $this->io->newLine();
+
+      $pending_domains_table->render();
+      $this->io->newLine();
+
+      $failed_domains_table->render();
+      $this->io->newLine();
+
+      $applications_resource = new Applications($client);
+      $applications = $applications_resource->getAll();
+      $subscription_applications = [];
+
+      foreach ($applications as $application) {
+        if ($application->subscription->uuid === $subscription->uuid) {
+          $subscription_applications[] = $application;
+        }
+      }
+      if (count($subscription_applications) === 0) {
+        throw new AcquiaCliException("You do not have access to any applications on the {$subscription->name} subscription");
+      }
+      if (count($subscription_applications) > 100) {
+        $this->io->warning('You have over 100 applications in this subscription. Retrieving the email domains for each could take a while!');
+        $continue = $this->io->confirm('Do you wish to continue?');
+        if (!$continue) {
+          return 1;
+        }
+      }
+      $apps_domains_table = $this->createApplicationDomainsTable($output, 'Domain Association Status');
+      foreach($subscription_applications as $index => $app) {
+        $app_domains = $client->request('get', "/applications/{$app->uuid}/email/domains");
+
+        if ($index !== 0) {
+          $apps_domains_table->addRow([new TableSeparator(['colspan' => 2])]);
+        }
+        $apps_domains_table->addRow([new TableCell("Application: {$app->name}", ['colspan' => 2])]);
+        if(count($app_domains)) {
+          foreach($app_domains as $domain) {
+            $apps_domains_table->addRow([
+              $domain->domain_name,
+              var_export($domain->flags->associated, TRUE)
+            ]);
+          }
+        }
+        else {
+          $apps_domains_table->addRow([new TableCell("No domains eligible for association.", [
+            'colspan' => 2,
+            'style' => new TableCellStyle([
+              'fg' => 'yellow'
+            ]),
+          ])
+]);
+        }
+      }
+      $apps_domains_table->render();
+    }
+    else {
+      $this->io->info("No email domains registered in {$subscription->name}.");
+    }
+
+    return 0;
+  }
+
+  /**
+   * Creates a table of all domains registered in a subscription.
+   *
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param string $title
+   *
+   * @return \Symfony\Component\Console\Helper\Table
+   */
+  protected function createTotalDomainTable(OutputInterface $output, string $title): Table {
+    $terminal_width = (new Terminal())->getWidth();
+    $terminal_width *= .90;
+    $table = new Table($output);
+    $table->setHeaders([
+      'Domain Name',
+      'Domain UUID',
+      'Verification Status',
+    ]);
+    $table->setHeaderTitle($title);
+    $table->setColumnWidths([
+      $terminal_width * .2,
+      $terminal_width * .2,
+      $terminal_width * .1,
+    ]);
+
+    return $table;
+  }
+
+  /**
+   * Creates a table of domains of one verification status in a subscription.
+   *
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param string $title
+   *
+   * @return \Symfony\Component\Console\Helper\Table
+   */
+  protected function createDomainStatusTable(OutputInterface $output, string $title): Table {
+    $terminal_width = (new Terminal())->getWidth();
+    $terminal_width *= .90;
+    $table = new Table($output);
+    $table->setHeaders([
+      'Domain Name',
+      'Domain UUID',
+      'Summary',
+    ]);
+    $table->setHeaderTitle($title);
+    $table->setColumnWidths([
+      $terminal_width * .2,
+      $terminal_width * .2,
+      $terminal_width * .2,
+    ]);
+
+    return $table;
+  }
+
+  /**
+   * Creates a table of domains of one verification status in a subscription.
+   *
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param string $title
+   *
+   * @return \Symfony\Component\Console\Helper\Table
+   */
+  protected function createApplicationDomainsTable(OutputInterface $output, string $title): Table {
+    $terminal_width = (new Terminal())->getWidth();
+    $terminal_width *= .90;
+    $table = new Table($output);
+    $table->setHeaders([
+      'Domain Name',
+      'Associated?',
+    ]);
+    $table->setHeaderTitle($title);
+    $table->setColumnWidths([
+      $terminal_width * .2,
+      $terminal_width * .1,
+    ]);
+
+    return $table;
+  }
+
+  /**
+   * Returns a human-readable string of whether a status code represents
+   * a failed, pending, or successful domain verification.
+   *
+   * @param string $code
+   *
+   * @return string
+   */
+  protected function showHumanReadableStatus(string $code) {
+    switch ($code) {
+      case '200':
+          return "Succeeded";
+      case '202':
+          return "Pending";
+      default:
+          return "Failed";
+    }
+  }
+
+}

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -80,6 +80,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    * @param array $domain_list
    *
    * @return void
+   * @throws \League\Csv\CannotInsertRecord
    */
   protected function writeDomainsToTables(OutputInterface $output, SubscriptionResponse $subscription, array $domain_list) {
 
@@ -225,6 +226,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    * @param $subscription_applications
    *
    * @return void
+   * @throws \League\Csv\CannotInsertRecord
    */
   protected function renderApplicationAssociations(OutputInterface $output, Client $client, $subscription, $subscription_applications) {
     $apps_domains_table = $this->createApplicationDomainsTable($output, 'Domain Association Status');
@@ -349,7 +351,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    *
    * @return string
    */
-  protected function showHumanReadableStatus(string $code) {
+  protected function showHumanReadableStatus(string $code): string {
     switch ($code) {
       case '200':
           return "Succeeded";

--- a/symfony.lock
+++ b/symfony.lock
@@ -86,6 +86,9 @@
     "kevinrob/guzzle-cache-middleware": {
         "version": "v3.3.1"
     },
+    "league/csv": {
+        "version": "9.8.0"
+    },
     "league/oauth2-client": {
         "version": "2.4.1"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -87,7 +87,7 @@
         "version": "v3.3.1"
     },
     "league/csv": {
-        "version": "9.8.0"
+        "version": "^9.8.0"
     },
     "league/oauth2-client": {
         "version": "2.4.1"

--- a/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
@@ -123,7 +123,7 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Please select a Cloud Platform subscription
       0,
       // Do you wish to continue?
-      'yes'
+      'no'
     ];
     $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
     $this->clientProphecy->request('get', '/subscriptions')
@@ -151,8 +151,7 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
 
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
-    $this->assertEquals(0, $this->getStatusCode());
-    $this->assertEquals(101, substr_count($output, 'Application: '));
+    $this->assertEquals(1, $this->getStatusCode());
 
   }
 

--- a/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Acquia\Cli\Tests\Commands\Email;
+
+use Acquia\Cli\Command\Email\ConfigurePlatformEmailCommand;
+use Acquia\Cli\Command\Email\EmailInfoForSubscriptionCommand;
+use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\Cli\Tests\CommandTestBase;
+use AcquiaCloudApi\Exception\ApiErrorException;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Class ConfigurePlatformEmailCommandTest.
+ *
+ * @property \Acquia\Cli\Command\Email\EmailInfoForSubscriptionCommand $command
+ * @package Acquia\Cli\Tests\Commands
+ */
+class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function createCommand(): Command {
+    return $this->injectCommand(EmailInfoForSubscriptionCommand::class);
+  }
+
+  /**
+   * Tests the 'email:info' command.
+   *
+   * @throws \Exception
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function testEmailInfoForSubscription(): void {
+    $inputs = [
+      // Please select a Cloud Platform subscription
+      0,
+    ];
+    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $this->clientProphecy->request('get', '/subscriptions')
+      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->shouldBeCalledTimes(1);
+
+    $get_domains_response = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($get_domains_response->_embedded->items);
+
+    $applications_response = $this->mockApplicationsRequest();
+    // We need the application to belong to the subscription.
+    $applications_response->_embedded->items[0]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+    $applications_response->_embedded->items[1]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+    $get_app_domains_response = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
+    $this->clientProphecy->request('get', "/applications/{$applications_response->_embedded->items[0]->uuid}/email/domains")->willReturn($get_app_domains_response->_embedded->items);
+    $this->clientProphecy->request('get', "/applications/{$applications_response->_embedded->items[1]->uuid}/email/domains")->willReturn($get_app_domains_response->_embedded->items);
+
+    $this->executeCommand([], $inputs);
+    $output = $this->getDisplay();
+    $this->assertEquals(0, $this->getStatusCode());
+    $this->assertStringContainsString('Application: ', $output);
+    $this->assertEquals(4, substr_count($output, $get_app_domains_response->_embedded->items[0]->domain_name));
+  }
+
+}

--- a/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
@@ -2,11 +2,9 @@
 
 namespace Acquia\Cli\Tests\Commands\Email;
 
-use Acquia\Cli\Command\Email\ConfigurePlatformEmailCommand;
 use Acquia\Cli\Command\Email\EmailInfoForSubscriptionCommand;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\CommandTestBase;
-use AcquiaCloudApi\Exception\ApiErrorException;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -41,21 +39,174 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       ->shouldBeCalledTimes(1);
 
     $get_domains_response = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($get_domains_response->_embedded->items);
+    // duplicating the request to ensure there is at least one domain with a successful, pending, and failed health code
+    $get_domains_response_2 = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $total_domains_list = array_merge($get_domains_response->_embedded->items, $get_domains_response_2->_embedded->items);
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($total_domains_list);
+
+    $total_domains_list[2]->domain_name = 'example3.com';
+    $total_domains_list[2]->health->code = '200';
+
+    $total_domains_list[3]->domain_name = 'example4.com';
+    $total_domains_list[3]->health->code = '202';
 
     $applications_response = $this->mockApplicationsRequest();
-    // We need the application to belong to the subscription.
+
     $applications_response->_embedded->items[0]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
-    $applications_response->_embedded->items[1]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+
     $get_app_domains_response = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
-    $this->clientProphecy->request('get', "/applications/{$applications_response->_embedded->items[0]->uuid}/email/domains")->willReturn($get_app_domains_response->_embedded->items);
-    $this->clientProphecy->request('get', "/applications/{$applications_response->_embedded->items[1]->uuid}/email/domains")->willReturn($get_app_domains_response->_embedded->items);
+    // duplicating the request to ensure added domains are included in association list
+    $get_app_domains_response_2 = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
+    $total_app_domains_list = array_merge($get_app_domains_response->_embedded->items, $get_app_domains_response_2->_embedded->items);
+    $this->clientProphecy->request('get', "/applications/{$applications_response->_embedded->items[0]->uuid}/email/domains")->willReturn($total_app_domains_list);
+
+    $total_app_domains_list[2]->domain_name = 'example3.com';
+    $total_app_domains_list[2]->flags->associated = TRUE;
+
+    $total_app_domains_list[3]->domain_name = 'example4.com';
+    $total_app_domains_list[3]->flags->associated = FALSE;
 
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
     $this->assertEquals(0, $this->getStatusCode());
     $this->assertStringContainsString('Application: ', $output);
-    $this->assertEquals(4, substr_count($output, $get_app_domains_response->_embedded->items[0]->domain_name));
+    foreach($get_app_domains_response->_embedded->items as $app_domain) {
+      $this->assertEquals(3, substr_count($output, $app_domain->domain_name));
+    }
+
+    $this->assertEquals(2, substr_count($output, 'Failed - 404'));
+    $this->assertEquals(1, substr_count($output, 'Pending - 202'));
+    $this->assertEquals(1, substr_count($output, 'Succeeded - 200'));
+
+    $this->assertEquals(3, substr_count($output, 'true'));
+    $this->assertEquals(1, substr_count($output, 'false'));
+  }
+
+  /**
+   * Tests the 'email:info' command when the subscription has no applications.
+   *
+   * @throws \Exception
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   */
+  public function testEmailInfoForSubscriptionNoApps(): void {
+    $inputs = [
+      // Please select a Cloud Platform subscription
+      0,
+    ];
+    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $this->clientProphecy->request('get', '/subscriptions')
+      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->shouldBeCalledTimes(1);
+
+    $get_domains_response = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($get_domains_response->_embedded->items);
+
+    $this->mockApplicationsRequest();
+
+    try {
+      $this->executeCommand([], $inputs);
+    }
+    catch (AcquiaCliException $exception) {
+      $this->assertStringContainsString("You do not have access", $exception->getMessage());
+    }
+  }
+
+  /**
+   * Tests the 'email:info' command when the subscription has over 100 applications.
+   *
+   * @throws \Exception
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function testEmailInfoForSubscriptionWith101Apps(): void {
+    $inputs = [
+      // Please select a Cloud Platform subscription
+      0,
+      // Do you wish to continue?
+      'yes'
+    ];
+    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $this->clientProphecy->request('get', '/subscriptions')
+      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->shouldBeCalledTimes(1);
+
+    $get_domains_response = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($get_domains_response->_embedded->items);
+
+    $applications_response = $this->getMockResponseFromSpec('/applications', 'get', '200');
+    $applications_response->_embedded->items[0]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+    $applications_response->_embedded->items[1]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+
+    $app = $this->getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
+    for ($i = 2; $i < 101; $i++) {
+      $applications_response->_embedded->items[$i]= $app;
+      $applications_response->_embedded->items[$i]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+    }
+
+    $this->clientProphecy->request('get', '/applications')->willReturn($applications_response->_embedded->items);
+
+    foreach($applications_response->_embedded->items as $app) {
+      $this->clientProphecy->request('get', "/applications/{$app->uuid}/email/domains")->willReturn([]);
+    }
+
+    $this->executeCommand([], $inputs);
+    $output = $this->getDisplay();
+    $this->assertEquals(0, $this->getStatusCode());
+    $this->assertEquals(101, substr_count($output, 'Application: '));
+
+  }
+
+  /**
+   * Tests the 'email:info' command when the subscription has no domains registred.
+   *
+   * @throws \Exception
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function testEmailInfoForSubscriptionNoDomains(): void {
+    $inputs = [
+      // Please select a Cloud Platform subscription
+      0,
+    ];
+    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $this->clientProphecy->request('get', '/subscriptions')
+      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->shouldBeCalledTimes(1);
+
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn([]);
+
+    $this->executeCommand([], $inputs);
+    $output = $this->getDisplay();
+    $this->assertStringContainsString('No email domains', $output);
+  }
+
+  /**
+   * Tests the 'email:info' command when the subscription's applications have no domains eligible for association.
+   *
+   * @throws \Exception
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function testEmailInfoForSubscriptionNoAppDomains(): void {
+    $inputs = [
+      // Please select a Cloud Platform subscription
+      0,
+    ];
+    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $this->clientProphecy->request('get', '/subscriptions')
+      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->shouldBeCalledTimes(1);
+
+    $get_domains_response = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($get_domains_response->_embedded->items);
+
+    $applications_response = $this->mockApplicationsRequest();
+
+    $applications_response->_embedded->items[0]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+
+    $this->clientProphecy->request('get', "/applications/{$applications_response->_embedded->items[0]->uuid}/email/domains")->willReturn([]);
+
+    $this->executeCommand([], $inputs);
+    $output = $this->getDisplay();
+    $this->assertStringContainsString('No domains eligible', $output);
   }
 
 }


### PR DESCRIPTION
**Motivation**
Supplements bulk Platform Email functionality/support by showing users the verification statuses of email domains registered to a subscription, as well as associated (or dissociated) domains for each application of the subscription.

**Proposed changes**
Add a new `email:info` command

**Alternatives considered**

**Testing steps**

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `./bin/acli email:info`
4. Verify that CSV files are successfully written to a folder called "domain-info-*" in the directory where `email:info` is being run.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
