### PR TITLE
Auto-merge Violinist PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,38 @@
+name: Merge dependency updates
+on:
+  workflow_run:
+    types:
+      - "completed"
+    workflows:
+      - "CI"
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'violinist-bot'
+    steps:
+    - name: "Get PR information"
+      uses: potiuk/get-workflow-origin@v1_3
+      id: source-run-info
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        sourceRunId: ${{ github.event.workflow_run.id }}
+    - run: 'gh pr merge --squash https://github.com/acquia/cli/pull/${{ env.GITHUB_PR }}'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PR: ${{ steps.source-run-info.outputs.pullRequestNumber }}
+  update_release_draft:
+    needs: merge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Violinist opens a lot of PRs for dependency updates. These are important, but mildly annoying to merge manually.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Merge them automatically as long as tests pass.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

This can't be tested before merging and waiting for a Violinist PR, but you can see that the same script is working here: https://github.com/acquia/drupal-recommended-project/pull/111

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
