### PR TITLE
Fixes #864: Fatal error with remote:aliases:download in ACLI 1.25.

### DIFF
--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -118,7 +118,7 @@ class AliasesDownloadCommand extends SshCommand {
               ->getLocalFilepath('~') . '/.drush';
           break;
         case 9:
-          $this->drushAliasesDir = Path::join($this->dir, 'drush');
+          $this->drushAliasesDir = Path::join($this->getRepoRoot(), 'drush');
           break;
         default:
           throw new AcquiaCliException("Unknown Drush version");


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #864

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
