### PR TITLE
Automatically create Jira tickets

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,0 +1,36 @@
+on:
+  issues:
+    types:
+      - opened
+
+name: Create new tickets in Jira
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Create new tickets in Jira
+    permissions:
+      issues: write
+    steps:
+    - name: Login
+      uses: acquia/gajira-login@server
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+    - name: Create
+      id: create
+      uses: acquia/gajira-create@server
+      with:
+        project: DX
+        issuetype: Task
+        summary: ${{ github.event.issue.title }}
+        description: ${{ github.event.issue.html_url }}
+        fields: '{"components": [{"id": "21989"}]}'
+    - name: Update Github issue with Jira ticket prefix
+      run: 'gh issue edit $GH_ISSUE --title "$JIRA_ISSUE: $ISSUE_TITLE"'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_ISSUE: ${{ github.event.issue.html_url }}
+        JIRA_ISSUE: ${{ steps.create.outputs.issue }}
+        ISSUE_TITLE: ${{ github.event.issue.title }}

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -22,11 +22,10 @@ jobs:
       id: create
       uses: acquia/gajira-create@server
       with:
-        project: DX
+        project: CLI
         issuetype: Task
         summary: ${{ github.event.issue.title }}
         description: ${{ github.event.issue.html_url }}
-        fields: '{"components": [{"id": "21989"}]}'
     - name: Update Github issue with Jira ticket prefix
       run: 'gh issue edit $GH_ISSUE --title "$JIRA_ISSUE: $ISSUE_TITLE"'
       env:


### PR DESCRIPTION
@grasmash you can see this working for BLT:

- https://github.com/acquia/blt/issues/4488
- https://github.com/acquia/blt/blob/main/.github/workflows/jira.yml

I'm going to port it to our other open-source projects as well.

This can't really be tested before merging. After it's merged I'll create a test issue.