### PR TITLE
Adding new command to get the used and un-used branches

### DIFF
--- a/src/Command/App/GetUsedUnusedBranchTags.php
+++ b/src/Command/App/GetUsedUnusedBranchTags.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Acquia\Cli\Command\App;
+
+use Acquia\Cli\Command\CommandBase;
+use AcquiaCloudApi\Endpoints\Code;
+use AcquiaCloudApi\Endpoints\Environments;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GetUsedUnusedBranchTags extends CommandBase {
+
+  protected static $defaultName = 'app:used-unsed-branch-tags';
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure() {
+    $this->setDescription('Get all used and un-used branches and tags of the application.');
+    $this->acceptApplicationUuid();
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *
+   * @return int 0 if everything went fine, or an exit code
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $cloud_application_uuid = $input->getArgument('applicationUuid');
+    // If application id is not provided in input.
+    if (!$cloud_application_uuid) {
+      $cloud_application_uuid = $this->determineCloudApplication();
+    }
+
+    $cloud_api_client = $this->cloudApiClientService->getClient();
+    $application_code_resource = new Code($cloud_api_client);
+    $all_branches_and_tags = $application_code_resource->getAll($cloud_application_uuid);
+
+    // Prepare list of all application tags and branches.
+    $all_vcs_paths = ['tags' => [], 'branches' => []];
+    foreach ($all_branches_and_tags as $branch_tag) {
+      $all_vcs_paths[$branch_tag->flags->tag ? 'tags' : 'branches'][$branch_tag->name] = $branch_tag->name;
+    }
+
+    $env_resource = new Environments($cloud_api_client);
+    $environments = $env_resource->getAll($cloud_application_uuid);
+    $deployed_branches = [];
+    // Get tags and branches deployed on each environment
+    // of the application.
+    foreach ($environments as $environment) {
+      $deployed_branches[] = $environment->vcs->path;
+      // Remove this deployed branch or tag from the all branch/tag list
+      if (isset($all_vcs_paths['tags'][$environment->vcs->path])) {
+        unset($all_vcs_paths['tags'][$environment->vcs->path]);
+      }
+      else {
+        unset($all_vcs_paths['branches'][$environment->vcs->path]);
+      }
+    }
+
+    $this->io->info('List of used branches and tags: ' . implode(', ', $deployed_branches));
+    $this->io->info('List of un-used branches: ' . implode(', ', $all_vcs_paths['tags']));
+    $this->io->info('List of un-used tags: ' . implode(', ', $all_vcs_paths['branches']));
+    return 0;
+  }
+
+}


### PR DESCRIPTION
```
acli app:used-unsed-branch-tags APPIDHERE

[INFO] List of used branches and tags: main-codestudio-build, tags/20211008-01, tags/2019-10-21



 [INFO] List of un-used branches: acquia-composer-update-codestudio-build, branch_2-codestudio-build,
        custom_test_job1-codestudio-build, develop, develop-build, develop-build-codestudio-build, develop-new, master,
        merge_check-codestudio-build, rohit_test_1-codestudio-build, rohit_test_2-codestudio-build,
        test2-codestudio-build, test_1-codestudio-build, test_local-codestudio-build, yaml_validate-codestudio-build



 [INFO] List of un-used tags: tags/12-03-2020-1, tags/12-03-2020-2, tags/12-03-2020-3, tags/14-03-2020-1,
        tags/14-03-2020-2, tags/14-03-2020-3, tags/18-01-2020, tags/20-03-2020-1, tags/2019-06-27, tags/2019-06-27.0,
        tags/2019-06-28, tags/2019-06-28-I, tags/2019-06-30, tags/2019-07-03, tags/2019-07-03-1, tags/2019-07-11,
        tags/2019-07-11-a, tags/2019-11-11, tags/2019-11-11-b, tags/2020-18-01, tags/20201031, tags/20201031-02,
        tags/22-02-2020.1, tags/22-02-2020.2, tags/25-03-2020-1, tags/pre-import-2019-06-21, tags/tag/2019-06-28
```