### PR TITLE
Remove fixtures from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,6 @@ build
 *.bak
 *.phar
 .DS_STORE
-tests/fixtures/.acquia/acquia-cli.json
-tests/fixtures/.acquia/cloud_api.conf
-tests/fixtures/project/.acquia-cli.yml
-tests/fixtures/project/blt/blt.yml
 
 ###> squizlabs/php_codesniffer ###
 /phpcs.xml


### PR DESCRIPTION
Now that we mirror test fixtures to a unique directory for every test, we no longer need to ignore files in the origin fixture directory (nothing should ever be created there). In fact, we want Git to alert us to any cruft in the fixture directory since it can cause bad behavior (I wasted a couple hours due to this yesterday, some rogue file was causing tests to behave differently locally than in CI).