### PR TITLE
Fixes #854: Add --tag option to push:artifact.

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1775,4 +1775,25 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return $api_secret;
   }
 
+  /**
+   * Get the first environment for a given Cloud application.
+   *
+   * @param string $cloud_app_uuid
+   *
+   * @return \AcquiaCloudApi\Response\EnvironmentResponse|null
+   * @throws \Exception
+   */
+  protected function getAnyNonProdAhEnvironment(string $cloud_app_uuid): ?EnvironmentResponse {
+    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    $environment_resource = new Environments($acquia_cloud_client);
+    /** @var EnvironmentResponse[] $application_environments */
+    $application_environments = iterator_to_array($environment_resource->getAll($cloud_app_uuid));
+    foreach ($application_environments as $environment) {
+      if (!$environment->flags->production) {
+        return $environment;
+      }
+    }
+    return NULL;
+  }
+
 }

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -68,13 +68,14 @@ class PushArtifactCommand extends PullCommandBase {
       ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Do not push changes to Acquia Cloud')
       ->addOption('destination-git-urls', NULL, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The URL(s) of your git repository to which the artifact branch will be pushed')
       ->addOption('destination-git-branch', NULL, InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
+      ->addOption('destination-git-tag', 't', InputOption::VALUE_REQUIRED, 'The destination tag to push the artifact to. Using this option requires also using the --source-git-branch option')
       ->addOption('source-git-branch', 's', InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
-      ->addOption('destination-git-tag', 't', InputOption::VALUE_REQUIRED, 'The destination tag to push the artifact to')
       ->acceptEnvironmentId()
       ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL
       . 'To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events')
-      ->addUsage('--no-sanitize --dry-run # skip sanitization and Git push')
+      ->addUsage('--destination-git-branch=main-build')
+      ->addUsage('--source-git-branch=main-build --destination-git-tag=1.0.0')
       ->addUsage('--dest-git-url=example@svn-1.prod.hosting.acquia.com:example.git --dest-branch=main-build');
   }
 
@@ -108,8 +109,8 @@ class PushArtifactCommand extends PullCommandBase {
     $ref_type = $this->input->getOption('destination-git-tag') ? 'tag' : 'branch';
     $this->io->note([
       "Acquia CLI will:",
-      "- clone $source_git_branch from $destination_git_urls[0]",
-      "- Compile the contents of $this->dir into an artifact",
+      "- git clone $source_git_branch from $destination_git_urls[0]",
+      "- Compile the contents of $this->dir into an artifact in a temporary directory",
       "- Copy the artifact files into the checked out copy of $source_git_branch",
       "- Commit changes and push the $destination_git_ref $ref_type to the following git remote(s):",
       "  $destination_git_urls_string",

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -66,10 +66,10 @@ class PushArtifactCommand extends PullCommandBase {
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be pushed')
       ->addOption('no-sanitize', NULL, InputOption::VALUE_NONE, 'Do not sanitize the build artifact')
       ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Do not push changes to Acquia Cloud')
-      ->addOption('destination-git-urls', NULL, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The URL(s) of your git repository to which the artifact branch will be pushed')
-      ->addOption('destination-git-branch', NULL, InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
-      ->addOption('destination-git-tag', 't', InputOption::VALUE_REQUIRED, 'The destination tag to push the artifact to. Using this option requires also using the --source-git-branch option')
-      ->addOption('source-git-tag', 's', InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
+      ->addOption('destination-git-urls', 'u', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The URL(s) of your git repository to which the artifact branch will be pushed')
+      ->addOption('destination-git-branch', 'b', InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
+      ->addOption('destination-git-tag', 't', InputOption::VALUE_REQUIRED, 'The destination tag to push the artifact to. Using this option requires also using the --source-git-tag option')
+      ->addOption('source-git-tag', 's', InputOption::VALUE_REQUIRED, 'The source tag from which to create the tag artifact')
       ->acceptEnvironmentId()
       ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -69,7 +69,7 @@ class PushArtifactCommand extends PullCommandBase {
       ->addOption('destination-git-urls', NULL, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The URL(s) of your git repository to which the artifact branch will be pushed')
       ->addOption('destination-git-branch', NULL, InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
       ->addOption('destination-git-tag', 't', InputOption::VALUE_REQUIRED, 'The destination tag to push the artifact to. Using this option requires also using the --source-git-branch option')
-      ->addOption('source-git-branch', 's', InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
+      ->addOption('source-git-tag', 's', InputOption::VALUE_REQUIRED, 'The destination branch to push the artifact to')
       ->acceptEnvironmentId()
       ->setHelp('This command builds a sanitized deploy artifact by running <options=bold>composer install</>, removing sensitive files, and committing vendor directories.' . PHP_EOL . PHP_EOL
       . 'Vendor directories and scaffold files are committed to the build artifact even if they are ignored in the source repository.' . PHP_EOL . PHP_EOL
@@ -103,7 +103,7 @@ class PushArtifactCommand extends PullCommandBase {
     $application_uuid = $this->determineCloudApplication();
     $destination_git_urls = $this->determineDestinationGitUrls($application_uuid);
     $destination_git_ref = $this->determineDestinationGitRef();
-    $source_git_branch = $this->determineSourceGitBranch();
+    $source_git_branch = $this->determineSourceGitRef();
 
     $destination_git_urls_string = implode(',', $destination_git_urls);
     $ref_type = $this->input->getOption('destination-git-tag') ? 'tag' : 'branch';
@@ -458,15 +458,15 @@ class PushArtifactCommand extends PullCommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  protected function determineSourceGitBranch() {
-    if ($this->input->getOption('source-git-branch')) {
-      return $this->input->getOption('source-git-branch');
+  protected function determineSourceGitRef() {
+    if ($this->input->getOption('source-git-tag')) {
+      return $this->input->getOption('source-git-tag');
     }
-    if ($env_var = getenv('ACLI_PUSH_ARTIFACT_SOURCE_GIT_BRANCH')) {
+    if ($env_var = getenv('ACLI_PUSH_ARTIFACT_SOURCE_GIT_TAG')) {
       return $env_var;
     }
     if ($this->input->getOption('destination-git-tag')) {
-      throw new AcquiaCliException('You must also set the --source-git-branch option when setting the --destination-git-tag option.');
+      throw new AcquiaCliException('You must also set the --source-git-tag option when setting the --destination-git-tag option.');
     }
 
     // Assume the source and destination branches are the same.

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -464,6 +464,9 @@ class PushArtifactCommand extends PullCommandBase {
     if ($env_var = getenv('ACLI_PUSH_ARTIFACT_SOURCE_GIT_BRANCH')) {
       return $env_var;
     }
+    if ($this->input->getOption('destination-git-tag')) {
+      throw new AcquiaCliException('You must also set the --source-git-branch option when setting the --destination-git-tag option.');
+    }
 
     // Assume the source and destination branches are the same.
     return $this->destinationGitRef;

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -186,27 +186,6 @@ EOT
   }
 
   /**
-   * Get the first environment for a given Cloud application.
-   *
-   * @param string $cloud_app_uuid
-   *
-   * @return \AcquiaCloudApi\Response\EnvironmentResponse|null
-   * @throws \Exception
-   */
-  protected function getAnyNonProdAhEnvironment(string $cloud_app_uuid): ?EnvironmentResponse {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $environment_resource = new Environments($acquia_cloud_client);
-    /** @var EnvironmentResponse[] $application_environments */
-    $application_environments = iterator_to_array($environment_resource->getAll($cloud_app_uuid));
-    foreach ($application_environments as $environment) {
-      if (!$environment->flags->production) {
-        return $environment;
-      }
-    }
-    return NULL;
-  }
-
-  /**
    * @param string $filename
    * @param string $password
    *

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -30,6 +30,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
    * @throws \Psr\Cache\InvalidArgumentException
    */
   public function testPushArtifact(): void {
+    $this->mockApplicationsRequest();
     $applications_response = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
     $environments_response = $this->mockEnvironmentsRequest($applications_response);
@@ -42,7 +43,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
       // Please select a Cloud Platform application:
       0,
       // Would you like to link the project at ... ?
-      'n',
+      'y',
       // Please choose an Acquia environment:
       0,
     ];
@@ -77,8 +78,6 @@ class PushArtifactCommandTest extends PullCommandTestBase {
       0,
       // Would you like to link the project at ... ?
       'n',
-      // Please choose an Acquia environment:
-      0,
     ];
     $this->executeCommand([
       '--tag-name' => $git_tag
@@ -88,12 +87,15 @@ class PushArtifactCommandTest extends PullCommandTestBase {
 
     $this->assertStringContainsString('Please select a Cloud Platform application:', $output);
     $this->assertStringContainsString('[0] Sample application 1', $output);
-    $this->assertStringContainsString('Choose a Cloud Platform environment', $output);
-    $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
     $this->assertStringContainsString('Pushing changes to Acquia Git (site@svn-3.hosted.acquia-sites.com:site.git)', $output);
   }
 
   public function testPushArtifactWithAcquiaCliFile() {
+    $this->mockApplicationsRequest();
+    $applications_response = $this->mockApplicationsRequest();
+    $this->mockApplicationRequest();
+    $environments_response = $this->mockEnvironmentsRequest($applications_response);
+    $selected_environment = $environments_response->_embedded->items[0];
     $this->datastoreAcli->set('push.artifact.destination-git-urls', [
       'https://github.com/example1/cli.git',
       'https://github.com/example2/cli.git',
@@ -114,6 +116,11 @@ class PushArtifactCommandTest extends PullCommandTestBase {
    * @throws \Exception
    */
   public function testPushArtifactWithArgs() {
+    $this->mockApplicationsRequest();
+    $applications_response = $this->mockApplicationsRequest();
+    $this->mockApplicationRequest();
+    $environments_response = $this->mockEnvironmentsRequest($applications_response);
+    $selected_environment = $environments_response->_embedded->items[0];
     $destination_git_urls = [
       'https://github.com/example1/cli.git',
       'https://github.com/example2/cli.git',

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -68,7 +68,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $selected_environment = $environments_response->_embedded->items[0];
     $local_machine_helper = $this->mockLocalMachineHelper();
     $this->setUpPushArtifact($local_machine_helper, $selected_environment->vcs->path, [$selected_environment->vcs->url]);
-    $git_tag = '1.2.0';
+    $git_tag = '1.2.0-build';
     $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $this->mockGitTag($local_machine_helper, $git_tag, $artifact_dir);
     $inputs = [
@@ -81,7 +81,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     ];
     $this->executeCommand([
       '--destination-git-tag' => $git_tag,
-      '--source-git-branch' => 'master',
+      '--source-git-tag' => '1.2.0',
     ], $inputs);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -80,7 +80,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
       'n',
     ];
     $this->executeCommand([
-      '--tag-name' => $git_tag
+      '--destination-git-tag' => $git_tag
     ], $inputs);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -67,7 +67,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     $environments_response = $this->mockEnvironmentsRequest($applications_response);
     $selected_environment = $environments_response->_embedded->items[0];
     $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->setUpPushArtifact($local_machine_helper, $selected_environment->vcs->path, [$selected_environment->vcs->url]);
+    $this->setUpPushArtifact($local_machine_helper, '1.2.0', [$selected_environment->vcs->url]);
     $git_tag = '1.2.0-build';
     $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $this->mockGitTag($local_machine_helper, $git_tag, $artifact_dir);

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -80,7 +80,8 @@ class PushArtifactCommandTest extends PullCommandTestBase {
       'n',
     ];
     $this->executeCommand([
-      '--destination-git-tag' => $git_tag
+      '--destination-git-tag' => $git_tag,
+      '--source-git-branch' => 'master',
     ], $inputs);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #854: Add --tag option to push:artifact.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Add a `--tag-name=[tag]` option that will create and push a git tag rather than a branch.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `cd` into a drupal application directory
4. `../cli/bin/acli push:artifact --destination-git-branch=[branch] --tag-name=[tag] -v`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
