### PR TITLE
Allow for 0-index when determining cloud database name

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -694,7 +694,8 @@ abstract class PullCommandBase extends CommandBase {
           $site = self::getSiteGroupFromSshUrl($chosen_environment->sshUrl);
         }
         $database_names = array_column($databases, 'name');
-        if ($database_key = array_search($site, $database_names)) {
+        $database_key = array_search($site, $database_names);
+        if ($database_key !== FALSE) {
           return [$databases[$database_key]];
         }
       }


### PR DESCRIPTION
**Motivation**
`acli pull:database` takes an optional `site` parameter that is supposed to select the named Cloud database that you want to pull from. However, I found this was not working for some databases I tried to pull, and it instead prompted me to select a database.

**Proposed changes**
array_search() could return 0 if the matching result is the first array item, or FALSE if there was no match. Hence, we need to do a non-identical comparison.

**Testing steps**
`acli pull:database sitename.env dbname1`

Expected behavior: `acli` will proceed to pull from the Cloud database named `dbname1`.

Actual behavior: If dbname1 happens to be the first item in the response from `/environments/UUID/databases`, you'll be prompted:

```
Choose a database [sitename (default)]:
  [0] dbname1
  [1] dbname2
  [2] sitename (default)
```