### PR TITLE
CLI-713: Fixes #875: Apache access logstream failing

### DIFF
--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -30,12 +30,12 @@ class LogTailCommand extends CommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $environment_id = $this->determineCloudEnvironment();
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $logs = $this->promptChooseLogs($acquia_cloud_client, $environment_id);
-    $log_types = array_map(function ($log) {
-      return $log->type;
+    $logs = $this->promptChooseLogs();
+    $log_types = array_map(static function ($log) {
+      return $log['type'];
     }, $logs);
     $logs_resource = new Logs($acquia_cloud_client);
     $stream = $logs_resource->stream($environment_id);

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -19,7 +19,6 @@ use AcquiaCloudApi\Endpoints\Account;
 use AcquiaCloudApi\Endpoints\Applications;
 use AcquiaCloudApi\Endpoints\Environments;
 use AcquiaCloudApi\Endpoints\Ides;
-use AcquiaCloudApi\Endpoints\Logs;
 use AcquiaCloudApi\Endpoints\Subscriptions;
 use AcquiaCloudApi\Response\ApplicationResponse;
 use AcquiaCloudApi\Response\EnvironmentResponse;
@@ -41,11 +40,9 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
@@ -551,18 +548,15 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * Prompts the user to choose from a list of logs for a given Cloud Platform environment.
    *
-   * @param Client $acquia_cloud_client
-   * @param string $environment_id
-   *
    * @return null|object|array
    */
-  protected function promptChooseLogs(
-    Client $acquia_cloud_client,
-    string $environment_id
-  ) {
-    $logs_resource = new Logs($acquia_cloud_client);
-    $logs = $logs_resource->getAll($environment_id);
-
+  protected function promptChooseLogs() {
+    $logs = array_map(static function ($log_type, $log_label) {
+      return [
+        'type' => $log_type,
+        'label' => $log_label,
+      ];
+    }, array_keys(LogstreamManager::AVAILABLE_TYPES), LogstreamManager::AVAILABLE_TYPES);
     return $this->promptChooseFromObjectsOrArrays(
       $logs,
       'type',

--- a/tests/phpunit/src/Commands/App/LogTailCommandTest.php
+++ b/tests/phpunit/src/Commands/App/LogTailCommandTest.php
@@ -31,7 +31,6 @@ class LogTailCommandTest extends CommandTestBase {
     $applications_response = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
     $this->mockEnvironmentsRequest($applications_response);
-    $this->mockLogListRequest();
     $this->mockLogStreamRequest();
     $this->executeCommand([], [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -52,7 +51,7 @@ class LogTailCommandTest extends CommandTestBase {
     $this->assertStringContainsString('Please select a Cloud Platform application:', $output);
     $this->assertStringContainsString('[0] Sample application 1', $output);
     $this->assertStringContainsString('[1] Sample application 2', $output);
-    $this->assertStringContainsString('Apache access', $output);
+    $this->assertStringContainsString('Apache request', $output);
     $this->assertStringContainsString('Drupal request', $output);
   }
 
@@ -62,7 +61,6 @@ class LogTailCommandTest extends CommandTestBase {
    * @throws \Psr\Cache\InvalidArgumentException
    */
   public function testLogTailCommandWithEnvArg(): void {
-    $this->mockLogListRequest();
     $this->mockLogStreamRequest();
     $this->executeCommand(
       ['environmentId' => '24-a47ac10b-58cc-4372-a567-0e02b2c3d470'],

--- a/tests/phpunit/src/Commands/App/LogTailCommandTest.php
+++ b/tests/phpunit/src/Commands/App/LogTailCommandTest.php
@@ -71,7 +71,7 @@ class LogTailCommandTest extends CommandTestBase {
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString('Apache access', $output);
+    $this->assertStringContainsString('Apache request', $output);
     $this->assertStringContainsString('Drupal request', $output);
   }
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -624,21 +624,6 @@ abstract class TestBase extends TestCase {
    * @return object
    * @throws \Psr\Cache\InvalidArgumentException
    */
-  protected function mockLogListRequest() {
-    $response = $this->getMockResponseFromSpec('/environments/{environmentId}/logs',
-      'get', '200');
-    $this->clientProphecy->request('get',
-      '/environments/24-a47ac10b-58cc-4372-a567-0e02b2c3d470/logs')
-      ->willReturn($response->{'_embedded'}->items)
-      ->shouldBeCalled();
-
-    return $response;
-  }
-
-  /**
-   * @return object
-   * @throws \Psr\Cache\InvalidArgumentException
-   */
   protected function mockLogStreamRequest() {
     $response = $this->getMockResponseFromSpec('/environments/{environmentId}/logstream',
       'get', '200');


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #875

It turns out other logs (mysql slow query, for instance) were borked as well, and some (balancer request) were missing entirely.

**Proposed changes**
Depends on https://github.com/typhonius/acquia-logstream/pull/144
Use the available types provided by typhonius/acquia-logstream.
This drastically speeds up the command (by cutting out an API call) and makes it more reliable (since it turns out the API was lying to us 😄 )

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

https://github.com/typhonius/acquia-logstream/issues/143

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `acli app:log:tail`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
