### PR TITLE
CLI-677: Fixes #834: For email:configure, add zone file as output format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: gmp
           # Only report coverage once
           coverage: ${{ env.COVERAGE }}
       - name: Check dependencies on Ubuntu

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ cx-api-spec
 # Generated files from Platform Email configuration/info commands
 dns-records.yaml
 dns-records.json
+dns-records.zone
 subscription-*/

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": "^7.4 | ^8.0",
         "ext-json": "*",
         "acquia/drupal-environment-detector": "^1.2.0",
+        "badcow/dns": "^4.1.1",
         "composer/semver": "^3.2",
         "consolidation/self-update": "2.0.0-alpha1 as 1.1",
         "cweagans/composer-patches": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "250005502e3ae7b7a38a09c57687ff75",
+    "content-hash": "561f7fdd74e21454eb9367a961f040ac",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -55,6 +55,53 @@
                 "source": "https://github.com/acquia/drupal-environment-detector/tree/1.4.1"
             },
             "time": "2022-03-15T20:59:14+00:00"
+        },
+        {
+            "name": "badcow/dns",
+            "version": "v4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Badcow/DNS.git",
+                "reference": "aeb1aa568001319ec881581010471b2f04528808"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Badcow/DNS/zipball/aeb1aa568001319ec881581010471b2f04528808",
+                "reference": "aeb1aa568001319ec881581010471b2f04528808",
+                "shasum": ""
+            },
+            "require": {
+                "christian-riesen/base32": "^1.5.2",
+                "php": "^7.3 || ^8.0",
+                "rlanvin/php-ip": "^2.0 || dev-php8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Badcow\\DNS\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Williams",
+                    "email": "sam@badcow.co"
+                }
+            ],
+            "description": "A PHP library for creating DNS zone files based on RFC1035",
+            "support": {
+                "issues": "https://github.com/Badcow/DNS/issues",
+                "source": "https://github.com/Badcow/DNS/tree/v4.1.1"
+            },
+            "time": "2021-01-21T22:53:54+00:00"
         },
         {
             "name": "brick/math",
@@ -115,6 +162,65 @@
                 }
             ],
             "time": "2021-08-15T20:50:18+00:00"
