### PR TITLE
CLI-692: Remove webmozart.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,6 @@
         "typhonius/acquia-logstream": "^0.0.12",
         "typhonius/acquia-php-sdk-v2": "^2.0.17",
         "violuke/rsa-ssh-key-fingerprint": "^1.1",
-        "webmozart/json": "^1.2",
-        "webmozart/key-value-store": "^1.0",
         "zumba/amplitude-php": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e91a7dac23feb20d07442f11370676b7",
+    "content-hash": "3351c9b20b0d7f11b6fcee2720e35f8c",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -943,76 +943,6 @@
                 "source": "https://github.com/http-interop/http-factory-guzzle/tree/1.2.0"
             },
             "time": "2021-07-21T13:50:14+00:00"
-        },
-        {
-            "name": "justinrainbow/json-schema",
-            "version": "1.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "cc84765fb7317f6b07bd8ac78364747f95b86341"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/cc84765fb7317f6b07bd8ac78364747f95b86341",
-                "reference": "cc84765fb7317f6b07bd8ac78364747f95b86341",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.29"
-            },
-            "require-dev": {
-                "json-schema/json-schema-test-suite": "1.1.0",
-                "phpdocumentor/phpdocumentor": "~2",
-                "phpunit/phpunit": "~3.7"
-            },
-            "bin": [
-                "bin/validate-json"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "JsonSchema\\": "src/JsonSchema/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Bruno Prieto Reis",
-                    "email": "bruno.p.reis@gmail.com"
-                },
-                {
-                    "name": "Justin Rainbow",
-                    "email": "justin.rainbow@gmail.com"
-                },
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                },
-                {
-                    "name": "Robert Schönthal",
-                    "email": "seroscho@googlemail.com"
-                }
-            ],
-            "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
-            "keywords": [
-                "json",
-                "schema"
-            ],
-            "support": {
-                "issues": "https://github.com/justinrainbow/json-schema/issues",
-                "source": "https://github.com/justinrainbow/json-schema/tree/master"
-            },
-            "time": "2016-01-25T15:43:01+00:00"
         },
         {
             "name": "kevinrob/guzzle-cache-middleware",
@@ -3462,70 +3392,6 @@
                 }
             ],
             "time": "2021-07-11T12:37:55+00:00"
