### PR TITLE
CLI-754: Fix slow PHPUnit tests

### DIFF
--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -108,6 +108,7 @@ class IdeCreateCommand extends IdeCommandBase {
    * @param $ide_url
    *
    * @return int
+   * @infection-ignore-all
    */
   protected function waitForDnsPropagation($ide_url): int {
     if (!$this->getClient()) {

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -319,6 +319,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @param string $notification_uuid
    * @param $acquia_cloud_client
+   * @infection-ignore-all
    */
   protected function waitForBackup($notification_uuid, $acquia_cloud_client): void {
     $loop = Loop::get();

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -325,7 +325,7 @@ abstract class PullCommandBase extends CommandBase {
     $spinner = LoopHelper::addSpinnerToLoop($loop, 'Waiting for database backup to complete...', $this->output);
     $notifications = new Notifications($acquia_cloud_client);
 
-    $loop->addPeriodicTimer(5, function () use ($loop, $spinner, $notification_uuid, $notifications) {
+    $callback = function () use ($loop, $spinner, $notification_uuid, $notifications) {
       try {
         $response = $notifications->get($notification_uuid);
         if ($response->status === 'completed') {
@@ -337,7 +337,10 @@ abstract class PullCommandBase extends CommandBase {
       } catch (Exception $e) {
         $this->logger->debug($e->getMessage());
       }
-    });
+    };
+    // Run once immediately to speed up tests.
+    $loop->addTimer(0.1, $callback);
+    $loop->addPeriodicTimer(5, $callback);
     LoopHelper::addTimeoutToLoop($loop, 45, $spinner);
 
     // Start the loop.

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -142,6 +142,7 @@ EOT
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    *
    * @throws \Exception
+   * @infection-ignore-all
    */
   protected function pollAcquiaCloudUntilSshSuccess(
     OutputInterface $output

--- a/tests/phpunit/src/ApplicationTestBase.php
+++ b/tests/phpunit/src/ApplicationTestBase.php
@@ -25,9 +25,6 @@ class ApplicationTestBase extends TestBase {
 
   public function setUp($output = NULL):void {
     parent::setUp($output);
-    // If kernel is cached from a previous run, it doesn't get detected in code
-    // coverage reports.
-    $this->fs->remove('var/cache');
     $this->kernel = new Kernel('dev', 0);
     $this->kernel->boot();
     $this->kernel->getContainer()->set(CloudDataStore::class, $this->datastoreCloud);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -17,7 +17,6 @@ use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Helpers\TelemetryHelper;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Exception\ApiErrorException;
-use AcquiaCloudApi\Response\ApplicationResponse;
 use AcquiaCloudApi\Response\IdeResponse;
 use AcquiaLogstream\LogstreamManager;
 use GuzzleHttp\Psr7\Response;
@@ -41,7 +40,6 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->

Tests are slower than necessary. This reduces the duration of unit tests from 90 seconds to 20 seconds!

**Proposed changes**

- Stop clearing the kernel cache between runs
- Run the event loop once immediately when it's created before starting the periodic loop. This feels a little hacky but I don't know how else to fix it.

**Merge requirements**
- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
