### PR TITLE
Kill escaped mutants

### DIFF
--- a/src/AcsfApi/AcsfClientService.php
+++ b/src/AcsfApi/AcsfClientService.php
@@ -42,6 +42,7 @@ class AcsfClientService extends ClientService {
 
     if (getenv('ACSF_USERNAME') && getenv('ACSF_PASSWORD') ) {
       $this->machineIsAuthenticated = TRUE;
+
       return $this->machineIsAuthenticated;
     }
 
@@ -55,4 +56,5 @@ class AcsfClientService extends ClientService {
     $this->machineIsAuthenticated = FALSE;
     return $this->machineIsAuthenticated;
   }
+
 }

--- a/src/AcsfApi/AcsfClientService.php
+++ b/src/AcsfApi/AcsfClientService.php
@@ -13,14 +13,6 @@ use AcquiaCloudApi\Connector\Client;
 class AcsfClientService extends ClientService {
 
   /**
-   * @param \Acquia\Cli\AcsfApi\AcsfConnectorFactory $connector_factory
-   * @param \Acquia\Cli\Application $application
-   */
-  public function __construct(AcsfConnectorFactory $connector_factory, Application $application) {
-    parent::__construct($connector_factory, $application);
-  }
-
-  /**
    * @return \AcquiaCloudApi\Connector\Client
    */
   public function getClient(): Client {
@@ -42,7 +34,6 @@ class AcsfClientService extends ClientService {
 
     if (getenv('ACSF_USERNAME') && getenv('ACSF_PASSWORD') ) {
       $this->machineIsAuthenticated = TRUE;
-
       return $this->machineIsAuthenticated;
     }
 

--- a/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
+++ b/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
@@ -31,6 +31,10 @@ class AcsfServiceTest extends TestBase {
         ['ACSF_USERNAME' => NULL, 'ACSF_PASSWORD' => NULL],
         FALSE,
       ],
+      [
+        ['ACSF_USERNAME' => 'key', 'ACSF_PASSWORD' => NULL],
+        FALSE,
+      ],
     ];
   }
 
@@ -46,4 +50,5 @@ class AcsfServiceTest extends TestBase {
     $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated($cloud_datastore->reveal()));
     self::unsetEnvVars($env_vars);
   }
+
 }


### PR DESCRIPTION
Just trying my hand at this... finding mutants turns out to be a lot easier than killing them 😄 

To verify this is helping:

- Observe escaped mutants like this one in prior test runs: https://github.com/acquia/cli/runs/6231672360?check_suite_focus=true#step:6:85
- Observe that this mutant no longer exists on this PR: https://github.com/acquia/cli/runs/6233376232?check_suite_focus=true#step:6:34

You can also run mutation tests locally and compare before and after: `composer infection-install && ./build/infection.phar --filter=AcsfClientService.php -j2 --only-covered`