### PR TITLE
Autolabel pull requests from Violinist

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,8 +11,8 @@ categories:
     label: 'chore'
 autolabeler:
   - label: 'chore'
-    branch:
-      - '/violinist\/.+/'
+    body:
+      - '/This is an automated pull request from \[Violinist\]/'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,9 +6,7 @@ on:
       - master
 
   pull_request:
-    types: [opened, reopened, synchronize]
   pull_request_target:
-    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
See https://github.com/acquia/cli/runs/6210108729?check_suite_focus=true

```
Run release-drafter/release-drafter@v5
  with:
    config-name: release-drafter.yml
  env:
    GITHUB_TOKEN: ***
"pull_request_target.opened" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)
"pull_request_target.reopened" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)
"pull_request_target.synchronize" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)
"pull_request_target.edited" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)
acquia/cli: Found 6[2](https://github.com/acquia/cli/runs/6210108729?check_suite_focus=true#step:2:2) releases
{ name: 'event', id: '22[3](https://github.com/acquia/cli/runs/6210108729?check_suite_focus=true#step:2:3)901[4](https://github.com/acquia/cli/runs/6210108729?check_suite_focus=true#step:2:4)196' }
acquia/cli: Draft release: 1.30.1
{ name: 'event', id: '2239014196' }
acquia/cli: Last release: 1.30.0
{ name: 'event', id: '2239014196' }
acquia/cli: Fetching parent commits of refs/heads/master since 2022-04-14T11:[5](https://github.com/acquia/cli/runs/6210108729?check_suite_focus=true#step:2:5)5:29Z
{ name: 'event', id: '223901419[6](https://github.com/acquia/cli/runs/6210108729?check_suite_focus=true#step:2:6)' }
acquia/cli: Updating existing release
{ name: 'event', id: '223[9](https://github.com/acquia/cli/runs/6210108729?check_suite_focus=true#step:2:9)0[14](https://github.com/acquia/cli/runs/6210108729?check_suite_focus=true#step:2:14)[19](https://github.com/acquia/cli/runs/6210108729?check_suite_focus=true#step:2:19)6' }
```