### PR TITLE
 For email:configure, add zone file as output format (without GMP extension).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ cx-api-spec
 # Generated files from Platform Email configuration/info commands
 dns-records.yaml
 dns-records.json
+dns-records.zone
 subscription-*/

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "kevinrob/guzzle-cache-middleware": "^3.3",
         "league/csv": "^9.8",
         "loophp/phposinfo": "^1.7.2",
+        "ltd-beget/dns-zone-configurator": "^1.2",
         "m4tthumphrey/php-gitlab-api": "^11.5",
         "psr/log": "^1.1",
         "ramsey/uuid": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "250005502e3ae7b7a38a09c57687ff75",
+    "content-hash": "8946db4c0a36a3b4123eef64bb86fd68",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -317,6 +317,42 @@
                 "source": "https://github.com/consolidation/self-update/tree/2.0.0-alpha1"
             },
             "time": "2021-10-05T04:23:36+00:00"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "support": {
+                "issues": "https://github.com/container-interop/container-interop/issues",
+                "source": "https://github.com/container-interop/container-interop/tree/master"
+            },
+            "abandoned": "psr/container",
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -1278,6 +1314,196 @@
             "time": "2021-06-29T07:18:36+00:00"
         },
         {
+            "name": "ltd-beget/ascii-table",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/LTD-Beget/ascii-table.git",
+                "reference": "4020cf9015ceff6405b7204bc14c8d58cf9879dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/LTD-Beget/ascii-table/zipball/4020cf9015ceff6405b7204bc14c8d58cf9879dd",
+                "reference": "4020cf9015ceff6405b7204bc14c8d58cf9879dd",
+                "shasum": ""
+            },
+            "require": {
+                "marc-mabe/php-enum": ">=2.2",
+                "php": ">=7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LTDBeget\\ascii": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "authors": [
+                {
+                    "name": "Viskov Sergey",
+                    "homepage": "https://github.com/voksiv"
+                }
+            ],
+            "description": "Php library with ascii table enum.",
+            "keywords": [
+                "ascii"
+            ],
+            "support": {
+                "issues": "https://github.com/LTD-Beget/ascii-table/issues",
+                "source": "https://github.com/LTD-Beget/ascii-table/tree/1.0.4"
+            },
+            "time": "2022-01-26T19:08:18+00:00"
+        },
+        {
+            "name": "ltd-beget/dns-zone-configurator",
+            "version": "v1.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/LTD-Beget/dns-zone-configurator.git",
+                "reference": "e52284eb624ae67a28aff4fdb19623b06e2ca3af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/LTD-Beget/dns-zone-configurator/zipball/e52284eb624ae67a28aff4fdb19623b06e2ca3af",
+                "reference": "e52284eb624ae67a28aff4fdb19623b06e2ca3af",
+                "shasum": ""
+            },
+            "require": {
+                "ltd-beget/dns-zone-tokenizer": "~0.0.6",
+                "marc-mabe/php-enum": "~2.2",
+                "php": ">=7.0",
+                "zendframework/zend-validator": "~2.7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.3",
+                "theseer/phpdox": "~0.8",
+                "tideways/profiler": "~2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LTDBeget\\dns": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Viskov Sergey",
+                    "homepage": "https://github.com/voksiv"
+                }
+            ],
+            "description": "Php library for parsing and editing dns zones files programmatically with high level abstraction.",
+            "keywords": [
+                "dns",
+                "zone file"
+            ],
+            "support": {
+                "issues": "https://github.com/LTD-Beget/dns-zone-configurator/issues",
+                "source": "https://github.com/LTD-Beget/dns-zone-configurator/tree/v1.2.9"
+            },
+            "time": "2020-04-22T12:11:58+00:00"
+        },
+        {
+            "name": "ltd-beget/dns-zone-tokenizer",
+            "version": "v0.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/LTD-Beget/dns-zone-tokenizer.git",
+                "reference": "8881f106f1a173b41e115c0b8bfea1caf7ad212a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/LTD-Beget/dns-zone-tokenizer/zipball/8881f106f1a173b41e115c0b8bfea1caf7ad212a",
+                "reference": "8881f106f1a173b41e115c0b8bfea1caf7ad212a",
+                "shasum": ""
+            },
+            "require": {
+                "ltd-beget/stringstream": "~1.0",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ext-json": "~1.0",
+                "phpunit/phpunit": "~7.3",
+                "theseer/phpdox": "0.8.*",
+                "tideways/profiler": "2.0.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LTDBeget\\dns": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Viskov Sergey",
+                    "homepage": "https://github.com/voksiv"
+                }
+            ],
+            "description": "tokenize dns zone files and that's all, folks.",
+            "keywords": [
+                "dns",
+                "dns parser",
+                "dns zone"
+            ],
+            "support": {
+                "issues": "https://github.com/LTD-Beget/dns-zone-tokenizer/issues",
+                "source": "https://github.com/LTD-Beget/dns-zone-tokenizer/tree/v0.0.9"
+            },
+            "time": "2020-11-24T15:40:10+00:00"
+        },
+        {
+            "name": "ltd-beget/stringstream",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/LTD-Beget/stringstream.git",
+                "reference": "1704f248a58c8dd1af3a3635f9ffa7b84a60ccd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/LTD-Beget/stringstream/zipball/1704f248a58c8dd1af3a3635f9ffa7b84a60ccd2",
+                "reference": "1704f248a58c8dd1af3a3635f9ffa7b84a60ccd2",
+                "shasum": ""
+            },
+            "require": {
+                "ltd-beget/ascii-table": "1.*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "theseer/phpdox": "0.8.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LTDBeget\\stringstream": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "authors": [
+                {
+                    "name": "Viskov Sergey",
+                    "homepage": "https://github.com/voksiv"
+                }
+            ],
+            "description": "Php Stringstream data structure.",
+            "keywords": [
+                "stream",
+                "stringstream"
+            ],
+            "support": {
+                "issues": "https://github.com/LTD-Beget/stringstream/issues",
+                "source": "https://github.com/LTD-Beget/stringstream/tree/v1.1.1"
+            },
+            "time": "2020-06-05T11:16:45+00:00"
+        },
+        {
             "name": "m4tthumphrey/php-gitlab-api",
             "version": "11.6.0",
             "source": {
@@ -1360,6 +1586,73 @@
                 }
             ],
             "time": "2022-01-23T19:13:35+00:00"
