### PR TITLE
CLI-575: Fix stalled tests

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1035,21 +1035,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   /**
-   * @param string $command_name
-   * @param array $arguments
-   *
-   * @return int
-   * @throws \Exception
-   */
-  protected function executeAcliCommand($command_name, $arguments = []): int {
-    $command = $this->getApplication()->find($command_name);
-    array_unshift($arguments, ['command' => $command_name]);
-    $create_input = new ArrayInput($arguments);
-
-    return $command->run($create_input, new NullOutput());
-  }
-
-  /**
    * @param string $alias
    *
    * @return string
@@ -1214,21 +1199,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       }
     }
     return NULL;
-  }
-
-  /**
-   * @param \stdClass|null $cloud_key
-   *
-   * @throws AcquiaCliException
-   * @throws \Exception
-   */
-  protected function deleteSshKeyFromCloud(stdClass $cloud_key): void {
-    $return_code = $this->executeAcliCommand('ssh-key:delete', [
-      '--cloud-key-uuid' => $cloud_key->uuid,
-    ]);
-    if ($return_code !== 0) {
-      throw new AcquiaCliException('Unable to delete SSH key from the Cloud Platform');
-    }
   }
 
   public function checkForNewVersion() {

--- a/src/Command/Ide/IdeDeleteCommand.php
+++ b/src/Command/Ide/IdeDeleteCommand.php
@@ -2,6 +2,7 @@
 
 namespace Acquia\Cli\Command\Ide;
 
+use Acquia\Cli\Helpers\SshCommandTrait;
 use AcquiaCloudApi\Endpoints\Ides;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -12,6 +13,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @package Grasmash\YamlCli\Command
  */
 class IdeDeleteCommand extends IdeCommandBase {
+
+  use SshCommandTrait;
 
   protected static $defaultName = 'ide:delete';
 
@@ -52,7 +55,7 @@ class IdeDeleteCommand extends IdeCommandBase {
     if ($cloud_key) {
       $answer = $this->io->confirm('Would you like to delete the SSH key associated with this IDE from your Cloud Platform account?');
       if ($answer) {
-        $this->deleteSshKeyFromCloud($cloud_key);
+        $this->deleteSshKeyFromCloud($output, $cloud_key);
       }
     }
 

--- a/src/Command/Ide/Wizard/IdeWizardCommandBase.php
+++ b/src/Command/Ide/Wizard/IdeWizardCommandBase.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Command\Ide\Wizard;
 
 use Acquia\Cli\Command\WizardCommandBase;
+use Acquia\Cli\Helpers\SshCommandTrait;
 use AcquiaCloudApi\Endpoints\Ides;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -11,6 +12,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Class IdeWizardCommandBase.
  */
 abstract class IdeWizardCommandBase extends WizardCommandBase {
+
+  use SshCommandTrait;
+
   /**
    * @var false|string
    */
@@ -72,4 +76,5 @@ abstract class IdeWizardCommandBase extends WizardCommandBase {
       $this->deleteSshKeyFromCloud($cloud_key);
     }
   }
+
 }

--- a/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\Command\Ide\Wizard;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\Cli\Helpers\SshCommandTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -11,6 +12,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Class IdeWizardDeleteSshKeyCommand.
  */
 class IdeWizardDeleteSshKeyCommand extends IdeWizardCommandBase {
+
+  use SshCommandTrait;
 
   protected static $defaultName = 'ide:wizard:ssh-key:delete';
 
@@ -38,7 +41,7 @@ class IdeWizardDeleteSshKeyCommand extends IdeWizardCommandBase {
       throw new AcquiaCliException('Could not find an SSH key on the Cloud Platform matching any local key in this IDE.');
     }
 
-    $this->deleteSshKeyFromCloud($cloud_key);
+    $this->deleteSshKeyFromCloud($output, $cloud_key);
     $this->deleteLocalSshKey();
 
     $this->output->writeln("<info>Deleted local files <options=bold>{$this->publicSshKeyFilepath}</> and <options=bold>{$this->privateSshKeyFilepath}</>");

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -5,6 +5,7 @@ namespace Acquia\Cli\Command\Ssh;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\LoopHelper;
+use Acquia\Cli\Helpers\SshCommandTrait;
 use AcquiaCloudApi\Endpoints\Applications;
 use AcquiaCloudApi\Endpoints\Environments;
 use AcquiaCloudApi\Response\EnvironmentResponse;
@@ -26,6 +27,8 @@ use Symfony\Component\Validator\Validation;
  * Class SshKeyCommandBase.
  */
 abstract class SshKeyCommandBase extends CommandBase {
+
+  use SshCommandTrait;
 
   /** @var string */
   protected $passphraseFilepath;
@@ -52,16 +55,6 @@ abstract class SshKeyCommandBase extends CommandBase {
     $this->privateSshKeyFilename = $private_ssh_key_filename;
     $this->privateSshKeyFilepath = $this->sshDir . '/' . $this->privateSshKeyFilename;
     $this->publicSshKeyFilepath = $this->privateSshKeyFilepath . '.pub';
-  }
-
-  /**
-   * @return \Symfony\Component\Finder\SplFileInfo[]
-   * @throws \Exception
-   */
-  protected function findLocalSshKeys(): array {
-    $finder = $this->localMachineHelper->getFinder();
-    $finder->files()->in($this->sshDir)->name('*.pub')->ignoreUnreadableDirs();
-    return iterator_to_array($finder);
   }
 
   /**

--- a/src/Command/Ssh/SshKeyDeleteCommand.php
+++ b/src/Command/Ssh/SshKeyDeleteCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Command\Ssh;
 
 use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\Cli\Helpers\SshCommandTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -11,6 +12,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Class SshKeyDeleteCommand.
  */
 class SshKeyDeleteCommand extends SshKeyCommandBase {
+
+  use SshCommandTrait;
 
   protected static $defaultName = 'ssh-key:delete';
 
@@ -31,56 +34,8 @@ class SshKeyDeleteCommand extends SshKeyCommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $cloud_key = $this->determineCloudKey($acquia_cloud_client);
-
-    $response = $acquia_cloud_client->makeRequest('delete', '/account/ssh-keys/' . $cloud_key->uuid);
-    if ($response->getStatusCode() === 202) {
-      $output->writeln("<info>Successfully deleted SSH key <options=bold>{$cloud_key->label}</> from the Cloud Platform.</info>");
-      $local_keys = $this->findLocalSshKeys();
-      foreach ($local_keys as $local_file) {
-        if (trim($local_file->getContents()) === trim($cloud_key->public_key)) {
-          $private_key_path = str_replace('.pub', '', $local_file->getRealPath());
-          $public_key_path = $local_file->getRealPath();
-          $answer = $this->io->confirm("Do you also want to delete the corresponding local key files {$local_file->getRealPath()} and $private_key_path ?", FALSE);
-          if ($answer) {
-            $this->localMachineHelper->getFilesystem()->remove([
-              $local_file->getRealPath(),
-              $private_key_path,
-            ]);
-            $this->io->success("Deleted $public_key_path and $private_key_path");
-            return 0;
-          }
-        }
-      }
-      return 0;
-    }
-
-    throw new AcquiaCliException($response->getBody()->getContents());
-  }
-
-  /**
-   * @param \AcquiaCloudApi\Connector\Client $acquia_cloud_client
-   *
-   * @return array|object|null
-   */
-  protected function determineCloudKey($acquia_cloud_client) {
-    if ($this->input->getOption('cloud-key-uuid')) {
-      $cloud_key_uuid = self::validateUuid($this->input->getOption('cloud-key-uuid'));
-      $cloud_key = $acquia_cloud_client->request('get', '/account/ssh-keys/' . $cloud_key_uuid);
-      return $cloud_key;
-    }
-
-    $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
-    $cloud_key = $this->promptChooseFromObjectsOrArrays(
-      $cloud_keys,
-      'uuid',
-      'label',
-      'Choose an SSH key to delete from the Cloud Platform'
-    );
-
-    return $cloud_key;
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    return $this->deleteSshKeyFromCloud($output);
   }
 
 }

--- a/src/Helpers/SshCommandTrait.php
+++ b/src/Helpers/SshCommandTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Acquia\Cli\Helpers;
+
+use Acquia\Cli\Exception\AcquiaCliException;
+
+trait SshCommandTrait {
+
+  /**
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   * @throws \Exception
+   */
+  public function deleteSshKeyFromCloud($output, $cloud_key = NULL): int {
+    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    if (!$cloud_key) {
+      $cloud_key = $this->determineCloudKey($acquia_cloud_client);
+    }
+
+    $response = $acquia_cloud_client->makeRequest('delete', '/account/ssh-keys/' . $cloud_key->uuid);
+    if ($response->getStatusCode() === 202) {
+      $output->writeln("<info>Successfully deleted SSH key <options=bold>$cloud_key->label</> from the Cloud Platform.</info>");
+      $local_keys = $this->findLocalSshKeys();
+      foreach ($local_keys as $local_file) {
+        if (trim($local_file->getContents()) === trim($cloud_key->public_key)) {
+          $private_key_path = str_replace('.pub', '', $local_file->getRealPath());
+          $public_key_path = $local_file->getRealPath();
+          $answer = $this->io->confirm("Do you also want to delete the corresponding local key files {$local_file->getRealPath()} and $private_key_path ?", FALSE);
+          if ($answer) {
+            $this->localMachineHelper->getFilesystem()->remove([
+              $local_file->getRealPath(),
+              $private_key_path,
+            ]);
+            $this->io->success("Deleted $public_key_path and $private_key_path");
+            return 0;
+          }
+        }
+      }
+      return 0;
+    }
+
+    throw new AcquiaCliException($response->getBody()->getContents());
+  }
+
+  /**
+   * @param \AcquiaCloudApi\Connector\Client $acquia_cloud_client
+   *
+   * @return array|object|null
+   */
+  protected function determineCloudKey($acquia_cloud_client) {
+    $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
+    return $this->promptChooseFromObjectsOrArrays(
+      $cloud_keys,
+      'uuid',
+      'label',
+      'Choose an SSH key to delete from the Cloud Platform'
+    );
+  }
+
+  /**
+   * @return \Symfony\Component\Finder\SplFileInfo[]
+   * @throws \Exception
+   */
+  protected function findLocalSshKeys(): array {
+    $finder = $this->localMachineHelper->getFinder();
+    $finder->files()->in($this->sshDir)->name('*.pub')->ignoreUnreadableDirs();
+    return iterator_to_array($finder);
+  }
+
+}

--- a/tests/phpunit/src/Commands/Ide/IdeDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeDeleteCommandTest.php
@@ -54,7 +54,6 @@ class IdeDeleteCommandTest extends CommandTestBase {
     $ide = new IdeResponse((object) $ide_get_response);
     $ssh_key_get_response = $this->mockListSshKeysRequestWithIdeKey($ide);
 
-    $this->mockGetIdeSshKeyRequest($ide);
     $this->mockDeleteSshKeyRequest($ssh_key_get_response->{'_embedded'}->items[0]->uuid);
 
     $inputs = [

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardDeleteSshKeyCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardDeleteSshKeyCommandTest.php
@@ -27,7 +27,6 @@ class IdeWizardDeleteSshKeyCommandTest extends IdeWizardTestBase {
     $ide = new IdeResponse((object) $ide_response);
     $mock_body = $this->mockListSshKeysRequestWithIdeKey($ide);
 
-    $this->mockGetIdeSshKeyRequest($ide);
     $this->mockDeleteSshKeyRequest($mock_body->{'_embedded'}->items[0]->uuid);
 
     // Create the file so it can be deleted.


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
I cannot run tests to completion locally, because some commands redispatch to SshKeyDeleteCommand via CommandBase::executeAcliCommand(). This does not preserve the command tester input, so confirmation dialogs in SshKeyDeleteCommand hang awaiting input.

If there's one lesson I've learned from BLT and Drush, it's that redispatching is the root of all evil. 👿 

**Proposed changes**
Instead of redispatching, move the SSH-key deletion business logic to a shared SshCommandTrait. I want to eventually convert all of our "base" commands (SshCommandBase, IdeCommandBase, etc) into traits, so they can be mixed-and-matched. For instance, by using traits instead of an inherited command base, the IdeWizardCreateSshKeyCommand can now be _both_ an SSH command and an IDE command.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Use the existing SSH Helper object instead of a trait. Either is fine with me, but traits require less refactoring from our current model of inheritance.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Create an IDE, set up an SSH key for it, then run `acli ide:delete` to ensure the key is still deleted automatically.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
