### PR TITLE
Hotfix: Adjust formatting of CSV file autogeneration message in email:info command

### DIFF
--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -62,7 +62,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
 
       $this->renderApplicationAssociations($output, $client, $subscription, $subscription_applications);
 
-      $this->io->info("CSV files with these tables have been exported to <options=bold>/subscription-{$subscription->uuid}-domains</>. A detailed breakdown of each domain's DNS records has been exported there as well.");
+      $this->output->writeln("<info>CSV files with these tables have been exported to <options=bold>/subscription-{$subscription->uuid}-domains</>. A detailed breakdown of each domain's DNS records has been exported there as well.</info>");
     }
     else {
       $this->io->info("No email domains registered in {$subscription->name}.");


### PR DESCRIPTION
**Motivation**
Ensures that formatting of the name of the created CSV file directory is clear when running `email:info`.
**Proposed changes**
**Before**
<img width="890" alt="Screen Shot 2022-03-10 at 5 08 28 PM" src="https://user-images.githubusercontent.com/28101298/157763461-dc27aa5e-5f2c-44d5-9988-91bbf1743d0b.png">
**After**
<img width="1460" alt="Screen Shot 2022-03-10 at 5 08 36 PM" src="https://user-images.githubusercontent.com/28101298/157763473-988ee095-8444-4123-a7ff-6f536c59d917.png">