-        },
-        {
-            "name": "seld/jsonlint",
-            "version": "1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "4211420d25eba80712bff236a98960ef68b866b7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/4211420d25eba80712bff236a98960ef68b866b7",
-                "reference": "4211420d25eba80712bff236a98960ef68b866b7",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.5",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
-            },
-            "bin": [
-                "bin/jsonlint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "JSON Linter",
-            "keywords": [
-                "json",
-                "linter",
-                "parser",
-                "validator"
-            ],
-            "support": {
-                "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.9.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/Seldaek",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-04-01T13:37:23+00:00"
         },
         {
             "name": "symfony/cache",
@@ -6293,124 +6159,6 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
             "time": "2021-03-09T10:59:23+00:00"
-        },
-        {
-            "name": "webmozart/json",
-            "version": "1.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/json.git",
-                "reference": "a1fb3da904b8364e3db47eed68f76bfb6cd0031a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/json/zipball/a1fb3da904b8364e3db47eed68f76bfb6cd0031a",
-                "reference": "a1fb3da904b8364e3db47eed68f76bfb6cd0031a",
-                "shasum": ""
-            },
-            "require": {
-                "justinrainbow/json-schema": "^1.6",
-                "php": "^5.3.3|^7.0",
-                "seld/jsonlint": "^1.0",
-                "webmozart/path-util": "^2.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1",
-                "symfony/filesystem": "^2.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Json\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "A robust JSON decoder/encoder with support for schema validation.",
-            "support": {
-                "issues": "https://github.com/webmozart/json/issues",
-                "source": "https://github.com/webmozart/json/tree/1.2.2"
-            },
-            "time": "2016-01-14T12:11:46+00:00"
-        },
-        {
-            "name": "webmozart/key-value-store",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/key-value-store.git",
-                "reference": "c9189402cba9d9cee3a5a1df70b235fe2f9c5453"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/key-value-store/zipball/c9189402cba9d9cee3a5a1df70b235fe2f9c5453",
-                "reference": "c9189402cba9d9cee3a5a1df70b235fe2f9c5453",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3|^7.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "basho/riak": "^1.4",
-                "doctrine/cache": "^1.4",
-                "doctrine/dbal": "^2.4",
-                "mongodb/mongodb": "^1.0",
-                "phpunit/phpunit": "^4.6",
-                "predis/predis": "^1.0",
-                "sebastian/version": "^1.0.1",
-                "symfony/filesystem": "^2.5",
-                "webmozart/json": "^1.1.1"
-            },
-            "suggest": {
-                "basho/riak": "to enable the RiakStore",
-                "doctrine/cache": "to enable the CachedStore",
-                "doctrine/dbal": "to enable the DbalStore",
-                "mongodb/mongodb": "to enable the MongoDbStore",
-                "predis/predis": "to enable the PredisStore",
-                "webmozart/json": "to enable the JsonFileStore"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\KeyValueStore\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "A key-value store API with implementations for different backends.",
-            "support": {
-                "issues": "https://github.com/webmozart/key-value-store/issues",
-                "source": "https://github.com/webmozart/key-value-store/tree/1.0.0"
-            },
-            "time": "2016-08-09T15:13:26+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -10248,6 +9996,70 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/4211420d25eba80712bff236a98960ef68b866b7",
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.5",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-01T13:37:23+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",

--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -19,18 +19,24 @@ services:
       # This should be root directory of the repository where acli is being invoked (not the root of acli itself).
       $repoRoot: "%app.repo_root%"
       $sshDir: "%app.ssh_dir%"
-      Webmozart\KeyValueStore\JsonFileStore $datastoreCloud: '@datastore.cloud'
-      Acquia\Cli\DataStore\YamlStore $datastoreAcli: '@datastore.acli'
     public: true
 
   # Register nearly all Acquia CLI classes as services.
   Acquia\Cli\:
     exclude:
       - ../../src/Kernel.php
+      - ../../src/DataStore/Datastore.php
       - ../../src/DataStore/YamlStore.php
+      - ../../src/DataStore/JsonDataStore.php
       - ../../src/CloudApi/AccessTokenConnector.php
     public: true
     resource: ../../src
+
+  Acquia\Cli\Config\AcquiaCliConfig: ~
+  Acquia\Cli\Config\CloudDataConfig: ~
+
+  Acquia\Cli\DataStore\AcquiaCliDatastore: ~
+  Acquia\Cli\DataStore\CloudDataStore: ~
 
   # All commands inherit from a common base and use the same DI parameters.
   Acquia\Cli\Command\:
@@ -57,30 +63,14 @@ services:
       - { name: kernel.event_listener, event: console.terminate, method: onConsoleTerminate}
       - { name: kernel.event_listener, event: console.command, method: onConsoleCommand}
 
-  # We have multiple datastores using the same class, just different arguments.
-  datastore.cloud:
-    class: Webmozart\KeyValueStore\JsonFileStore
-    arguments:
-      $path: '%app.cloud_config_filepath%'
-      # NO_SERIALIZE_STRINGS & NO_SERIALIZE_ARRAYS
-      $flags: 3
-  datastore.acli:
-    class: Acquia\Cli\DataStore\YamlStore
-    arguments:
-      $path: '%app.acli_config_filepath%'
-
   Acquia\Cli\ApiCredentialsInterface:
     alias: Acquia\Cli\CloudApi\CloudCredentials
 
   cloud.credentials:
     class: Acquia\Cli\CloudApi\CloudCredentials
-    arguments:
-      $datastoreCloud: '@datastore.cloud'
 
   acsf.credentials:
     class: Acquia\Cli\AcsfApi\AcsfCredentials
-    arguments:
-      $datastoreCloud: '@datastore.cloud'
 
   # AcquiaCloudApi services.
   Acquia\Cli\Command\Api\ApiCommandFactory: ~

--- a/src/AcsfApi/AcsfClientService.php
+++ b/src/AcsfApi/AcsfClientService.php
@@ -4,8 +4,8 @@ namespace Acquia\Cli\AcsfApi;
 
 use Acquia\Cli\Application;
 use Acquia\Cli\CloudApi\ClientService;
+use Acquia\Cli\DataStore\CloudDataStore;
 use AcquiaCloudApi\Connector\Client;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * AcsfClientService class.
@@ -31,11 +31,11 @@ class AcsfClientService extends ClientService {
   }
 
   /**
-   * @param JsonFileStore $cloud_datastore
+   * @param CloudDataStore $cloud_datastore
    *
    * @return bool
    */
-  public function isMachineAuthenticated(JsonFileStore $cloud_datastore): ?bool {
+  public function isMachineAuthenticated(CloudDataStore $cloud_datastore): ?bool {
     if ($this->machineIsAuthenticated) {
       return $this->machineIsAuthenticated;
     }

--- a/src/AcsfApi/AcsfCredentials.php
+++ b/src/AcsfApi/AcsfCredentials.php
@@ -3,7 +3,7 @@
 namespace Acquia\Cli\AcsfApi;
 
 use Acquia\Cli\ApiCredentialsInterface;
-use Webmozart\KeyValueStore\JsonFileStore;
+use Acquia\Cli\DataStore\CloudDataStore;
 
 /**
  * @package Acquia\Cli\Helpers
@@ -11,16 +11,16 @@ use Webmozart\KeyValueStore\JsonFileStore;
 class AcsfCredentials implements ApiCredentialsInterface {
 
   /**
-   * @var \Webmozart\KeyValueStore\JsonFileStore
+   * @var \Acquia\Cli\DataStore\CloudDataStore
    */
   private $datastoreCloud;
 
   /**
    * CloudCredentials constructor.
    *
-   * @param \Webmozart\KeyValueStore\JsonFileStore $datastoreCloud
+   * @param \Acquia\Cli\DataStore\CloudDataStore $datastoreCloud
    */
-  public function __construct(JsonFileStore $datastoreCloud) {
+  public function __construct(CloudDataStore $datastoreCloud) {
     $this->datastoreCloud = $datastoreCloud;
   }
 

--- a/src/CloudApi/ClientService.php
+++ b/src/CloudApi/ClientService.php
@@ -5,10 +5,10 @@ namespace Acquia\Cli\CloudApi;
 use Acquia\Cli\Application;
 use Acquia\Cli\ClientServiceInterface;
 use Acquia\Cli\ConnectorFactoryInterface;
+use Acquia\Cli\DataStore\CloudDataStore;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Connector\Connector;
 use AcquiaCloudApi\Connector\ConnectorInterface;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Factory producing Acquia Cloud Api clients.
@@ -75,11 +75,11 @@ class ClientService implements ClientServiceInterface {
   }
 
   /**
-   * @param JsonFileStore $cloud_datastore
+   * @param CloudDataStore $cloud_datastore
    *
    * @return bool
    */
-  public function isMachineAuthenticated(JsonFileStore $cloud_datastore): ?bool {
+  public function isMachineAuthenticated(CloudDataStore $cloud_datastore): ?bool {
     if ($this->machineIsAuthenticated) {
       return $this->machineIsAuthenticated;
     }

--- a/src/CloudApi/CloudCredentials.php
+++ b/src/CloudApi/CloudCredentials.php
@@ -3,7 +3,7 @@
 namespace Acquia\Cli\CloudApi;
 
 use Acquia\Cli\ApiCredentialsInterface;
-use Webmozart\KeyValueStore\JsonFileStore;
+use Acquia\Cli\DataStore\CloudDataStore;
 
 /**
  * @package Acquia\Cli\Helpers
@@ -11,16 +11,16 @@ use Webmozart\KeyValueStore\JsonFileStore;
 class CloudCredentials implements ApiCredentialsInterface {
 
   /**
-   * @var \Webmozart\KeyValueStore\JsonFileStore
+   * @var \Acquia\Cli\DataStore\CloudDataStore
    */
   private $datastoreCloud;
 
   /**
    * CloudCredentials constructor.
    *
-   * @param \Webmozart\KeyValueStore\JsonFileStore $datastoreCloud
+   * @param \Acquia\Cli\DataStore\CloudDataStore $datastoreCloud
    */
-  public function __construct(JsonFileStore $datastoreCloud) {
+  public function __construct(CloudDataStore $datastoreCloud) {
     $this->datastoreCloud = $datastoreCloud;
   }
 

--- a/src/Command/Acsf/AcsfApiAuthLoginCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLoginCommand.php
@@ -87,7 +87,7 @@ class AcsfApiAuthLoginCommand extends AcsfCommandBase {
     $username = $input->getOption('username');
     $password = $input->getOption('password');
     $this->writeAcsfCredentialsToDisk($factory_url, $username, $password);
-    $output->writeln("<info>Saved credentials to <options=bold>{$this->cloudConfigFilepath}</></info>");
+    $output->writeln("<info>Saved credentials</info>");
 
     return 0;
   }

--- a/src/Command/Acsf/AcsfApiAuthLoginCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLoginCommand.php
@@ -47,6 +47,9 @@ class AcsfApiAuthLoginCommand extends AcsfCommandBase {
     elseif ($input->isInteractive() && $this->datastoreCloud->get('acsf_factories')) {
       $factories = $this->datastoreCloud->get('acsf_factories');
       $factory_choices = $factories;
+      foreach ($factory_choices as $url => $factory_choice) {
+        $factory_choices[$url]['url'] = $url;
+      }
       $factory_choices['add_new'] = [
         'url' => 'Enter a new factory URL',
       ];

--- a/src/Command/Acsf/AcsfApiAuthLogoutCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLogoutCommand.php
@@ -43,6 +43,9 @@ class AcsfApiAuthLogoutCommand extends AcsfCommandBase {
       return 1;
     }
     $factories = $this->datastoreCloud->get('acsf_factories');
+    foreach ($factories as $url => $factory) {
+      $factories[$url]['url'] = $url;
+    }
     $factory = $this->promptChooseFromObjectsOrArrays($factories, 'url', 'url', 'Please choose a Factory to logout of');
     $factory_url = $factory['url'];
 

--- a/src/Command/Acsf/AcsfApiAuthLogoutCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLogoutCommand.php
@@ -62,7 +62,7 @@ class AcsfApiAuthLogoutCommand extends AcsfCommandBase {
     $this->datastoreCloud->set('acsf_factories', $factories);
     $this->datastoreCloud->remove('acsf_active_factory');
 
-    $output->writeln("Logged {$active_user['username']} out of $factory_url in <options=bold>{$this->cloudConfigFilepath}</></info>");
+    $output->writeln("Logged {$active_user['username']} out of $factory_url</info>");
 
     return 0;
   }

--- a/src/Command/Acsf/AcsfCommandFactory.php
+++ b/src/Command/Acsf/AcsfCommandFactory.php
@@ -5,13 +5,13 @@ namespace Acquia\Cli\Command\Acsf;
 use Acquia\Cli\AcsfApi\AcsfClientService;
 use Acquia\Cli\AcsfApi\AcsfCredentials;
 use Acquia\Cli\CommandFactoryInterface;
-use Acquia\Cli\DataStore\YamlStore;
+use Acquia\Cli\DataStore\AcquiaCliDatastore;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Helpers\LocalMachineHelper;
 use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Helpers\TelemetryHelper;
 use AcquiaLogstream\LogstreamManager;
 use Psr\Log\LoggerInterface;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Class ApiCommandFactory.
@@ -19,17 +19,12 @@ use Webmozart\KeyValueStore\JsonFileStore;
 class AcsfCommandFactory implements CommandFactoryInterface {
 
   /**
-   * @var string
-   */
-  private string $cloudConfigFilepath;
-
-  /**
    * @var \Acquia\Cli\Helpers\LocalMachineHelper
    */
   private $localMachineHelper;
 
   /**
-   * @var \Webmozart\KeyValueStore\JsonFileStore
+   * @var \Acquia\Cli\DataStore\CloudDataStore
    */
   private $datastoreCloud;
 
@@ -52,11 +47,6 @@ class AcsfCommandFactory implements CommandFactoryInterface {
    * @var string
    */
   private string $repoRoot;
-
-  /**
-   * @var string
-   */
-  private string $acliConfigFilepath;
 
   /**
    * @var \Acquia\Cli\AcsfApi\AcsfClientService
@@ -84,13 +74,11 @@ class AcsfCommandFactory implements CommandFactoryInterface {
   private $logger;
 
   /**
-   * @param string $cloudConfigFilepath
    * @param \Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
-   * @param \Webmozart\KeyValueStore\JsonFileStore $datastoreCloud
-   * @param \Acquia\Cli\DataStore\YamlStore $datastoreAcli
+   * @param \Acquia\Cli\DataStore\CloudDataStore $datastoreCloud
+   * @param \Acquia\Cli\DataStore\AcquiaCliDatastore $datastoreAcli
    * @param \Acquia\Cli\AcsfApi\AcsfCredentials $cloudCredentials
    * @param \Acquia\Cli\Helpers\TelemetryHelper $telemetryHelper
-   * @param string $acliConfigFilepath
    * @param string $repoRoot
    * @param \Acquia\Cli\AcsfApi\AcsfClientService $cloudApiClientService
    * @param \AcquiaLogstream\LogstreamManager $logstreamManager
@@ -99,13 +87,11 @@ class AcsfCommandFactory implements CommandFactoryInterface {
    * @param \Psr\Log\LoggerInterface $logger
    */
   public function __construct(
-    string $cloudConfigFilepath,
     LocalMachineHelper $localMachineHelper,
-    JsonFileStore $datastoreCloud,
-    YamlStore $datastoreAcli,
+    CloudDataStore $datastoreCloud,
+    AcquiaCliDatastore $datastoreAcli,
     AcsfCredentials $cloudCredentials,
     TelemetryHelper $telemetryHelper,
-    string $acliConfigFilepath,
     string $repoRoot,
     AcsfClientService $cloudApiClientService,
     LogstreamManager $logstreamManager,
@@ -113,13 +99,11 @@ class AcsfCommandFactory implements CommandFactoryInterface {
     string $sshDir,
     LoggerInterface $logger
   ) {
-    $this->cloudConfigFilepath = $cloudConfigFilepath;
     $this->localMachineHelper = $localMachineHelper;
     $this->datastoreCloud = $datastoreCloud;
     $this->datastoreAcli = $datastoreAcli;
     $this->cloudCredentials = $cloudCredentials;
     $this->telemetryHelper = $telemetryHelper;
-    $this->acliConfigFilepath = $acliConfigFilepath;
     $this->repoRoot = $repoRoot;
     $this->cloudApiClientService = $cloudApiClientService;
     $this->logstreamManager = $logstreamManager;
@@ -133,13 +117,11 @@ class AcsfCommandFactory implements CommandFactoryInterface {
    */
   public function createCommand(): AcsfApiBaseCommand {
     return new AcsfApiBaseCommand(
-      $this->cloudConfigFilepath,
       $this->localMachineHelper,
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->cloudCredentials,
       $this->telemetryHelper,
-      $this->acliConfigFilepath,
       $this->repoRoot,
       $this->cloudApiClientService,
       $this->logstreamManager,
@@ -154,13 +136,11 @@ class AcsfCommandFactory implements CommandFactoryInterface {
    */
   public function createListCommand(): AcsfListCommand {
     return new AcsfListCommand(
-      $this->cloudConfigFilepath,
       $this->localMachineHelper,
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->cloudCredentials,
       $this->telemetryHelper,
-      $this->acliConfigFilepath,
       $this->repoRoot,
       $this->cloudApiClientService,
       $this->logstreamManager,

--- a/src/Command/Api/ApiCommandFactory.php
+++ b/src/Command/Api/ApiCommandFactory.php
@@ -7,13 +7,13 @@ use Acquia\Cli\AcsfApi\AcsfCredentials;
 use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\CloudApi\CloudCredentials;
 use Acquia\Cli\CommandFactoryInterface;
-use Acquia\Cli\DataStore\YamlStore;
+use Acquia\Cli\DataStore\AcquiaCliDatastore;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Helpers\LocalMachineHelper;
 use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Helpers\TelemetryHelper;
 use AcquiaLogstream\LogstreamManager;
 use Psr\Log\LoggerInterface;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Class ApiCommandFactory.
@@ -21,17 +21,12 @@ use Webmozart\KeyValueStore\JsonFileStore;
 class ApiCommandFactory implements CommandFactoryInterface {
 
   /**
-   * @var string
-   */
-  private string $cloudConfigFilepath;
-
-  /**
    * @var \Acquia\Cli\Helpers\LocalMachineHelper
    */
   private $localMachineHelper;
 
   /**
-   * @var \Webmozart\KeyValueStore\JsonFileStore
+   * @var \Acquia\Cli\DataStore\CloudDataStore
    */
   private $datastoreCloud;
 
@@ -54,11 +49,6 @@ class ApiCommandFactory implements CommandFactoryInterface {
    * @var string
    */
   private string $repoRoot;
-
-  /**
-   * @var string
-   */
-  private string $acliConfigFilepath;
 
   /**
    * @var \Acquia\Cli\AcsfApi\AcsfClientService
@@ -86,13 +76,11 @@ class ApiCommandFactory implements CommandFactoryInterface {
   private $logger;
 
   /**
-   * @param string $cloudConfigFilepath
    * @param \Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
-   * @param \Webmozart\KeyValueStore\JsonFileStore $datastoreCloud
-   * @param \Acquia\Cli\DataStore\YamlStore $datastoreAcli
+   * @param \Acquia\Cli\DataStore\CloudDataStore $datastoreCloud
+   * @param \Acquia\Cli\DataStore\AcquiaCliDatastore $datastoreAcli
    * @param \Acquia\Cli\CloudApi\CloudCredentials $cloudCredentials
    * @param \Acquia\Cli\Helpers\TelemetryHelper $telemetryHelper
-   * @param string $acliConfigFilepath
    * @param string $repoRoot
    * @param \Acquia\Cli\CloudApi\ClientService $cloudApiClientService
    * @param \AcquiaLogstream\LogstreamManager $logstreamManager
@@ -101,13 +89,11 @@ class ApiCommandFactory implements CommandFactoryInterface {
    * @param \Psr\Log\LoggerInterface $logger
    */
   public function __construct(
-    string $cloudConfigFilepath,
     LocalMachineHelper $localMachineHelper,
-    JsonFileStore $datastoreCloud,
-    YamlStore $datastoreAcli,
+    CloudDataStore $datastoreCloud,
+    AcquiaCliDatastore $datastoreAcli,
     CloudCredentials $cloudCredentials,
     TelemetryHelper $telemetryHelper,
-    string $acliConfigFilepath,
     string $repoRoot,
     ClientService $cloudApiClientService,
     LogstreamManager $logstreamManager,
@@ -115,13 +101,11 @@ class ApiCommandFactory implements CommandFactoryInterface {
     string $sshDir,
     LoggerInterface $logger
   ) {
-    $this->cloudConfigFilepath = $cloudConfigFilepath;
     $this->localMachineHelper = $localMachineHelper;
     $this->datastoreCloud = $datastoreCloud;
     $this->datastoreAcli = $datastoreAcli;
     $this->cloudCredentials = $cloudCredentials;
     $this->telemetryHelper = $telemetryHelper;
-    $this->acliConfigFilepath = $acliConfigFilepath;
     $this->repoRoot = $repoRoot;
     $this->cloudApiClientService = $cloudApiClientService;
     $this->logstreamManager = $logstreamManager;
@@ -135,13 +119,11 @@ class ApiCommandFactory implements CommandFactoryInterface {
    */
   public function createCommand(): ApiBaseCommand {
     return new ApiBaseCommand(
-      $this->cloudConfigFilepath,
       $this->localMachineHelper,
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->cloudCredentials,
       $this->telemetryHelper,
-      $this->acliConfigFilepath,
       $this->repoRoot,
       $this->cloudApiClientService,
       $this->logstreamManager,
@@ -156,13 +138,11 @@ class ApiCommandFactory implements CommandFactoryInterface {
    */
   public function createListCommand(): ApiListCommand {
     return new ApiListCommand(
-      $this->cloudConfigFilepath,
       $this->localMachineHelper,
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->cloudCredentials,
       $this->telemetryHelper,
-      $this->acliConfigFilepath,
       $this->repoRoot,
       $this->cloudApiClientService,
       $this->logstreamManager,

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -50,7 +50,7 @@ class AuthLoginCommand extends CommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    /** @var \Webmozart\KeyValueStore\JsonFileStore $cloud_datastore */
+    /** @var \Acquia\Cli\DataStore\CloudDataStore $cloud_datastore */
     if ($this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
       $answer = $this->io->confirm('Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?');
       if (!$answer) {
@@ -60,6 +60,9 @@ class AuthLoginCommand extends CommandBase {
 
     // If keys already are saved locally, prompt to select.
     if ($input->isInteractive() && $keys = $this->datastoreCloud->get('keys')) {
+      foreach ($keys as $uuid => $key) {
+        $keys[$uuid]['uuid'] = $uuid;
+      }
       $keys['create_new'] = [
         'uuid' => 'create_new',
         'label' => 'Enter a new API key',
@@ -78,7 +81,7 @@ class AuthLoginCommand extends CommandBase {
     $api_secret = $this->determineApiSecret($input, $output);
     $this->reAuthenticate($api_key, $api_secret, $this->cloudCredentials->getBaseUri());
     $this->writeApiCredentialsToDisk($api_key, $api_secret);
-    $output->writeln("<info>Saved credentials to <options=bold>{$this->cloudConfigFilepath}</></info>");
+    $output->writeln("<info>Saved credentials</info>");
 
     return 0;
   }

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -39,7 +39,7 @@ class AuthLogoutCommand extends CommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    /** @var \Webmozart\KeyValueStore\JsonFileStore $cloud_datastore */
+    /** @var \Acquia\Cli\DataStore\CloudDataStore $cloud_datastore */
     if ($this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
       $answer = $this->io->confirm('Are you sure you\'d like to unset the Acquia Cloud API key for Acquia CLI?');
       if (!$answer) {
@@ -48,7 +48,7 @@ class AuthLogoutCommand extends CommandBase {
     }
     $this->datastoreCloud->remove('acli_key');
 
-    $output->writeln("Unset the Acquia Cloud API key for Acquia CLI in <options=bold>{$this->cloudConfigFilepath}</></info>");
+    $output->writeln("Unset the Acquia Cloud API key for Acquia CLI</info>");
 
     return 0;
   }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -7,7 +7,8 @@ use Acquia\Cli\ClientServiceInterface;
 use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\CloudApi\CloudCredentials;
 use Acquia\Cli\Command\Ssh\SshKeyCommandBase;
-use Acquia\Cli\DataStore\YamlStore;
+use Acquia\Cli\DataStore\AcquiaCliDatastore;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\DataStoreContract;
 use Acquia\Cli\Helpers\LocalMachineHelper;
@@ -58,8 +59,6 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\Cache\ItemInterface;
-use Webmozart\KeyValueStore\JsonFileStore;
-use Webmozart\KeyValueStore\Util\Serializer;
 use Zumba\Amplitude\Amplitude;
 
 /**
@@ -106,7 +105,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   public $localMachineHelper;
 
   /**
-   * @var JsonFileStore
+   * @var CloudDataStore
    */
   protected $datastoreCloud;
 
@@ -119,16 +118,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @var CloudCredentials
    */
   protected $cloudCredentials;
-
-  /**
-   * @var string
-   */
-  protected $cloudConfigFilepath;
-
-  /**
-   * @var string
-   */
-  protected $acliConfigFilepath;
 
   /**
    * @var string
@@ -175,13 +164,11 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * CommandBase constructor.
    *
-   * @param string $cloudConfigFilepath
    * @param LocalMachineHelper $localMachineHelper
-   * @param JsonFileStore $datastoreCloud
-   * @param YamlStore $datastoreAcli
+   * @param CloudDataStore $datastoreCloud
+   * @param AcquiaCliDatastore $datastoreAcli
    * @param ApiCredentialsInterface $cloudCredentials
    * @param TelemetryHelper $telemetryHelper
-   * @param string $acliConfigFilepath
    * @param string $repoRoot
    * @param ClientService $cloudApiClientService
    * @param LogstreamManager $logstreamManager
@@ -190,13 +177,11 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @param ConsoleLogger $logger
    */
   public function __construct(
-    string $cloudConfigFilepath,
     LocalMachineHelper $localMachineHelper,
-    JsonFileStore $datastoreCloud,
-    YamlStore $datastoreAcli,
+    CloudDataStore $datastoreCloud,
+    AcquiaCliDatastore $datastoreAcli,
     ApiCredentialsInterface $cloudCredentials,
     TelemetryHelper $telemetryHelper,
-    string $acliConfigFilepath,
     string $repoRoot,
     ClientServiceInterface $cloudApiClientService,
     LogstreamManager $logstreamManager,
@@ -204,13 +189,11 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     string $sshDir,
     LoggerInterface $logger
   ) {
-    $this->cloudConfigFilepath = $cloudConfigFilepath;
     $this->localMachineHelper = $localMachineHelper;
     $this->datastoreCloud = $datastoreCloud;
     $this->datastoreAcli = $datastoreAcli;
     $this->cloudCredentials = $cloudCredentials;
     $this->telemetryHelper = $telemetryHelper;
-    $this->acliConfigFilepath = $acliConfigFilepath;
     $this->repoRoot = $repoRoot;
     $this->cloudApiClientService = $cloudApiClientService;
     $this->logstreamManager = $logstreamManager;
@@ -350,7 +333,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
     $this->output->writeln('Acquia CLI version: ' . $this->getApplication()->getVersion(), OutputInterface::VERBOSITY_DEBUG);
     $this->checkAndPromptTelemetryPreference();
-    $this->migrateLegacyApiKey();
     $this->telemetryHelper->initializeAmplitude();
 
     if ($this->commandRequiresAuthentication($this->input) && !$this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
@@ -372,19 +354,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    */
   public function checkAndPromptTelemetryPreference(): void {
     $send_telemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
-    if (!isset($send_telemetry) || is_null($send_telemetry)) {
-      $this->migrateLegacySendTelemetryPreference();
-      $send_telemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
-    }
-    // Convert from serialized to unserialized.
-    if ($this->datastoreCloud
-      && $this->datastoreCloud->get('user')
-      && is_string($this->datastoreCloud->get('user'))
-      && strpos($this->datastoreCloud->get('user'), 'a:') === 0
-    ) {
-      $value = Serializer::unserialize($this->datastoreCloud->get('user'));
-      $this->datastoreCloud->set('user', $value);
-    }
     if ($this->getName() !== 'telemetry' && (!isset($send_telemetry) || is_null($send_telemetry)) && $this->input->isInteractive()) {
       $this->output->writeln('We strive to give you the best tools for development.');
       $this->output->writeln('You can really help us improve by sharing anonymous performance and usage data.');
@@ -1455,55 +1424,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->logger->debug("Multisite detected");
     $this->warnMultisite();
     return $this->io->choice('Choose a site', $sites, $sites[0]);
-  }
-
-  /**
-   * Migrate from storing preference in acquia-cli.json.
-   */
-  protected function migrateLegacySendTelemetryPreference(): void {
-    $legacy_acli_config_filepath = $this->localMachineHelper->getLocalFilepath(Path::join(dirname($this->cloudConfigFilepath),
-      'acquia-cli.json'));
-    if ($this->localMachineHelper->getFilesystem()->exists($legacy_acli_config_filepath)) {
-      $legacy_acli_config = json_decode(file_get_contents($legacy_acli_config_filepath), TRUE);
-      if (array_key_exists('send_telemetry', $legacy_acli_config)) {
-        $send_telemetry = $legacy_acli_config['send_telemetry'];
-        $this->datastoreCloud->set('send_telemetry', $send_telemetry);
-      }
-    }
-  }
-
-  /**
-   * Migrate from storing only a single API key to storing multiple.
-   */
-  protected function migrateLegacyApiKey(): void {
-    if ($this->datastoreCloud
-      && $this->datastoreCloud->get('key')
-      && $this->datastoreCloud->get('secret')
-      && !$this->datastoreCloud->get('acli_key')
-      && !$this->datastoreCloud->get('keys')
-    ) {
-      $uuid = $this->datastoreCloud->get('key');
-      $token_info = $this->cloudApiClientService->getClient()->request('get', "/account/tokens/{$uuid}");
-      $keys[$uuid] = [
-        'label' => $token_info->label,
-        'uuid' => $uuid,
-        'secret' => $this->datastoreCloud->get('secret'),
-      ];
-      $this->datastoreCloud->set('keys', $keys);
-      $this->datastoreCloud->set('acli_key', $uuid);
-    }
-
-    // Convert from serialized to unserialized.
-    if ($this->datastoreCloud
-      && $this->datastoreCloud->get('acli_key')
-      && $this->datastoreCloud->get('keys')
-      && is_string($this->datastoreCloud->get('keys'))
-      && strpos($this->datastoreCloud->get('keys'), 'a:') === 0
-    ) {
-      $value = Serializer::unserialize($this->datastoreCloud->get('keys'));
-      $this->datastoreCloud->set('keys', $value);
-      $this->reAuthenticate($this->cloudCredentials->getCloudKey(), $this->cloudCredentials->getCloudSecret(), $this->cloudCredentials->getBaseUri());
-    }
   }
 
   public static function getLandoInfo() {

--- a/src/Config/AcquiaCliConfig.php
+++ b/src/Config/AcquiaCliConfig.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Acquia\Cli\Config;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class AcquiaCliConfig implements ConfigurationInterface {
+
+  /**
+   * @return string
+   */
+  public function getName(): string {
+    return 'acquia_cli';
+  }
+
+  /**
+   * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder
+   */
+  public function getConfigTreeBuilder(): TreeBuilder {
+    $treeBuilder = new TreeBuilder('acquia_cli');
+    $treeBuilder
+      ->getRootNode()
+        ->children()
+          ->scalarNode('cloud_app_uuid')
+        ->end()
+      ->end();
+    return $treeBuilder;
+  }
+}

--- a/src/Config/CloudDataConfig.php
+++ b/src/Config/CloudDataConfig.php
@@ -23,9 +23,10 @@ class CloudDataConfig implements ConfigurationInterface {
     $root_node
       ->children()
 
-        ->booleanNode('send_telemetry')
-          ->defaultNull()
-        ->end()
+        // I can't find a better node type that accepts TRUE, FALSE, and NULL.
+        // boolNode() will cast NULL to FALSE and enumNode()->values() will
+        // strip out a NULL value.
+        ->scalarNode('send_telemetry')->end()
 
         ->scalarNode('acli_key')->end()
 

--- a/src/Config/CloudDataConfig.php
+++ b/src/Config/CloudDataConfig.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Acquia\Cli\Config;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class CloudDataConfig implements ConfigurationInterface {
+
+  /**
+   * @return string
+   */
+  public function getName(): string {
+    return 'cloud_api';
+  }
+
+  /**
+   * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder
+   */
+  public function getConfigTreeBuilder(): TreeBuilder {
+    $treeBuilder = new TreeBuilder('cloud_api');
+    $root_node = $treeBuilder->getRootNode();
+    $root_node
+      ->children()
+
+        ->booleanNode('send_telemetry')
+          ->defaultNull()
+        ->end()
+
+        ->scalarNode('acli_key')->end()
+
+        ->arrayNode('keys')
+            ->useAttributeAsKey('uuid')
+            ->arrayPrototype()
+                ->children()
+                  ->scalarNode('label')->end()
+                  ->scalarNode('uuid')->end()
+                  ->scalarNode('secret')->end()
+                ->end()
+            ->end()
+        ->end()
+
+        ->arrayNode('user')
+            ->children()
+                ->scalarNode('uuid')->end()
+                ->booleanNode('is_acquian')
+                  ->defaultValue(FALSE)
+                ->end()
+            ->end()
+        ->end()
+
+        ->arrayNode('acsf_factories')
+            ->useAttributeAsKey('url')
+            ->arrayPrototype()
+                ->children()
+                    ->arrayNode('users')
+                        ->arrayPrototype()
+                            ->children()
+                                ->scalarNode('username')->end()
+                                ->scalarNode('password')->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->scalarNode('url')->end()
+                    ->scalarNode('active_user')->end()
+                ->end()
+            ->end()
+        ->end()
+
+        ->scalarNode('acsf_active_factory')->end()
+
+      ->end();
+    return $treeBuilder;
+  }
+}

--- a/src/Config/CloudDataConfig.php
+++ b/src/Config/CloudDataConfig.php
@@ -32,6 +32,7 @@ class CloudDataConfig implements ConfigurationInterface {
 
         ->arrayNode('keys')
             ->useAttributeAsKey('uuid')
+            ->normalizeKeys(FALSE)
             ->arrayPrototype()
                 ->children()
                   ->scalarNode('label')->end()

--- a/src/DataStore/AcquiaCliDatastore.php
+++ b/src/DataStore/AcquiaCliDatastore.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Acquia\Cli\DataStore;
+
+use Acquia\Cli\Config\AcquiaCliConfig;
+use Acquia\Cli\Config\CloudDataConfig;
+use Acquia\Cli\Helpers\LocalMachineHelper;
+
+class AcquiaCliDatastore extends YamlStore implements DataStoreInterface {
+
+  /**
+   * @var \Acquia\Cli\Helpers\LocalMachineHelper
+   */
+  protected LocalMachineHelper $localMachineHelper;
+
+  /**
+   * @var array
+   */
+  protected array $config;
+
+  /**
+   * @param \Acquia\Cli\Helpers\LocalMachineHelper $local_machine_helper
+   * @param \Acquia\Cli\Config\AcquiaCliConfig $config_definition
+   * @param string $acliConfigFilepath
+   */
+  public function __construct(
+    LocalMachineHelper $local_machine_helper,
+    AcquiaCliConfig $config_definition,
+    string $acliConfigFilepath
+  ) {
+    $this->localMachineHelper = $local_machine_helper;
+    $file_path = $local_machine_helper->getLocalFilepath($acliConfigFilepath);
+    parent::__construct($file_path, $config_definition);
+  }
+
+}

--- a/src/DataStore/CloudDataStore.php
+++ b/src/DataStore/CloudDataStore.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Acquia\Cli\DataStore;
+
+use Acquia\Cli\Config\CloudDataConfig;
+use Acquia\Cli\Helpers\LocalMachineHelper;
+
+class CloudDataStore extends JsonDataStore {
+
+  /**
+   * @var \Acquia\Cli\Helpers\LocalMachineHelper
+   */
+  protected LocalMachineHelper $localMachineHelper;
+
+  /**
+   * @var array
+   */
+  protected array $config;
+
+  /**
+   * @param \Acquia\Cli\Helpers\LocalMachineHelper $local_machine_helper
+   * @param \Acquia\Cli\Config\CloudDataConfig $cloud_data_config
+   * @param string $cloudConfigFilepath
+   */
+  public function __construct(
+    LocalMachineHelper $local_machine_helper,
+    CloudDataConfig $cloud_data_config,
+    string $cloudConfigFilepath
+  ) {
+    $this->localMachineHelper = $local_machine_helper;
+    parent::__construct($cloudConfigFilepath, $cloud_data_config);
+  }
+
+}

--- a/src/DataStore/DataStoreInterface.php
+++ b/src/DataStore/DataStoreInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Acquia\Cli\DataStore;
+
+interface DataStoreInterface {
+
+  public function set(string $key, $value);
+
+  public function get(string $key, $default = NULL);
+
+  public function dump();
+
+  public function remove(string $key);
+
+  public function exists(string $key);
+}

--- a/src/DataStore/Datastore.php
+++ b/src/DataStore/Datastore.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Acquia\Cli\DataStore;
+
+use Dflydev\DotAccessData\Data;
+use Grasmash\Expander\Expander;
+use Grasmash\Expander\Stringifier;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Class YamlStore
+ * @package Acquia\Cli\DataStore
+ */
+abstract class Datastore implements DataStoreInterface {
+
+  /** @var Data */
+  protected $data;
+
+  /**
+   * @var \Symfony\Component\Filesystem\Filesystem
+   */
+  protected $fileSystem;
+
+  /**
+   * @var string
+   */
+  protected $filepath;
+
+  /**
+   * @var \Grasmash\Expander\Expander
+   */
+  protected $expander;
+
+  /**
+   * @param string $path
+   */
+  public function __construct(string $path) {
+    $this->fileSystem = new Filesystem();
+    $this->filepath = $path;
+    $this->expander = new Expander();
+    $this->expander->setStringifier(new Stringifier());
+    $this->data = new Data();
+  }
+
+  /**
+   * @param string $key
+   * @param mixed $value
+   */
+  public function set(string $key, $value) {
+    $this->data->set($key, $value);
+    $this->dump();
+  }
+
+  /**
+   * @param string $key
+   * @param null $default
+   *
+   * @return array|mixed|null
+   */
+  public function get(string $key, $default = NULL) {
+    return $this->data->get($key);
+  }
+
+  /**
+   * @param string $key
+   */
+  public function remove(string $key) {
+    $this->data->remove($key);
+  }
+
+  /**
+   * @param string $key
+   *
+   * @return bool
+   */
+  public function exists(string $key) {
+    return $this->data->has($key);
+  }
+
+  /**
+   * @param array $config
+   * @param \Symfony\Component\Config\Definition\ConfigurationInterface $definition
+   *
+   * @return array
+   */
+  protected function processConfig(array $config, ConfigurationInterface $definition): array {
+    $processor = new Processor();
+    return $processor->processConfiguration(
+      $definition,
+      [$definition->getName() => $config],
+    );
+  }
+
+}

--- a/src/DataStore/Datastore.php
+++ b/src/DataStore/Datastore.php
@@ -68,6 +68,7 @@ abstract class Datastore implements DataStoreInterface {
    */
   public function remove(string $key) {
     $this->data->remove($key);
+    $this->dump();
   }
 
   /**
@@ -75,7 +76,7 @@ abstract class Datastore implements DataStoreInterface {
    *
    * @return bool
    */
-  public function exists(string $key) {
+  public function exists(string $key): bool {
     return $this->data->has($key);
   }
 

--- a/src/DataStore/JsonDataStore.php
+++ b/src/DataStore/JsonDataStore.php
@@ -2,19 +2,14 @@
 
 namespace Acquia\Cli\DataStore;
 
-use Dflydev\DotAccessData\Data;
-use Grasmash\Expander\Expander;
-use Grasmash\Expander\Stringifier;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Class YamlStore
+ *
  * @package Acquia\Cli\DataStore
  */
-class YamlStore extends Datastore {
+class JsonDataStore extends Datastore implements DataStoreInterface {
 
   /**
    * Creates a new store.
@@ -25,7 +20,7 @@ class YamlStore extends Datastore {
   public function __construct(string $path, ConfigurationInterface $config_definition = NULL) {
     parent::__construct($path);
     if ($this->fileSystem->exists($path)) {
-      $array = Yaml::parseFile($path);
+      $array = json_decode(file_get_contents($path), TRUE);
       $array = $this->expander->expandArrayProperties($array);
       if ($config_definition) {
         $array = $this->processConfig($array, $config_definition);
@@ -38,7 +33,6 @@ class YamlStore extends Datastore {
    *
    */
   public function dump() {
-    $this->fileSystem->dumpFile($this->filepath, Yaml::dump($this->data->export()));
+    $this->fileSystem->dumpFile($this->filepath, json_encode($this->data->export(), JSON_PRETTY_PRINT));
   }
-
 }

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -4,14 +4,14 @@ namespace Acquia\Cli\Helpers;
 
 use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\Command\CommandBase;
-use Acquia\Cli\DataStore\YamlStore;
+use Acquia\Cli\DataStore\AcquiaCliDatastore;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Endpoints\Account;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use loophp\phposinfo\OsInfo;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Webmozart\KeyValueStore\JsonFileStore;
 use Zumba\Amplitude\Amplitude;
 
 class TelemetryHelper {
@@ -37,7 +37,7 @@ class TelemetryHelper {
   private $cloudApiClientService;
 
   /**
-   * @var \Webmozart\KeyValueStore\JsonFileStore
+   * @var \Acquia\Cli\DataStore\CloudDataStore
    */
   private $datastoreCloud;
 
@@ -47,15 +47,15 @@ class TelemetryHelper {
    * @param \Symfony\Component\Console\Input\InputInterface $input
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    * @param \Acquia\Cli\CloudApi\ClientService $client_service
-   * @param \Acquia\Cli\DataStore\YamlStore $datastoreAcli
-   * @param \Webmozart\KeyValueStore\JsonFileStore $datastoreCloud
+   * @param \Acquia\Cli\DataStore\AcquiaCliDatastore $datastoreAcli
+   * @param \Acquia\Cli\DataStore\CloudDataStore $datastoreCloud
    */
   public function __construct(
     InputInterface $input,
     OutputInterface $output,
     ClientService $client_service,
-    YamlStore $datastoreAcli,
-    JsonFileStore $datastoreCloud
+    AcquiaCliDatastore $datastoreAcli,
+    CloudDataStore $datastoreCloud
   ) {
     $this->input = $input;
     $this->output = $output;

--- a/symfony.lock
+++ b/symfony.lock
@@ -83,9 +83,6 @@
     "http-interop/http-factory-guzzle": {
         "version": "1.2.0"
     },
-    "justinrainbow/json-schema": {
-        "version": "1.6.1"
-    },
     "kevinrob/guzzle-cache-middleware": {
         "version": "v3.5.0"
     },
@@ -501,12 +498,6 @@
     },
     "webmozart/assert": {
         "version": "1.10.0"
-    },
-    "webmozart/json": {
-        "version": "1.2.2"
-    },
-    "webmozart/key-value-store": {
-        "version": "1.0.0"
     },
     "webmozart/path-util": {
         "version": "2.3.0"

--- a/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
+++ b/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
@@ -5,8 +5,9 @@ namespace Acquia\Cli\Tests\AcsfApi;
 use Acquia\Cli\AcsfApi\AcsfClientService;
 use Acquia\Cli\AcsfApi\AcsfConnectorFactory;
 use Acquia\Cli\Application;
+use Acquia\Cli\Config\CloudDataConfig;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Tests\TestBase;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Class CloudServiceTest.
@@ -41,7 +42,7 @@ class AcsfServiceTest extends TestBase {
   public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated) {
     self::setEnvVars($env_vars);
     $client_service = new AcsfClientService(new AcsfConnectorFactory(['key' => NULL, 'secret' => NULL]), $this->prophet->prophesize(Application::class)->reveal());
-    $cloud_datastore = $this->prophet->prophesize(JsonFileStore::class);
+    $cloud_datastore = $this->prophet->prophesize(CloudDataStore::class);
     $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated($cloud_datastore->reveal()));
     self::unsetEnvVars($env_vars);
   }

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\Tests\Application;
 
 use Acquia\Cli\Application;
 use Acquia\Cli\CloudApi\ClientService;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Kernel;
 use Acquia\Cli\Tests\TestBase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -35,7 +36,7 @@ class ExceptionApplicationTest extends TestBase {
     $this->fs->remove('var/cache');
     $this->kernel = new Kernel('dev', 0);
     $this->kernel->boot();
-    $this->kernel->getContainer()->set('datastore.cloud', $this->datastoreCloud);
+    $this->kernel->getContainer()->set(CloudDataStore::class, $this->datastoreCloud);
     $this->kernel->getContainer()->set(ClientService::class, $this->clientServiceProphecy->reveal());
     $output = new BufferedOutput();
     $this->kernel->getContainer()->set(OutputInterface::class, $output);

--- a/tests/phpunit/src/CloudApi/CloudServiceTest.php
+++ b/tests/phpunit/src/CloudApi/CloudServiceTest.php
@@ -5,8 +5,9 @@ namespace Acquia\Cli\Tests\CloudApi;
 use Acquia\Cli\Application;
 use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\CloudApi\ConnectorFactory;
+use Acquia\Cli\Config\CloudDataConfig;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Tests\TestBase;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Class CloudServiceTest.
@@ -41,7 +42,7 @@ class CloudServiceTest extends TestBase {
   public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated) {
     self::setEnvVars($env_vars);
     $client_service = new ClientService(new ConnectorFactory(['key' => NULL, 'secret' => NULL, 'accessToken' => NULL]), $this->prophet->prophesize(Application::class)->reveal());
-    $cloud_datastore = $this->prophet->prophesize(JsonFileStore::class);
+    $cloud_datastore = $this->prophet->prophesize(CloudDataStore::class);
     $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated($cloud_datastore->reveal()));
     self::unsetEnvVars($env_vars);
   }

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -458,13 +458,12 @@ abstract class CommandTestBase extends TestBase {
    * @return \Acquia\Cli\Command\Api\ApiCommandFactory
    */
   protected function getCommandFactory(): CommandFactoryInterface {
-    return new ApiCommandFactory($this->cloudConfigFilepath,
+    return new ApiCommandFactory(
       $this->localMachineHelper,
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->cloudCredentials,
       $this->telemetryHelper,
-      $this->acliConfigFilename,
       $this->projectFixtureDir,
       $this->clientServiceProphecy->reveal(),
       $this->logStreamManagerProphecy->reveal(),

--- a/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
@@ -55,13 +55,12 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
   }
 
   protected function getCommandFactory(): CommandFactoryInterface {
-    return new AcsfCommandFactory($this->cloudConfigFilepath,
+    return new AcsfCommandFactory(
       $this->localMachineHelper,
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->cloudCredentials,
       $this->telemetryHelper,
-      $this->acliConfigFilename,
       $this->projectFixtureDir,
       $this->clientServiceProphecy->reveal(),
       $this->logStreamManagerProphecy->reveal(),

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
@@ -35,6 +35,8 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
         FALSE,
         // $inputs
         [
+          // Would you like to share anonymous performance usage and data? (yes/no) [yes]
+          'yes',
           // Enter the full URL of the factory
           $this->acsfCurrentFactoryUrl,
           // Please enter a value for username

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
@@ -35,8 +35,6 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
         FALSE,
         // $inputs
         [
-          // Would you like to share anonymous performance usage and data? (yes/no) [yes]
-          'yes',
           // Enter the full URL of the factory
           $this->acsfCurrentFactoryUrl,
           // Please enter a value for username
@@ -54,10 +52,7 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
         // $machine_is_authenticated
         FALSE,
         // $inputs
-        [
-          // Would you like to share anonymous performance usage and data? (yes/no) [yes]
-          'yes',
-        ],
+        [],
         // Arguments.
         [
           // Enter the full URL of the factory
@@ -102,9 +97,10 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
    * @param $inputs
    * @param $args
    * @param $output_to_assert
+   * @param array $config
    *
-   * @requires OS linux|darwin
    * @throws \Exception
+   * @requires OS linux|darwin
    */
   public function testAcsfAuthLoginCommand($machine_is_authenticated, $inputs, $args, $output_to_assert, $config = []): void {
     if (!$machine_is_authenticated) {
@@ -112,8 +108,11 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
       $this->removeMockCloudConfigFile();
     }
     else {
+      $this->removeMockCloudConfigFile();
       $this->createMockCloudConfigFile($config);
     }
+    $this->createDataStores();
+    $this->command = $this->createCommand();
 
     $this->executeCommand($args, $inputs);
     $output = $this->getDisplay();

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
@@ -153,6 +153,9 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
   public function testAcsfAuthLoginInvalidInputCommand($inputs, $args): void {
     $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
     $this->removeMockCloudConfigFile();
+    $this->createDataStores();
+    $this->command = $this->createCommand();
+
     try {
       $this->executeCommand($args, $inputs);
     }

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
@@ -180,7 +180,6 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
     $this->assertArrayHasKey($factory_url, $factories);
     $factory = $factories[$factory_url];
     $this->assertArrayHasKey('users', $factory);
-    //$this->assertArrayHasKey('url', $factory);
     $this->assertArrayHasKey('active_user', $factory);
     $this->assertEquals($this->acsfUsername, $factory['active_user']);
     $users = $factory['users'];

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
@@ -72,6 +72,8 @@ class AcsfAuthLogoutCommandTest extends AcsfCommandTestBase {
       $this->createMockCloudConfigFile($config);
     }
 
+    $this->createDataStores();
+    $this->command = $this->createCommand();
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
     // Assert creds are removed locally.

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
@@ -3,12 +3,11 @@
 namespace Acquia\Cli\Tests\Commands\Acsf;
 
 use Acquia\Cli\AcsfApi\AcsfCredentials;
-use Acquia\Cli\CloudApi\CloudCredentials;
 use Acquia\Cli\Command\Acsf\AcsfApiAuthLogoutCommand;
-use Acquia\Cli\Tests\CommandTestBase;
+use Acquia\Cli\Config\CloudDataConfig;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Class AcsfAuthLogoutCommandTest.
@@ -66,7 +65,7 @@ class AcsfAuthLogoutCommandTest extends AcsfCommandTestBase {
    */
   public function testAcsfAuthLogoutCommand(bool $machine_is_authenticated, array $inputs, array $config = []): void {
     if (!$machine_is_authenticated) {
-      $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(JsonFileStore::class))->willReturn(FALSE);
+      $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
     }
     else {
@@ -77,7 +76,7 @@ class AcsfAuthLogoutCommandTest extends AcsfCommandTestBase {
     $output = $this->getDisplay();
     // Assert creds are removed locally.
     $this->assertFileExists($this->cloudConfigFilepath);
-    $config = new JsonFileStore($this->cloudConfigFilepath, JsonFileStore::NO_SERIALIZE_STRINGS);
+    $config = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $this->cloudConfigFilepath);
     $this->assertFalse($config->exists('acli_key'));
     $this->assertNull($config->get('acsf_active_factory'));
   }

--- a/tests/phpunit/src/Commands/Acsf/AcsfListCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfListCommandTest.php
@@ -61,7 +61,7 @@ class AcsfListCommandTest extends CommandTestBase {
    * @throws \Exception
    */
   public function testListCommand(): void {
-    $this->command = $this->injectCommand(ListCommand::class);
+    $this->command = new ListCommand('list');
     $this->executeCommand();
     $output = $this->getDisplay();
     $this->assertStringContainsString('acsf:cron-jobs', $output);

--- a/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
@@ -60,7 +60,7 @@ class ApiListCommandTest extends CommandTestBase {
    * @throws \Exception
    */
   public function testListCommand(): void {
-    $this->command = $this->injectCommand(ListCommand::class);
+    $this->command = new ListCommand();
     $this->executeCommand();
     $output = $this->getDisplay();
     $this->assertStringContainsString(' api:accounts', $output);

--- a/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
@@ -119,6 +119,8 @@ class AuthLoginCommandTest extends CommandTestBase {
     if (!$machine_is_authenticated) {
       $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
+      $this->createDataStores();
+      $this->command = $this->createCommand();
     }
 
     $this->executeCommand($args, $inputs);
@@ -160,6 +162,8 @@ class AuthLoginCommandTest extends CommandTestBase {
   public function testAuthLoginInvalidInputCommand($inputs, $args): void {
     $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
     $this->removeMockCloudConfigFile();
+    $this->createDataStores();
+    $this->command = $this->createCommand();
     try {
       $this->executeCommand($args, $inputs);
     }
@@ -176,6 +180,8 @@ class AuthLoginCommandTest extends CommandTestBase {
       'secret' => 'test',
       DataStoreContract::SEND_TELEMETRY => FALSE,
     ]);
+    $this->createDataStores();
+    $this->command = $this->createCommand();
     $inputs = [
       // Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?
       'n',
@@ -205,7 +211,6 @@ class AuthLoginCommandTest extends CommandTestBase {
     $this->assertTrue($config->exists('keys'));
     $keys = $config->get('keys');
     $this->assertArrayHasKey($this->key, $keys);
-    $this->assertArrayHasKey('uuid', $keys[$this->key]);
     $this->assertArrayHasKey('label', $keys[$this->key]);
     $this->assertArrayHasKey('secret', $keys[$this->key]);
     $this->assertEquals($this->secret, $keys[$this->key]['secret']);

--- a/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
@@ -172,25 +172,6 @@ class AuthLoginCommandTest extends CommandTestBase {
     }
   }
 
-  public function testMigrateLegacyApiKey() {
-    $mock_body = $this->mockTokenRequest();
-    $this->removeMockCloudConfigFile();
-    $this->createMockCloudConfigFile([
-      'key' => $mock_body->uuid,
-      'secret' => 'test',
-      DataStoreContract::SEND_TELEMETRY => FALSE,
-    ]);
-    $this->createDataStores();
-    $this->command = $this->createCommand();
-    $inputs = [
-      // Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?
-      'n',
-    ];
-    $this->executeCommand([], $inputs);
-    $output = $this->getDisplay();
-    $this->assertStringContainsString('Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?', $output);
-  }
-
   /**
    * @param string $output
    */

--- a/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
@@ -3,10 +3,11 @@
 namespace Acquia\Cli\Tests\Commands\Auth;
 
 use Acquia\Cli\Command\Auth\AuthLogoutCommand;
+use Acquia\Cli\Config\CloudDataConfig;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Tests\CommandTestBase;
 use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Class AuthLogoutCommandTest.
@@ -46,7 +47,7 @@ class AuthLogoutCommandTest extends CommandTestBase {
    */
   public function testAuthLogoutCommand($machine_is_authenticated, $inputs): void {
     if (!$machine_is_authenticated) {
-      $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(JsonFileStore::class))->willReturn(FALSE);
+      $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
     }
 
@@ -54,7 +55,7 @@ class AuthLogoutCommandTest extends CommandTestBase {
     $output = $this->getDisplay();
     // Assert creds are removed locally.
     $this->assertFileExists($this->cloudConfigFilepath);
-    $config = new JsonFileStore($this->cloudConfigFilepath, JsonFileStore::NO_SERIALIZE_STRINGS);
+    $config = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $this->cloudConfigFilepath);
     $this->assertFalse($config->exists('acli_key'));
   }
 

--- a/tests/phpunit/src/Commands/CommandBaseTest.php
+++ b/tests/phpunit/src/Commands/CommandBaseTest.php
@@ -5,12 +5,12 @@ namespace Acquia\Cli\Tests\Commands;
 use Acquia\Cli\Command\App\LinkCommand;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ide\IdeListCommand;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Tests\CommandTestBase;
 use Exception;
 use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Validator\Exception\ValidatorException;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Class CommandBaseTest.
@@ -26,7 +26,7 @@ class CommandBaseTest extends CommandTestBase {
   }
 
   public function testUnauthenticatedFailure(): void {
-    $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(JsonFileStore::class))->willReturn(FALSE);
+    $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
     $this->removeMockConfigFiles();
 
     $inputs = [

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -79,6 +79,7 @@ class TelemetryCommandTest extends CommandTestBase {
     $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => NULL];
     $this->createMockConfigFiles();
     $this->createMockAcliConfigFile('a47ac10b-58cc-4372-a567-0e02b2c3d470');
+    $this->createDataStores();
     $this->mockApplicationRequest();
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -75,12 +75,12 @@ class TelemetryCommandTest extends CommandTestBase {
    * @throws \Psr\Cache\InvalidArgumentException
    */
   public function testTelemetryPrompt(array $inputs, $message): void {
-    $this->command = $this->injectCommand(LinkCommand::class);
     $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => NULL];
     $this->createMockConfigFiles();
     $this->createMockAcliConfigFile('a47ac10b-58cc-4372-a567-0e02b2c3d470');
     $this->createDataStores();
     $this->mockApplicationRequest();
+    $this->command = $this->injectCommand(LinkCommand::class);
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -3,12 +3,14 @@
 namespace Acquia\Cli\Tests;
 
 use Acquia\Cli\Application;
-use Acquia\Cli\CloudApi\AccessTokenConnector;
 use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\CloudApi\CloudCredentials;
 use Acquia\Cli\Command\ClearCacheCommand;
 use Acquia\Cli\Command\Ssh\SshKeyCommandBase;
-use Acquia\Cli\DataStore\YamlStore;
+use Acquia\Cli\Config\AcquiaCliConfig;
+use Acquia\Cli\Config\CloudDataConfig;
+use Acquia\Cli\DataStore\AcquiaCliDatastore;
+use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Helpers\DataStoreContract;
 use Acquia\Cli\Helpers\LocalMachineHelper;
 use Acquia\Cli\Helpers\SshHelper;
@@ -19,7 +21,6 @@ use AcquiaCloudApi\Response\IdeResponse;
 use AcquiaLogstream\LogstreamManager;
 use GuzzleHttp\Psr7\Response;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
-use PhpParser\Node\Arg;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -29,7 +30,6 @@ use Psr\Http\Message\StreamInterface;
 use React\EventLoop\Factory;
 use React\EventLoop\Loop;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Console\Command\Command;
@@ -43,7 +43,6 @@ use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
-use Webmozart\KeyValueStore\JsonFileStore;
 
 /**
  * Class CommandTestBase.
@@ -128,12 +127,12 @@ abstract class TestBase extends TestCase {
   protected $acliConfigFilepath;
 
   /**
-   * @var \Webmozart\KeyValueStore\JsonFileStore
+   * @var \Acquia\Cli\DataStore\AcquiaCliDatastore
    */
   protected $datastoreAcli;
 
   /**
-   * @var \Webmozart\KeyValueStore\JsonFileStore
+   * @var \Acquia\Cli\DataStore\CloudDataStore
    */
   protected $datastoreCloud;
 
@@ -199,6 +198,9 @@ abstract class TestBase extends TestCase {
     $this->fs = new Filesystem();
     $this->prophet = new Prophet();
     $this->consoleOutput = new ConsoleOutput();
+    $this->setClientProphecies();
+    $this->setIo($input, $output);
+
     $this->fixtureDir = realpath(__DIR__ . '/../../fixtures');
     $this->projectFixtureDir = $this->fixtureDir . '/project';
     $this->acliRepoRoot = $this->projectFixtureDir;
@@ -207,16 +209,12 @@ abstract class TestBase extends TestCase {
     $this->acliConfigFilename = '.acquia-cli.yml';
     $this->cloudConfigFilepath = $this->dataDir . '/cloud_api.conf';
     $this->acliConfigFilepath = $this->projectFixtureDir . '/' . $this->acliConfigFilename;
-    $this->datastoreAcli = new YamlStore($this->acliConfigFilepath);
-    $this->datastoreCloud = new JsonFileStore($this->cloudConfigFilepath, 1);
-    $this->cloudCredentials = new CloudCredentials($this->datastoreCloud);
-    $this->setClientProphecies();
-    $this->logStreamManagerProphecy = $this->prophet->prophesize(LogstreamManager::class);
-
-    $this->setIo($input, $output);
-
     $this->removeMockConfigFiles();
     $this->createMockConfigFiles();
+    $this->createDataStores();
+    $this->cloudCredentials = new CloudCredentials($this->datastoreCloud);
+    $this->telemetryHelper = new TelemetryHelper($input, $output, $this->clientServiceProphecy->reveal(), $this->datastoreAcli, $this->datastoreCloud);
+    $this->logStreamManagerProphecy = $this->prophet->prophesize(LogstreamManager::class);
     ClearCacheCommand::clearCaches();
 
     parent::setUp();
@@ -250,7 +248,6 @@ abstract class TestBase extends TestCase {
     $this->localMachineHelper = new LocalMachineHelper($input, $output, $this->logger);
     // TTY should never be used for tests.
     $this->localMachineHelper->setIsTty(FALSE);
-    $this->telemetryHelper = new TelemetryHelper($input, $output, $this->clientServiceProphecy->reveal(), $this->datastoreAcli, $this->datastoreCloud);
     $this->sshHelper = new SshHelper($output, $this->localMachineHelper, $this->logger);
   }
 
@@ -329,13 +326,11 @@ abstract class TestBase extends TestCase {
    */
   protected function injectCommand(string $commandName): Command {
     return new $commandName(
-      $this->cloudConfigFilepath,
       $this->localMachineHelper,
       $this->datastoreCloud,
       $this->datastoreAcli,
       $this->cloudCredentials,
       $this->telemetryHelper,
-      $this->acliConfigFilename,
       $this->acliRepoRoot,
       $this->clientServiceProphecy->reveal(),
       $this->logStreamManagerProphecy->reveal(),
@@ -880,8 +875,13 @@ abstract class TestBase extends TestCase {
     $this->clientServiceProphecy = $this->prophet->prophesize($client_service_class);
     $this->clientServiceProphecy->getClient()
       ->willReturn($this->clientProphecy->reveal());
-    $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(JsonFileStore::class))
+    $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))
       ->willReturn(TRUE);
+  }
+
+  protected function createDataStores(): void {
+    $this->datastoreAcli = new AcquiaCliDatastore($this->localMachineHelper, new AcquiaCliConfig(), $this->acliConfigFilepath);
+    $this->datastoreCloud = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $this->cloudConfigFilepath);
   }
 
 }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Enables https://github.com/acquia/cli/issues/782

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
* Remove all implementations of webmozart/key-value-store
* Add our own datastore classes for `cloud_api.conf` and `.acquia-cli.yml`
* Add validation to datastore classes

There is a notable internal change here. Prior to this, values from the datastore would not be loaded until requested. We were not really injecting configuration into any services, we were injecting a datastore and lazy loading values. 

Now, we load the configuration up front and inject it as a dependency into other services. 

This change required various changes to testing so that configuration is set and loaded earlier.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
* Upgrading webmozart ourselves

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Nothing should appear to have changed!
4. Run `acli login`
5. Run `acli link`
6. Run `acli logout`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
