### PR TITLE
Fix mutation reporting, make it less verbose

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -29,7 +29,8 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          php build/infection.phar -j8 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --only-covered
+          # Explicitly specify GitHub logger since our Stryker reporting will otherwise disable it.
+          php build/infection.phar -j8 --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --only-covered
 
       - name: Run Infection for all files
         if: github.event_name == 'push'


### PR DESCRIPTION
- Mutation reporting was broken when we added Stryker integration, this fixes it
- This also reduces the verbosity of PR reporting by [only mutating changed _lines_](https://infection.github.io/guide/command-line-options.html#git-diff-lines) instead of changed _files_. This especially helps when working on big files like CommandBase.php, which can generate hundreds of mutations.