### PR TITLE
Use pcov instead of xdebug for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - os: "ubuntu-latest"
             php: "8.1"
-            coverage: "xdebug"
+            coverage: "pcov"
     steps:
       - name: Prepare Git
         # Windows corrupts line endings on checkout, causing test failures.
@@ -47,10 +47,10 @@ jobs:
           composer validate --no-check-all --ansi
           composer test
       - name: Run coverage
-        if: matrix.coverage == 'xdebug'
+        if: matrix.coverage == 'pcov'
         run: composer coverage
       - name: Upload coverage results to Coveralls
-        if: matrix.coverage == 'xdebug'
+        if: matrix.coverage == 'pcov'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: composer coveralls

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           php-version: 8.0
           tools: composer:v2
-          extensions: pcov
           coverage: pcov
 
       - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,7 @@
             "curl -f -L https://github.com/infection/infection/releases/download/0.26.0/infection.phar -o build/infection.phar"
         ],
         "infection": [
-            "XDEBUG_MODE=coverage php build/infection.phar --threads=8"
+            "php -d pcov.enabled=1 build/infection.phar --threads=8"
         ],
         "cs": "phpcs",
         "cbf": "phpcbf",

--- a/composer.json
+++ b/composer.json
@@ -186,7 +186,7 @@
         "cs": "phpcs",
         "cbf": "phpcbf",
         "unit": "phpunit tests/phpunit -vvv",
-        "coverage": "XDEBUG_MODE=coverage phpunit tests/phpunit --coverage-clover build/logs/clover.xml",
+        "coverage": "php -d pcov.enabled=1 vendor/bin/phpunit tests/phpunit --coverage-clover build/logs/clover.xml",
         "lint": "phplint",
         "test": [
             "@lint",


### PR DESCRIPTION
It's twice as fast! Compare 2 m ([last run with Xdebug](https://github.com/acquia/cli/runs/6233376495?check_suite_focus=true)) to 1 m ([this run with pcov](https://github.com/danepowell/cli/runs/6235229772?check_suite_focus=true))