+        },
+        {
+            "name": "christian-riesen/base32",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ChristianRiesen/base32.git",
+                "reference": "2e82dab3baa008e24a505649b0d583c31d31e894"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ChristianRiesen/base32/zipball/2e82dab3baa008e24a505649b0d583c31d31e894",
+                "reference": "2e82dab3baa008e24a505649b0d583c31d31e894",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.17",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^8.5.13 || ^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Base32\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Riesen",
+                    "email": "chris.riesen@gmail.com",
+                    "homepage": "http://christianriesen.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Base32 encoder/decoder according to RFC 4648",
+            "homepage": "https://github.com/ChristianRiesen/base32",
+            "keywords": [
+                "base32",
+                "decode",
+                "encode",
+                "rfc4648"
+            ],
+            "support": {
+                "issues": "https://github.com/ChristianRiesen/base32/issues",
+                "source": "https://github.com/ChristianRiesen/base32/tree/1.6.0"
+            },
+            "time": "2021-02-26T10:19:33+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -3171,24 +3277,69 @@
             "time": "2021-07-11T12:37:55+00:00"
         },
         {
-            "name": "seld/jsonlint",
-            "version": "1.8.3",
+            "name": "rlanvin/php-ip",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57"
+                "url": "https://github.com/rlanvin/php-ip.git",
+                "reference": "1bea521987f3c7db5f4b9f17f321e90feaefad11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
-                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "url": "https://api.github.com/repos/rlanvin/php-ip/zipball/1bea521987f3c7db5f4b9f17f321e90feaefad11",
+                "reference": "1bea521987f3c7db5f4b9f17f321e90feaefad11",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gmp": "*",
+                "php": "~7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=6.5 <8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpIP\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "IPv4/IPv6 manipulation library for PHP",
+            "homepage": "https://github.com/rlanvin/php-ip",
+            "keywords": [
+                "IP",
+                "ipv4",
+                "ipv6"
+            ],
+            "support": {
+                "issues": "https://github.com/rlanvin/php-ip/issues",
+                "source": "https://github.com/rlanvin/php-ip/tree/v2.1.0"
+            },
+            "time": "2020-10-31T12:31:56+00:00"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/4211420d25eba80712bff236a98960ef68b866b7",
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpstan/phpstan": "^1.5",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
             },
             "bin": [
                 "bin/jsonlint"
@@ -3219,7 +3370,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.8.3"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.9.0"
             },
             "funding": [
                 {
@@ -3231,7 +3382,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-11T09:19:24+00:00"
+            "time": "2022-04-01T13:37:23+00:00"
         },
         {
             "name": "symfony/cache",
@@ -8005,16 +8156,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
@@ -8049,9 +8200,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2022-01-04T19:58:01+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpro/grumphp",
@@ -8282,35 +8433,30 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.2.0",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e"
+                "reference": "4cb3021a4e10ffe3d5f94a4c34cf4b3f6de2fa3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
-                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/4cb3021a4e10ffe3d5f94a4c34cf4b3f6de2fa3d",
+                "reference": "4cb3021a4e10ffe3d5f94a4c34cf4b3f6de2fa3d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan": "^1.5",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PHPStan\\PhpDocParser\\": [
@@ -8325,9 +8471,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.4.2"
             },
-            "time": "2021-09-16T20:46:02+00:00"
+            "time": "2022-03-30T13:33:37+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -8764,16 +8910,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.19",
+            "version": "9.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807"
+                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/35ea4b7f3acabb26f4bb640f8c30866c401da807",
-                "reference": "35ea4b7f3acabb26f4bb640f8c30866c401da807",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
                 "shasum": ""
             },
             "require": {
@@ -8851,7 +8997,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
             },
             "funding": [
                 {
@@ -8863,7 +9009,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-15T09:57:31+00:00"
+            "time": "2022-04-01T12:37:26+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -9884,32 +10030,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.0.19",
+            "version": "7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "bef66a43815bbf9b5f49775e9ded3f7c6ba0cc37"
+                "reference": "b521bd358b5f7a7d69e9637fd139e036d8adeb6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/bef66a43815bbf9b5f49775e9ded3f7c6ba0cc37",
-                "reference": "bef66a43815bbf9b5f49775e9ded3f7c6ba0cc37",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b521bd358b5f7a7d69e9637fd139e036d8adeb6f",
+                "reference": "b521bd358b5f7a7d69e9637fd139e036d8adeb6f",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.0.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.4.1",
                 "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
                 "phing/phing": "2.17.2",
                 "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.4.6",
+                "phpstan/phpstan": "1.4.10|1.5.2",
                 "phpstan/phpstan-deprecation-rules": "1.0.0",
-                "phpstan/phpstan-phpunit": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.0",
                 "phpstan/phpstan-strict-rules": "1.1.0",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.16"
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.19"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -9929,7 +10075,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.0.19"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.1"
             },
             "funding": [
                 {
@@ -9941,7 +10087,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-01T18:01:41+00:00"
+            "time": "2022-03-29T12:44:16+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -10211,5 +10357,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -10,9 +10,12 @@ use AcquiaCloudApi\Endpoints\Applications;
 use AcquiaCloudApi\Endpoints\Environments;
 use AcquiaCloudApi\Exception\ApiErrorException;
 use AcquiaCloudApi\Response\SubscriptionResponse;
+use Badcow\DNS\AlignedBuilder;
+use Badcow\DNS\Rdata\Factory;
+use Badcow\DNS\ResourceRecord;
+use Badcow\DNS\Zone;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Validator\Constraints\Hostname;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -80,8 +83,8 @@ class ConfigurePlatformEmailCommand extends CommandBase {
       "Provide these records to your DNS provider",
       "After you've done this, please continue to domain verification."
     ]);
-    $file_format = $this->io->choice('Would you like your DNS records in JSON or YAML format?', ['YAML', 'JSON'], 'YAML');
-    $this->createDnsText($client, $subscription, $domain_uuid, $file_format);
+    $file_format = $this->io->choice('Would you like your DNS records in JSON, YAML, or Zone File format?', ['Zone File', 'YAML', 'JSON'], 'Zone File');
+    $this->createDnsText($client, $subscription, $base_domain, $domain_uuid, $file_format);
     $continue = $this->io->confirm('Have you finished providing the DNS records to your DNS provider?');
     if (!$continue) {
       $this->io->info("Make sure to give these records to your DNS provider, then rerun this script with the domain that you just registered.");
@@ -107,6 +110,46 @@ class ConfigurePlatformEmailCommand extends CommandBase {
     $this->io->success("You're all set to start using Platform Email!");
 
     return 0;
+  }
+
+  /**
+   * Generates Zone File for DNS records of the registered domain.
+   *
+   * @param string $base_domain
+   * @param array $records
+   *
+   */
+  protected function generateZoneFile($base_domain, $records) {
+
+    $zone = new Zone($base_domain . '.');
+    $zone->setDefaultTtl(3600);
+
+    foreach ($records as $record) {
+      unset($record->health);
+      $record_to_add = new ResourceRecord;
+      $record_to_add->setName($record->name . '.');
+
+      switch ($record->type) {
+        case 'MX':
+          $mx_priority_value_arr = explode(' ', $record->value);
+          $record_to_add->setRdata(Factory::Mx(
+            $mx_priority_value_arr[0],
+            $mx_priority_value_arr[1] . '.')
+          );
+          break;
+        case 'TXT':
+          $record_to_add->setRdata(Factory::TXT($record->value . '.'));
+          break;
+        case 'CNAME':
+          $record_to_add->setRdata(Factory::CNAME($record->value . '.'));
+          break;
+      }
+      $zone->addResourceRecord($record_to_add);
+    }
+
+    $builder = new AlignedBuilder();
+    $this->localMachineHelper->getFilesystem()
+            ->dumpFile('dns-records.zone', $builder->build($zone));
   }
 
   /**
@@ -275,17 +318,18 @@ class ConfigurePlatformEmailCommand extends CommandBase {
   }
 
   /**
-   * Creates a TXT file, either in JSON or YAML format,
+   * Creates a file, either in JSON, YAML, or Zone File format,
    * of the DNS records needed to complete Platform Email setup.
    *
    * @param \AcquiaCloudApi\Connector\Client $client
    * @param SubscriptionResponse $subscription
+   * @param string $base_domain
    * @param string $domain_uuid
    * @param string $file_format
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function createDnsText(Client $client, $subscription, $domain_uuid, $file_format): void {
+  protected function createDnsText(Client $client, $subscription, $base_domain, $domain_uuid, $file_format): void {
     $domain_registration_response = $client->request('get', "/subscriptions/{$subscription->uuid}/domains/{$domain_uuid}");
     if (!isset($domain_registration_response->dns_records)) {
       throw new AcquiaCliException('Could not retrieve DNS records for this domain. Please try again by rerunning this script with the domain that you just registered.');
@@ -293,6 +337,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
     $records = [];
     $this->localMachineHelper->getFilesystem()->remove('dns-records.json');
     $this->localMachineHelper->getFilesystem()->remove('dns-records.yaml');
+    $this->localMachineHelper->getFilesystem()->remove('dns-records.zone');
     if ($file_format === 'JSON') {
       foreach ($domain_registration_response->dns_records as $record) {
         unset($record->health);
@@ -302,7 +347,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
       $this->localMachineHelper->getFilesystem()
             ->dumpFile('dns-records.json', json_encode($records, JSON_PRETTY_PRINT));
     }
-    else {
+    else if ($file_format === 'YAML') {
       foreach ($domain_registration_response->dns_records as $record) {
         unset($record->health);
         $records[] = ['type' => $record->type, 'name' => $record->name, 'value' => $record->value];
@@ -310,6 +355,9 @@ class ConfigurePlatformEmailCommand extends CommandBase {
       $this->logger->debug(json_encode($records));
       $this->localMachineHelper->getFilesystem()
             ->dumpFile('dns-records.yaml', Yaml::dump($records));
+    }
+    else {
+      $this->generateZoneFile($base_domain, $domain_registration_response->dns_records);
     }
 
   }

--- a/symfony.lock
+++ b/symfony.lock
@@ -29,8 +29,14 @@
     "amphp/sync": {
         "version": "v1.4.2"
     },
+    "badcow/dns": {
+        "version": "v4.1.1"
+    },
     "brick/math": {
         "version": "0.9.3"
+    },
+    "christian-riesen/base32": {
+        "version": "1.6.0"
     },
     "clue/stream-filter": {
         "version": "v1.6.0"
@@ -270,6 +276,9 @@
     },
     "react/stream": {
         "version": "v1.2.0"
+    },
+    "rlanvin/php-ip": {
+        "version": "v2.1.0"
     },
     "sebastian/cli-parser": {
         "version": "1.0.1"

--- a/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
@@ -35,7 +35,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'www.test.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in JSON, YAML, or Zone File format?
           '0',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -56,7 +56,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'test.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in JSON, YAML, or Zone File format?
           '1',
           // Have you finished providing the DNS records to your DNS provider?
           'n',
@@ -75,7 +75,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'https://www.test.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in JSON, YAML, or Zone File format?
           '1',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -96,7 +96,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'https://www.test.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in JSON, YAML, or Zone File format?
           '1',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -127,7 +127,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'example.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in JSON, YAML, or Zone File format?
           '0',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -150,7 +150,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'example.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in JSON, YAML, or Zone File format?
           '0',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -179,7 +179,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'example.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in JSON, YAML, or Zone File format?
           '0',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -202,7 +202,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'example.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in JSON, YAML, or Zone File format?
           '0',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -276,7 +276,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
       $base_domain,
       // Please select a Cloud Platform subscription
       '0',
-      //Would you like your DNS records in JSON or YAML format?
+      // Would you like your DNS records in JSON, YAML, or Zone File format?
       '0',
       // Have you finished providing the DNS records to your DNS provider?
       'y',
@@ -347,7 +347,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
       $base_domain,
       // Please select a Cloud Platform subscription
       '0',
-      //Would you like your DNS records in JSON or YAML format?
+      // Would you like your DNS records in JSON, YAML, or Zone File format?
       '0',
       // Have you finished providing the DNS records to your DNS provider?
       'y',
@@ -395,7 +395,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
       $base_domain,
       // Please select a Cloud Platform subscription
       '0',
-      //Would you like your DNS records in JSON or YAML format?
+      // Would you like your DNS records in JSON, YAML, or Zone File format?
       '0',
       // Have you finished providing the DNS records to your DNS provider?
       'y',
@@ -433,8 +433,8 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
       $base_domain,
       // Please select a Cloud Platform subscription
       '0',
-      //Would you like your DNS records in JSON or YAML format?
-      '0',
+      // Would you like your DNS records in JSON, YAML, or Zone File format?
+      '2',
       // Have you finished providing the DNS records to your DNS provider?
       'y',
     ];

--- a/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
@@ -36,7 +36,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           // Please select a Cloud Platform subscription
           '0',
           // Would you like your DNS records in JSON, YAML, or Zone File format?
-          '0',
+          '2',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
           // What are the environments you'd like to enable email for? You may enter multiple separated by a comma.


### PR DESCRIPTION
**Motivation**
Fixes #834 

**Proposed changes**
Adds the option of a Zone File output format when asked to export DNS records after registering a domain in the `email:configure` script

**Testing steps**

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `./bin/acli email:configure` - when asked to choose a file type for exporting DNS records, choose 'Zone File' and verify contents of `dns-records.zone` in the root of the directory where the command was run

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
