### PR TITLE
Remove duplicate release drafter trigger

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,16 +4,14 @@ on:
   push:
     branches:
       - master
-
   pull_request:
-  pull_request_target:
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: release-drafter/release-drafter@v5
         env:


### PR DESCRIPTION
`pull_request` and `pull_request_target` triggers are essentially identical and using both in the same workflow results in multiple workflows running at once.

The only difference is that `pull_request_target` runs in the context of the base branch and injects repo secrets. Using `pull_request` is safer and just requires tweaking permissions. 