+        },
+        {
+            "name": "marc-mabe/php-enum",
+            "version": "v2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "b93dd64030cdd700d18ba681919a52054999b1fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/b93dd64030cdd700d18ba681919a52054999b1fa",
+                "reference": "b93dd64030cdd700d18ba681919a52054999b1fa",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "php": "PHP>=5.4 will be required for using trait EnumSerializableTrait"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-2.x": "2.3-dev",
+                    "dev-1.x": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "http://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP 5.3 and upper",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enummap",
+                "enumset",
+                "type-hint",
+                "typehint"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum/issues",
+                "source": "https://github.com/marc-mabe/php-enum/tree/2.x"
+            },
+            "time": "2019-03-16T18:21:30+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -6170,6 +6463,145 @@
             "time": "2015-12-17T08:42:14+00:00"
         },
         {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/66536006722aff9e62d1b331025089b7ec71c065",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "keywords": [
+                "ZendFramework",
+                "stdlib",
+                "zf"
+            ],
+            "support": {
+                "docs": "https://docs.zendframework.com/zend-stdlib/",
+                "forum": "https://discourse.zendframework.com/c/questions/components",
+                "issues": "https://github.com/zendframework/zend-stdlib/issues",
+                "rss": "https://github.com/zendframework/zend-stdlib/releases.atom",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "source": "https://github.com/zendframework/zend-stdlib"
+            },
+            "abandoned": "laminas/laminas-stdlib",
+            "time": "2018-08-28T21:34:05+00:00"
+        },
+        {
+            "name": "zendframework/zend-validator",
+            "version": "2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-validator.git",
+                "reference": "b54acef1f407741c5347f2a97f899ab21f2229ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/b54acef1f407741c5347f2a97f899ab21f2229ef",
+                "reference": "b54acef1f407741c5347f2a97f899ab21f2229ef",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^7.1",
+                "zendframework/zend-stdlib": "^3.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-math": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.8",
+                "zendframework/zend-uri": "^2.5"
+            },
+            "suggest": {
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators",
+                "zendframework/zend-db": "Zend\\Db component, required by the (No)RecordExists validator",
+                "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
+                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages",
+                "zendframework/zend-i18n-resources": "Translations of validator messages",
+                "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "zendframework/zend-session": "Zend\\Session component, ^2.8; required by the Csrf validator",
+                "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.13.x-dev",
+                    "dev-develop": "2.14.x-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Validator",
+                    "config-provider": "Zend\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "keywords": [
+                "ZendFramework",
+                "validator",
+                "zf"
+            ],
+            "support": {
+                "chat": "https://zendframework-slack.herokuapp.com",
+                "docs": "https://docs.zendframework.com/zend-validator/",
+                "forum": "https://discourse.zendframework.com/c/questions/components",
+                "issues": "https://github.com/zendframework/zend-validator/issues",
+                "rss": "https://github.com/zendframework/zend-validator/releases.atom",
+                "source": "https://github.com/zendframework/zend-validator"
+            },
+            "abandoned": "laminas/laminas-validator",
+            "time": "2019-12-28T04:07:18+00:00"
+        },
+        {
             "name": "zumba/amplitude-php",
             "version": "1.0.2",
             "source": {
@@ -10211,5 +10643,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -63,7 +63,6 @@ class ConfigurePlatformEmailCommand extends CommandBase {
     $this->checklist->completePreviousItem();
     $this->checklist->addItem('the environment or environments for the above applications where Platform Email will be enabled');
     $this->checklist->completePreviousItem();
-
     $base_domain = $this->determineDomain();
     $client = $this->cloudApiClientService->getClient();
     $subscription = $this->determineCloudSubscription();
@@ -119,7 +118,6 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    */
   protected function generateZoneFile($base_domain, $records) {
 
-    // also you can make zone programmatically
     $zone = new Zone($base_domain . '.');
 
     foreach ($records as $record) {

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -10,9 +10,9 @@ use AcquiaCloudApi\Endpoints\Applications;
 use AcquiaCloudApi\Endpoints\Environments;
 use AcquiaCloudApi\Exception\ApiErrorException;
 use AcquiaCloudApi\Response\SubscriptionResponse;
+use LTDBeget\dns\configurator\Zone;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Validator\Constraints\Hostname;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -63,6 +63,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
     $this->checklist->completePreviousItem();
     $this->checklist->addItem('the environment or environments for the above applications where Platform Email will be enabled');
     $this->checklist->completePreviousItem();
+
     $base_domain = $this->determineDomain();
     $client = $this->cloudApiClientService->getClient();
     $subscription = $this->determineCloudSubscription();
@@ -76,12 +77,12 @@ class ConfigurePlatformEmailCommand extends CommandBase {
 
     $this->io->success([
       "Great! You've registered the domain {$base_domain} to subscription {$subscription->name}.",
-      "We will create a text file with the DNS records for your newly registered domain",
+      "We will create a file with the DNS records for your newly registered domain",
       "Provide these records to your DNS provider",
       "After you've done this, please continue to domain verification."
     ]);
-    $file_format = $this->io->choice('Would you like your DNS records in JSON or YAML format?', ['YAML', 'JSON'], 'YAML');
-    $this->createDnsText($client, $subscription, $domain_uuid, $file_format);
+    $file_format = $this->io->choice('Would you like your DNS records in BIND Zone File, JSON, or YAML format?', ['BIND Zone File', 'YAML', 'JSON'], 'BIND Zone File');
+    $this->createDnsText($client, $subscription, $base_domain, $domain_uuid, $file_format);
     $continue = $this->io->confirm('Have you finished providing the DNS records to your DNS provider?');
     if (!$continue) {
       $this->io->info("Make sure to give these records to your DNS provider, then rerun this script with the domain that you just registered.");
@@ -107,6 +108,41 @@ class ConfigurePlatformEmailCommand extends CommandBase {
     $this->io->success("You're all set to start using Platform Email!");
 
     return 0;
+  }
+
+  /**
+   * Generates Zone File for DNS records of the registered domain.
+   *
+   * @param string $base_domain
+   * @param array $records
+   *
+   */
+  protected function generateZoneFile($base_domain, $records) {
+
+    // also you can make zone programmatically
+    $zone = new Zone($base_domain . '.');
+
+    foreach ($records as $record) {
+      unset($record->health);
+      $record_to_add = $zone->getNode($record->name . '.');
+
+      switch ($record->type) {
+        case 'MX':
+          $mx_priority_value_arr = explode(' ', $record->value);
+          $record_to_add->getRecordAppender()->appendMxRecord($mx_priority_value_arr[0], $mx_priority_value_arr[1] . '.', 3600);
+          break;
+        case 'TXT':
+          $record_to_add->getRecordAppender()->appendTxtRecord($record->value, 3600);
+          break;
+        case 'CNAME':
+          $record_to_add->getRecordAppender()->appendCNameRecord($record->value . '.', 3600);
+          break;
+      }
+    }
+
+    $this->localMachineHelper->getFilesystem()
+      ->dumpFile('dns-records.zone', (string) $zone);
+
   }
 
   /**
@@ -275,17 +311,18 @@ class ConfigurePlatformEmailCommand extends CommandBase {
   }
 
   /**
-   * Creates a TXT file, either in JSON or YAML format,
+   * Creates a file, either in Bind Zone File, JSON or YAML format,
    * of the DNS records needed to complete Platform Email setup.
    *
    * @param \AcquiaCloudApi\Connector\Client $client
    * @param SubscriptionResponse $subscription
+   * @param string $base_domain
    * @param string $domain_uuid
    * @param string $file_format
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function createDnsText(Client $client, $subscription, $domain_uuid, $file_format): void {
+  protected function createDnsText(Client $client, $subscription, $base_domain, $domain_uuid, $file_format): void {
     $domain_registration_response = $client->request('get', "/subscriptions/{$subscription->uuid}/domains/{$domain_uuid}");
     if (!isset($domain_registration_response->dns_records)) {
       throw new AcquiaCliException('Could not retrieve DNS records for this domain. Please try again by rerunning this script with the domain that you just registered.');
@@ -293,6 +330,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
     $records = [];
     $this->localMachineHelper->getFilesystem()->remove('dns-records.json');
     $this->localMachineHelper->getFilesystem()->remove('dns-records.yaml');
+    $this->localMachineHelper->getFilesystem()->remove('dns-records.zone');
     if ($file_format === 'JSON') {
       foreach ($domain_registration_response->dns_records as $record) {
         unset($record->health);
@@ -302,7 +340,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
       $this->localMachineHelper->getFilesystem()
             ->dumpFile('dns-records.json', json_encode($records, JSON_PRETTY_PRINT));
     }
-    else {
+    else if ($file_format === 'YAML') {
       foreach ($domain_registration_response->dns_records as $record) {
         unset($record->health);
         $records[] = ['type' => $record->type, 'name' => $record->name, 'value' => $record->value];
@@ -310,6 +348,9 @@ class ConfigurePlatformEmailCommand extends CommandBase {
       $this->logger->debug(json_encode($records));
       $this->localMachineHelper->getFilesystem()
             ->dumpFile('dns-records.yaml', Yaml::dump($records));
+    }
+    else {
+      $this->generateZoneFile($base_domain, $domain_registration_response->dns_records);
     }
 
   }

--- a/symfony.lock
+++ b/symfony.lock
@@ -41,6 +41,9 @@
     "consolidation/self-update": {
         "version": "2.0.0-alpha1"
     },
+    "container-interop/container-interop": {
+        "version": "1.2.0"
+    },
     "cweagans/composer-patches": {
         "version": "1.7.2"
     },
@@ -95,8 +98,23 @@
     "loophp/phposinfo": {
         "version": "1.7.2"
     },
+    "ltd-beget/ascii-table": {
+        "version": "1.0.4"
+    },
+    "ltd-beget/dns-zone-configurator": {
+        "version": "v1.2.9"
+    },
+    "ltd-beget/dns-zone-tokenizer": {
+        "version": "v0.0.9"
+    },
+    "ltd-beget/stringstream": {
+        "version": "v1.1.1"
+    },
     "m4tthumphrey/php-gitlab-api": {
         "version": "11.6.0"
+    },
+    "marc-mabe/php-enum": {
+        "version": "v2.3.2"
     },
     "monolog/monolog": {
         "version": "2.3.5"
@@ -492,6 +510,12 @@
     },
     "webmozart/path-util": {
         "version": "2.3.0"
+    },
+    "zendframework/zend-stdlib": {
+        "version": "3.2.1"
+    },
+    "zendframework/zend-validator": {
+        "version": "2.13.0"
     },
     "zumba/amplitude-php": {
         "version": "1.0.2"

--- a/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
@@ -35,7 +35,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'www.test.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
           '0',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -56,7 +56,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'test.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
           '1',
           // Have you finished providing the DNS records to your DNS provider?
           'n',
@@ -75,8 +75,8 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'https://www.test.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
-          '1',
+          // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
+          '2',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
           // Would you like to retry verification?
@@ -96,8 +96,8 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'https://www.test.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
-          '1',
+          // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
+          '0',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
           // Would you like to refresh?
@@ -127,8 +127,8 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'example.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
-          '0',
+          // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
+          '1',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
           // What are the environments you'd like to enable email for? You may enter multiple separated by a comma.
@@ -150,8 +150,8 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'example.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
-          '0',
+          // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
+          '2',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
         ],
@@ -179,7 +179,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'example.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
           '0',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -202,7 +202,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
           'example.com',
           // Please select a Cloud Platform subscription
           '0',
-          //Would you like your DNS records in JSON or YAML format?
+          // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
           '0',
           // Have you finished providing the DNS records to your DNS provider?
           'y',
@@ -276,7 +276,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
       $base_domain,
       // Please select a Cloud Platform subscription
       '0',
-      //Would you like your DNS records in JSON or YAML format?
+      // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
       '0',
       // Have you finished providing the DNS records to your DNS provider?
       'y',
@@ -347,7 +347,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
       $base_domain,
       // Please select a Cloud Platform subscription
       '0',
-      //Would you like your DNS records in JSON or YAML format?
+      // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
       '0',
       // Have you finished providing the DNS records to your DNS provider?
       'y',
@@ -395,7 +395,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
       $base_domain,
       // Please select a Cloud Platform subscription
       '0',
-      //Would you like your DNS records in JSON or YAML format?
+      // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
       '0',
       // Have you finished providing the DNS records to your DNS provider?
       'y',
@@ -433,7 +433,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
       $base_domain,
       // Please select a Cloud Platform subscription
       '0',
-      //Would you like your DNS records in JSON or YAML format?
+      // Would you like your DNS records in BIND Zone File, JSON, or YAML format?
       '0',
       // Have you finished providing the DNS records to your DNS provider?
       'y',


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Re-implements #883, and in turn, #834

**Proposed changes**
Re-implements Zone File output option when exporting DNS records in the `email:configure` wizard, but using a library that does not include a blocking PHP extension

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `./bin/acli email:configure` - when asked to choose a file type for exporting DNS records, choose 'Zone File' and verify contents of dns-records.zone in the root of the directory where the command was run

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
