### PR TITLE
Fix Stryker reporting

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -29,7 +29,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          php build/infection.phar -j2 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --only-covered
+          php build/infection.phar -j1 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --only-covered
 
       - name: Run Infection for all files
         if: github.event_name == 'push'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -25,13 +25,7 @@ jobs:
       - name: Download Infection
         run: composer infection-install
 
-      - name: Run Infection for added files only
+      - name: Run Infection for all files
         if: github.event_name == 'pull_request'
         run: |
-          git fetch --depth=1 origin $GITHUB_BASE_REF
-          php build/infection.phar -j1 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --only-covered
-
-      - name: Run Infection for all files
-        if: github.event_name == 'push'
-        run: |
-          php build/infection.phar -j2 --only-covered
+          php build/infection.phar -j1 --only-covered

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Run Infection for all files
         if: github.event_name == 'pull_request'
         run: |
-          php build/infection.phar -j2 --only-covered
+          php build/infection.phar -j4 --only-covered

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Run Infection for all files
         if: github.event_name == 'pull_request'
         run: |
-          php build/infection.phar -j8 --only-covered
+          php build/infection.phar -j16 --only-covered

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Run Infection for all files
         if: github.event_name == 'pull_request'
         run: |
-          php build/infection.phar -j4 --only-covered
+          php build/infection.phar -j8 --only-covered

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -25,7 +25,15 @@ jobs:
       - name: Download Infection
         run: composer infection-install
 
-      - name: Run Infection for all files
+      - name: Run Infection for added files only
         if: github.event_name == 'pull_request'
         run: |
-          php build/infection.phar -j16 --only-covered
+          git fetch --depth=1 origin $GITHUB_BASE_REF
+          php build/infection.phar -j8 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --only-covered
+
+      - name: Run Infection for all files
+        if: github.event_name == 'push'
+        env:
+          INFECTION_DASHBOARD_API_KEY: ${{ secrets.INFECTION_DASHBOARD_API_KEY }}
+        run: |
+          php build/infection.phar -j8 --only-covered

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Run Infection for all files
         if: github.event_name == 'pull_request'
         run: |
-          php build/infection.phar -j1 --only-covered
+          php build/infection.phar -j2 --only-covered


### PR DESCRIPTION
Nowhere is it documented how many threads are available on GitHub Actions runners, but experimentation shows 8 threads to be fastest. We also need to inject INFECTION_DASHBOARD_API_KEY to get that sweet sweet badge working.