### PR TITLE
DG-25844. Add ACSF openAPI regen script.  

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,6 +160,13 @@
             "cp cx-api-spec/dist/spec/acquia-spec.yaml assets/",
             "rm -rf cx-api-spec"
         ],
+        "update-acsf-api-spec": [
+            "rm -rf gardener",
+            "git clone --single-branch -b 2.139-RC-1 --depth 1 git@github.com:acquia/gardener.git",
+            "composer install --working-dir=gardener",
+            "php gardener/tools/openapi_spec_gen.php gen > assets/acsf-spec.yaml",
+            "rm -rf gardener"
+        ],
         "box-install": [
             "curl -f -L https://github.com/box-project/box/releases/download/3.15.0/box.phar -o build/box.phar"
         ],


### PR DESCRIPTION
Note: branch is pinned to 139, because the generator is broken in 2.140

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
Adds a script that regenerates the openAPI spec for ACSF REST API, based on whatever resources are present in gardener repo.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
run
```
composer  update-acsf-api-spec
```
... verify it has placed a new valid spec file in assets/acsf-spec.yaml

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
