### PR TITLE
CLI-657: Improve SSH key polling and permission checks

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -29,6 +29,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
+          # Explicitly specify GitHub logger since our Stryker reporting will otherwise disable it.
           php build/infection.phar -j8 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --only-covered
 
       - name: Run Infection for all files

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -29,8 +29,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          # Explicitly specify GitHub logger since our Stryker reporting will otherwise disable it.
-          php build/infection.phar -j8 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --only-covered
+          php build/infection.phar -j8 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --only-covered
 
       - name: Run Infection for all files
         if: github.event_name == 'push'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -29,7 +29,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          php build/infection.phar -j8 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --only-covered
+          php build/infection.phar -j8 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --only-covered
 
       - name: Run Infection for all files
         if: github.event_name == 'push'

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1648,7 +1648,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   /**
-   * Get the first environment for a given Cloud application.
+   * Get the first non-prod environment for a given Cloud application.
    *
    * @param string $cloud_app_uuid
    *
@@ -1666,6 +1666,43 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       }
     }
     return NULL;
+  }
+
+  /**
+   * Get the first prod environment for a given Cloud application.
+   *
+   * @param string $cloud_app_uuid
+   *
+   * @return \AcquiaCloudApi\Response\EnvironmentResponse|null
+   * @throws \Exception
+   */
+  protected function getAnyProdAhEnvironment(string $cloud_app_uuid): ?EnvironmentResponse {
+    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    $environment_resource = new Environments($acquia_cloud_client);
+    /** @var EnvironmentResponse[] $application_environments */
+    $application_environments = iterator_to_array($environment_resource->getAll($cloud_app_uuid));
+    foreach ($application_environments as $environment) {
+      if ($environment->flags->production) {
+        return $environment;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Get the first VCS URL for a given Cloud application.
+   *
+   * @param string $cloud_app_uuid
+   *
+   * @return \AcquiaCloudApi\Response\EnvironmentResponse|null
+   * @throws \Exception
+   */
+  protected function getAnyVcsUrl(string $cloud_app_uuid): string {
+    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    $environment_resource = new Environments($acquia_cloud_client);
+    /** @var EnvironmentResponse[] $application_environments */
+    $application_environments = iterator_to_array($environment_resource->getAll($cloud_app_uuid));
+    return reset($application_environments)->vcs->url;
   }
 
   /**

--- a/src/Command/Ide/Wizard/IdeWizardCommandBase.php
+++ b/src/Command/Ide/Wizard/IdeWizardCommandBase.php
@@ -71,9 +71,9 @@ abstract class IdeWizardCommandBase extends WizardCommandBase {
   /**
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function deleteThisSshKeyFromCloud(): void {
+  protected function deleteThisSshKeyFromCloud($output): void {
     if ($cloud_key = $this->findIdeSshKeyOnCloud($this::getThisCloudIdeUuid())) {
-      $this->deleteSshKeyFromCloud($cloud_key);
+      $this->deleteSshKeyFromCloud($output, $cloud_key);
     }
   }
 

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -45,7 +45,7 @@ class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
       // Just in case the public key exists and the private doesn't, remove the public key.
       $this->deleteLocalSshKey();
       // Just in case there's an orphaned key on the Cloud Platform for this Cloud IDE.
-      $this->deleteThisSshKeyFromCloud();
+      $this->deleteThisSshKeyFromCloud($output);
 
       $this->checklist->addItem('Creating a local SSH key');
 
@@ -68,7 +68,7 @@ class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
 
       // Just in case there is an uploaded key,  but it doesn't actually match
       // the local key, delete remote key!
-      $this->deleteThisSshKeyFromCloud();
+      $this->deleteThisSshKeyFromCloud($output);
       $public_key = $this->localMachineHelper->readFile($this->publicSshKeyFilepath);
       $chosen_local_key = basename($this->publicSshKeyFilepath);
       $this->uploadSshKey($this->getSshKeyLabel(), $chosen_local_key, $public_key);

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -172,9 +172,7 @@ class PushArtifactCommand extends PullCommandBase {
       return $this->datastoreAcli->get('push.artifact.destination-git-urls');
     }
 
-    $environment = $this->getAnyNonProdAhEnvironment($application_uuid);
-    $destination_git_url = $environment->vcs->url;
-    return [$destination_git_url];
+    return [$this->getAnyVcsUrl($application_uuid)];
   }
 
   /**

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -171,7 +171,7 @@ EOT
     }
     else {
       $poll_nonprod = FALSE;
-      $output->writeln('<comment>You do not have access to Cloud Platform non-prod environments on this application and will not be able to clone your non-prod sites to this IDE. Check that you have the <options=bold>add ssh key to non-prod environments</> permission. Documentation on Cloud Teams permissions: <href=https://docs.acquia.com/cloud-platform/access/teams/permissions/default/>https://docs.acquia.com/cloud-platform/access/teams/permissions/default/</>');
+      $output->writeln('<comment>You do not have access to Cloud Platform <options=bold>non-prod</> environments on this application and will not be able to clone your non-prod sites to this IDE. Check that you have the <options=bold>add ssh key to non-prod environments</> permission. Documentation on Cloud Teams permissions: <href=https://docs.acquia.com/cloud-platform/access/teams/permissions/default/>https://docs.acquia.com/cloud-platform/access/teams/permissions/default/</>');
     }
     if (in_array('add ssh key to prod', $perms, TRUE)) {
       $poll_prod = TRUE;
@@ -179,7 +179,7 @@ EOT
     }
     else {
       $poll_prod = FALSE;
-      $output->writeln('<comment>You do not have access to Cloud Platform prod environments on this application and will not be able to clone your prod sites to this IDE. Check that you have the <options=bold>add ssh key to prod environments</> permission. Documentation on Cloud Teams permissions: <href=https://docs.acquia.com/cloud-platform/access/teams/permissions/default/>https://docs.acquia.com/cloud-platform/access/teams/permissions/default/</>');
+      $output->writeln('<comment>You do not have access to Cloud Platform <options=bold>prod</> environments on this application and will not be able to clone your prod sites to this IDE. Check that you have the <options=bold>add ssh key to prod environments</> permission. Documentation on Cloud Teams permissions: <href=https://docs.acquia.com/cloud-platform/access/teams/permissions/default/>https://docs.acquia.com/cloud-platform/access/teams/permissions/default/</>');
     }
 
     // Poll Cloud every 5 seconds.

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -6,9 +6,6 @@ use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\LoopHelper;
 use Acquia\Cli\Helpers\SshCommandTrait;
-use AcquiaCloudApi\Endpoints\Applications;
-use AcquiaCloudApi\Endpoints\Environments;
-use AcquiaCloudApi\Response\EnvironmentResponse;
 use AcquiaCloudApi\Response\IdeResponse;
 use Closure;
 use React\EventLoop\Loop;
@@ -149,22 +146,59 @@ EOT
   protected function pollAcquiaCloudUntilSshSuccess(
     OutputInterface $output
   ): void {
+    $cloud_app_uuid = $this->determineCloudApplication(TRUE);
+    $permissions = $this->cloudApiClientService->getClient()->request('get', "/applications/{$cloud_app_uuid}/permissions");
+    $perms = array_column($permissions, 'name');
+
+    if (in_array('add ssh key to git', $perms, TRUE)) {
+      $full_url = $this->getAnyVcsUrl($cloud_app_uuid);
+      $url_parts = explode(':', $full_url);
+      $vcs_url = $url_parts[0];
+      $this->pollSshTarget($output, 'git', function () use ($vcs_url) {
+        $process = $this->sshHelper->executeCommandUrl($vcs_url, ['ls'], FALSE);
+        // Interactive Git shell is disabled, the best we can hope for is a 128 exit code.
+        return [$process, $process->getExitCode() === 128];
+      });
+    }
+    else {
+      $output->writeln('<comment>You do not have access to Cloud Platform git on this application and will not be able to clone your codebase to this IDE. Check that you have the <options=bold>add ssh key to git</> permission. Documentation on Cloud Teams permissions: <href=https://docs.acquia.com/cloud-platform/access/teams/permissions/default/>https://docs.acquia.com/cloud-platform/access/teams/permissions/default/</>');
+    }
+
+    if (in_array('add ssh key to non-prod', $perms, TRUE)) {
+      $environment = $this->getAnyNonProdAhEnvironment($cloud_app_uuid);
+      $this->pollSshTarget($output, 'non-prod environments', function () use ($environment) {
+        $process = $this->sshHelper->executeCommand($environment, ['ls'], FALSE);
+        return [$process, $process->isSuccessful()];
+      });
+    }
+    else {
+      $output->writeln('<comment>You do not have access to Cloud Platform non-prod environments on this application and will not be able to clone your non-prod sites to this IDE. Check that you have the <options=bold>add ssh key to non-prod environments</> permission. Documentation on Cloud Teams permissions: <href=https://docs.acquia.com/cloud-platform/access/teams/permissions/default/>https://docs.acquia.com/cloud-platform/access/teams/permissions/default/</>');
+    }
+
+    if (in_array('add ssh key to prod', $perms, TRUE)) {
+      $environment = $this->getAnyProdAhEnvironment($cloud_app_uuid);
+      $this->pollSshTarget($output, 'prod environments', function () use ($environment) {
+        $process = $this->sshHelper->executeCommand($environment, ['ls'], FALSE);
+        return [$process, $process->isSuccessful()];
+      });
+    }
+    else {
+      $output->writeln('<comment>You do not have access to Cloud Platform prod environments on this application and will not be able to clone your prod sites to this IDE. Check that you have the <options=bold>add ssh key to prod environments</> permission. Documentation on Cloud Teams permissions: <href=https://docs.acquia.com/cloud-platform/access/teams/permissions/default/>https://docs.acquia.com/cloud-platform/access/teams/permissions/default/</>');
+    }
+  }
+
+  protected function pollSshTarget(OutputInterface $output, $target_name, $callback): void {
     // Create a loop to periodically poll the Cloud Platform.
     $loop = Loop::get();
-    $spinner = LoopHelper::addSpinnerToLoop($loop, 'Waiting for the key to become available on the Cloud Platform', $output);
-
-    // Wait for SSH key to be available on a web.
-    $cloud_app_uuid = $this->determineCloudApplication(TRUE);
-    $environment = $this->getAnyNonProdAhEnvironment($cloud_app_uuid);
+    $spinner = LoopHelper::addSpinnerToLoop($loop, 'Waiting for the key to become available in Cloud Platform ' . $target_name, $output);
 
     // Poll Cloud every 5 seconds.
-    $loop->addPeriodicTimer(5, function () use ($output, $loop, $environment, $spinner) {
+    $loop->addPeriodicTimer(5, function () use ($loop, $callback, $spinner) {
       try {
-        $process = $this->sshHelper->executeCommand($environment, ['ls'], FALSE);
-        if ($process->isSuccessful()) {
+        [$process, $is_successful] = $callback();
+        if ($is_successful) {
           LoopHelper::finishSpinner($spinner);
           $loop->stop();
-          $output->writeln("\n<info>Your SSH key is ready for use!</info>\n");
         }
         else {
           $this->logger->debug($process->getOutput() . $process->getErrorOutput());

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -434,7 +434,7 @@ abstract class CommandTestBase extends TestBase {
     $ssh_helper = $this->mockSshHelper();
     // Mock Git.
     $url_parts = explode(':', $environments_response->_embedded->items[0]->vcs->url);
-    $ssh_helper->executeCommandUrl($url_parts[0], ['ls'], FALSE)
+    $ssh_helper->executeCommand($url_parts[0], ['ls'], FALSE)
       ->willReturn($gitProcess->reveal())
       ->shouldBeCalled();
     // Mock non-prod.
@@ -458,7 +458,7 @@ abstract class CommandTestBase extends TestBase {
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(128);
     $ssh_helper = $this->mockSshHelper();
-    $ssh_helper->executeCommandUrl($environment_response->vcs->url, ['ls'], FALSE)
+    $ssh_helper->executeCommand($environment_response->vcs->url, ['ls'], FALSE)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
     return $ssh_helper;

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
@@ -26,10 +26,14 @@ class IdeWizardCreateSshKeyCommandTest extends IdeWizardTestBase {
 
   protected $ide;
 
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
   public function setUp($output = NULL): void {
     parent::setUp($output);
-    $this->mockApplicationRequest();
+    $application_response = $this->mockApplicationRequest();
     $this->mockListSshKeysRequest();
+    $this->mockPermissionsRequest($application_response);
     $this->ide = $this->mockIdeRequest();
     $this->sshKeyFileName = IdeWizardCreateSshKeyCommand::getSshKeyFilename(IdeRequiredTestTrait::$remote_ide_uuid);
   }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -93,7 +93,6 @@ class SshKeyUploadCommandTest extends CommandTestBase
     /** @var Filesystem|\Prophecy\Prophecy\ObjectProphecy $file_system */
     $file_system = $this->prophet->prophesize(Filesystem::class);
     $file_name = $this->mockGetLocalSshKey($local_machine_helper, $file_system, $this->sshKeysRequestBody['public_key']);
-    $this->mockEnvironmentsRequest($applications_response);
 
     $local_machine_helper->getFilesystem()->willReturn($file_system);
     $file_system->exists(Argument::type('string'))->willReturn(TRUE);
@@ -103,7 +102,7 @@ class SshKeyUploadCommandTest extends CommandTestBase
     $this->command->localMachineHelper = $local_machine_helper->reveal();
 
     if ($perms) {
-      $environments_response = $this->getMockEnvironmentsResponse();
+      $environments_response = $this->mockEnvironmentsRequest($applications_response);
       $ssh_helper = $this->mockPollCloudViaSsh($environments_response);
       $this->command->sshHelper = $ssh_helper->reveal();
     }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -82,7 +82,8 @@ class SshKeyUploadCommandTest extends CommandTestBase
     $this->mockUploadSshKey();
     $this->mockListSshKeyRequestWithUploadedKey($this->sshKeysRequestBody);
     $applications_response = $this->mockApplicationsRequest();
-    $this->mockApplicationRequest();
+    $application_response = $this->mockApplicationRequest();
+    $this->mockPermissionsRequest($application_response);
 
     $local_machine_helper = $this->mockLocalMachineHelper();
     /** @var Filesystem|\Prophecy\Prophecy\ObjectProphecy $file_system */
@@ -98,7 +99,7 @@ class SshKeyUploadCommandTest extends CommandTestBase
     $this->command->localMachineHelper = $local_machine_helper->reveal();
 
     $environments_response = $this->getMockEnvironmentsResponse();
-    $ssh_helper = $this->mockPollCloudViaSsh($environments_response->_embedded->items[0]);
+    $ssh_helper = $this->mockPollCloudViaSsh($environments_response);
     $this->command->sshHelper = $ssh_helper->reveal();
 
     // Choose a local SSH key to upload to the Cloud Platform.

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -102,8 +102,8 @@ class SshKeyUploadCommandTest extends CommandTestBase
 
     $this->command->localMachineHelper = $local_machine_helper->reveal();
 
-    $environments_response = $this->getMockEnvironmentsResponse();
     if ($perms) {
+      $environments_response = $this->getMockEnvironmentsResponse();
       $ssh_helper = $this->mockPollCloudViaSsh($environments_response);
       $this->command->sshHelper = $ssh_helper->reveal();
     }

--- a/tests/phpunit/src/Commands/WizardTestBase.php
+++ b/tests/phpunit/src/Commands/WizardTestBase.php
@@ -71,7 +71,6 @@ abstract class WizardTestBase extends CommandTestBase {
    */
   protected function runTestCreate(): void {
     $environments_response = $this->getMockEnvironmentsResponse();
-    $selected_environment = $environments_response->_embedded->items[0];
     $this->clientProphecy->request('get', "/applications/{$this::$application_uuid}/environments")->willReturn($environments_response->_embedded->items)->shouldBeCalled();
 
     // List uploaded keys.
@@ -80,7 +79,7 @@ abstract class WizardTestBase extends CommandTestBase {
     $local_machine_helper = $this->mockLocalMachineHelper();
 
     // Poll Cloud.
-    $ssh_helper = $this->mockPollCloudViaSsh($selected_environment);
+    $ssh_helper = $this->mockPollCloudViaSsh($environments_response);
     $this->command->sshHelper = $ssh_helper->reveal();
 
     /** @var Filesystem|ObjectProphecy $file_system */
@@ -132,7 +131,6 @@ abstract class WizardTestBase extends CommandTestBase {
       ->shouldBeCalled();
 
     $environments_response = $this->getMockEnvironmentsResponse();
-    $selected_environment = $environments_response->_embedded->items[0];
     $this->clientProphecy->request('get', "/applications/{$this::$application_uuid}/environments")->willReturn($environments_response->_embedded->items)->shouldBeCalled();
 
     $local_machine_helper = $this->mockLocalMachineHelper();
@@ -141,7 +139,7 @@ abstract class WizardTestBase extends CommandTestBase {
     $this->mockUploadSshKey();
 
     // Poll Cloud.
-    $ssh_helper = $this->mockPollCloudViaSsh($selected_environment);
+    $ssh_helper = $this->mockPollCloudViaSsh($environments_response);
     $this->command->sshHelper = $ssh_helper->reveal();
 
     /** @var Filesystem|ObjectProphecy $file_system */

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -17,6 +17,7 @@ use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Helpers\TelemetryHelper;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Exception\ApiErrorException;
+use AcquiaCloudApi\Response\ApplicationResponse;
 use AcquiaCloudApi\Response\IdeResponse;
 use AcquiaLogstream\LogstreamManager;
 use GuzzleHttp\Psr7\Response;
@@ -556,6 +557,17 @@ abstract class TestBase extends TestCase {
       ->shouldBeCalled();
 
     return $application_response;
+  }
+
+  protected function mockPermissionsRequest($application_response) {
+    $permissions_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/permissions",
+      'get', '200');
+    $this->clientProphecy->request('get',
+      '/applications/' . $application_response->uuid . '/permissions')
+      ->willReturn($permissions_response->_embedded->items)
+      ->shouldBeCalled();
+
+    return $permissions_response;
   }
 
   /**

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -563,10 +563,16 @@ abstract class TestBase extends TestCase {
     $permissions_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/permissions",
       'get', '200');
     if (!$perms) {
-      unset($permissions_response->_embedded->items['add ssh key to git'],
-        $permissions_response->_embedded->items['add ssh key to non-prod'],
-        $permissions_response->_embedded->items['add ssh key to prod']
-      );
+      $delete_perms = [
+        'add ssh key to git',
+        'add ssh key to non-prod',
+        'add ssh key to prod',
+      ];
+      foreach ($permissions_response->_embedded->items as $index => $item) {
+        if (in_array($item->name, $delete_perms, TRUE)) {
+          unset($permissions_response->_embedded->items[$index]);
+        }
+      }
     }
     $this->clientProphecy->request('get',
       '/applications/' . $application_response->uuid . '/permissions')

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -559,9 +559,15 @@ abstract class TestBase extends TestCase {
     return $application_response;
   }
 
-  protected function mockPermissionsRequest($application_response) {
+  protected function mockPermissionsRequest($application_response, $perms = TRUE) {
     $permissions_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/permissions",
       'get', '200');
+    if (!$perms) {
+      unset($permissions_response->_embedded->items['add ssh key to git'],
+        $permissions_response->_embedded->items['add ssh key to non-prod'],
+        $permissions_response->_embedded->items['add ssh key to prod']
+      );
+    }
     $this->clientProphecy->request('get',
       '/applications/' . $application_response->uuid . '/permissions')
       ->willReturn($permissions_response->_embedded->items)


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #818 

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
- Add permission checks for git, prod, and non-prod environments (the three places where SSH keys can be installed)
- Warn the user if they lack permissions for any of these
- Poll all three places to make sure SSH keys are fully installed and available

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

0. Use or mimic an IDE (export REMOTEIDE_UUID and AH_SITE_ENVIRONMENT=ide)
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Remove any existing local IDE SSH keys
4. Run `acli ide:wizard`
5. Depending on whether you have permissions to access git / prod / non-prod environments in the respective application, see that the corresponding environment is either polled or you are warned that you lack access.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
