### PR TITLE
CLI-679: Consolidate internal commands under self

### DIFF
--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Acquia\Cli\Command;
+namespace Acquia\Cli\Command\App;
 
+use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Input\InputArgument;
@@ -15,7 +16,7 @@ use Symfony\Component\Filesystem\Path;
  */
 class NewCommand extends CommandBase {
 
-  protected static $defaultName = 'new';
+  protected static $defaultName = 'app:new';
 
   /**
    * {inheritdoc}.
@@ -23,7 +24,8 @@ class NewCommand extends CommandBase {
   protected function configure(): void {
     $this->setDescription('Create a new Drupal project')
       ->addOption('distribution', NULL, InputOption::VALUE_REQUIRED, 'The Composer package name of the Drupal distribution to download')
-      ->addArgument('directory', InputArgument::OPTIONAL, 'The destination directory');
+      ->addArgument('directory', InputArgument::OPTIONAL, 'The destination directory')
+      ->setAliases(['new']);
   }
 
   /**

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Filesystem\Path;
  */
 class NewCommand extends CommandBase {
 
-  protected static $defaultName = 'app:new';
+  protected static $defaultName = 'app:new:local';
 
   /**
    * {inheritdoc}.

--- a/src/Command/App/UnlinkCommand.php
+++ b/src/Command/App/UnlinkCommand.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Acquia\Cli\Command;
+namespace Acquia\Cli\Command\App;
 
+use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -11,13 +12,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class UnlinkCommand extends CommandBase {
 
-  protected static $defaultName = 'unlink';
+  protected static $defaultName = 'app:unlink';
 
   /**
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Remove local association between your project and a Cloud Platform application');
+    $this->setDescription('Remove local association between your project and a Cloud Platform application')
+      ->setAliases(['unlink']);
   }
 
   /**

--- a/src/Command/Self/ClearCacheCommand.php
+++ b/src/Command/Self/ClearCacheCommand.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Acquia\Cli\Command;
+namespace Acquia\Cli\Command\Self;
 
+use Acquia\Cli\Command\CommandBase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;

--- a/src/Command/Self/ListCommand.php
+++ b/src/Command/Self/ListCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acquia\Cli\Command;
+namespace Acquia\Cli\Command\Self;
 
 use Acquia\Cli\Command\Acsf\AcsfListCommandBase;
 use Acquia\Cli\Command\Api\ApiListCommandBase;
@@ -12,6 +12,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Class ListCommand.
  */
 class ListCommand extends \Symfony\Component\Console\Command\ListCommand {
+
+  protected function configure(): void {
+    parent::configure();
+    $this->setName('self:list')
+      ->setAliases(['list']);
+  }
 
   /**
    * {@inheritdoc}

--- a/src/Command/Self/TelemetryCommand.php
+++ b/src/Command/Self/TelemetryCommand.php
@@ -1,17 +1,18 @@
 <?php
 
-namespace Acquia\Cli\Command;
+namespace Acquia\Cli\Command\Self;
 
+use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Helpers\DataStoreContract;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class TelemetryEnableCommand.
+ * Class TelemetryCommand.
  */
-class TelemetryEnableCommand extends CommandBase {
+class TelemetryCommand extends CommandBase {
 
-  protected static $defaultName = 'telemetry:enable';
+  protected static $defaultName = 'self:telemetry:toggle';
 
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
@@ -26,7 +27,8 @@ class TelemetryEnableCommand extends CommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Enable anonymous sharing of usage and performance data');
+    $this->setDescription('Toggle anonymous sharing of usage and performance data')
+      ->setAliases(['telemetry']);
   }
 
   /**
@@ -38,8 +40,16 @@ class TelemetryEnableCommand extends CommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     $datastore = $this->datastoreCloud;
-    $datastore->set(DataStoreContract::SEND_TELEMETRY, TRUE);
-    $this->io->success('Telemetry has been enabled.');
+    if ($datastore->get(DataStoreContract::SEND_TELEMETRY)) {
+      $datastore->set(DataStoreContract::SEND_TELEMETRY, FALSE);
+      $this->io->success('Telemetry has been disabled.');
+    }
+    else {
+      $datastore->set(DataStoreContract::SEND_TELEMETRY, TRUE);
+      $this->io->success('Telemetry has been enabled.');
+    }
+    $opposite_verb = $datastore->get(DataStoreContract::SEND_TELEMETRY) ? 'disable' : 'enable';
+    $this->io->writeln("Run this command again to $opposite_verb telemetry");
 
     return 0;
   }

--- a/src/Command/Self/TelemetryDisableCommand.php
+++ b/src/Command/Self/TelemetryDisableCommand.php
@@ -1,17 +1,18 @@
 <?php
 
-namespace Acquia\Cli\Command;
+namespace Acquia\Cli\Command\Self;
 
+use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Helpers\DataStoreContract;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class TelemetryCommand.
+ * Class TelemetryDisableCommand.
  */
-class TelemetryCommand extends CommandBase {
+class TelemetryDisableCommand extends CommandBase {
 
-  protected static $defaultName = 'telemetry:toggle';
+  protected static $defaultName = 'self:telemetry:disable';
 
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
@@ -26,8 +27,8 @@ class TelemetryCommand extends CommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Toggle anonymous sharing of usage and performance data')
-      ->setAliases(['telemetry']);
+    $this->setDescription('Disable anonymous sharing of usage and performance data')
+      ->setAliases(['telemetry:disable']);
   }
 
   /**
@@ -39,16 +40,8 @@ class TelemetryCommand extends CommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     $datastore = $this->datastoreCloud;
-    if ($datastore->get(DataStoreContract::SEND_TELEMETRY)) {
-      $datastore->set(DataStoreContract::SEND_TELEMETRY, FALSE);
-      $this->io->success('Telemetry has been disabled.');
-    }
-    else {
-      $datastore->set(DataStoreContract::SEND_TELEMETRY, TRUE);
-      $this->io->success('Telemetry has been enabled.');
-    }
-    $opposite_verb = $datastore->get(DataStoreContract::SEND_TELEMETRY) ? 'disable' : 'enable';
-    $this->io->writeln("Run this command again to $opposite_verb telemetry");
+    $datastore->set(DataStoreContract::SEND_TELEMETRY, FALSE);
+    $this->io->success('Telemetry has been disabled.');
 
     return 0;
   }

--- a/src/Command/Self/TelemetryEnableCommand.php
+++ b/src/Command/Self/TelemetryEnableCommand.php
@@ -1,17 +1,18 @@
 <?php
 
-namespace Acquia\Cli\Command;
+namespace Acquia\Cli\Command\Self;
 
+use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Helpers\DataStoreContract;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class TelemetryDisableCommand.
+ * Class TelemetryEnableCommand.
  */
-class TelemetryDisableCommand extends CommandBase {
+class TelemetryEnableCommand extends CommandBase {
 
-  protected static $defaultName = 'telemetry:disable';
+  protected static $defaultName = 'self:telemetry:enable';
 
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
@@ -26,7 +27,8 @@ class TelemetryDisableCommand extends CommandBase {
    * {inheritdoc}.
    */
   protected function configure() {
-    $this->setDescription('Disable anonymous sharing of usage and performance data');
+    $this->setDescription('Enable anonymous sharing of usage and performance data')
+      ->setAliases(['telemetry:enable']);
   }
 
   /**
@@ -38,8 +40,8 @@ class TelemetryDisableCommand extends CommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     $datastore = $this->datastoreCloud;
-    $datastore->set(DataStoreContract::SEND_TELEMETRY, FALSE);
-    $this->io->success('Telemetry has been disabled.');
+    $datastore->set(DataStoreContract::SEND_TELEMETRY, TRUE);
+    $this->io->success('Telemetry has been enabled.');
 
     return 0;
   }

--- a/tests/phpunit/src/Commands/Acsf/AcsfListCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfListCommandTest.php
@@ -4,7 +4,7 @@ namespace Acquia\Cli\Tests\Commands\Acsf;
 
 use Acquia\Cli\Command\Acsf\AcsfListCommand;
 use Acquia\Cli\Command\Acsf\AcsfListCommandBase;
-use Acquia\Cli\Command\ListCommand;
+use Acquia\Cli\Command\Self\ListCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 

--- a/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
@@ -4,7 +4,7 @@ namespace Acquia\Cli\Tests\Commands\Api;
 
 use Acquia\Cli\Command\Api\ApiListCommand;
 use Acquia\Cli\Command\Api\ApiListCommandBase;
-use Acquia\Cli\Command\ListCommand;
+use Acquia\Cli\Command\Self\ListCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 

--- a/tests/phpunit/src/Commands/ClearCacheCommandTest.php
+++ b/tests/phpunit/src/Commands/ClearCacheCommandTest.php
@@ -2,16 +2,16 @@
 
 namespace Acquia\Cli\Tests\Commands;
 
-use Acquia\Cli\Command\ClearCacheCommand;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ide\IdeListCommand;
+use Acquia\Cli\Command\Self\ClearCacheCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 
 /**
  * Class ClearCacheCommandTest.
  *
- * @property \Acquia\Cli\Command\UnlinkCommand $command
+ * @property \Acquia\Cli\Command\App\UnlinkCommand $command
  * @package Acquia\Cli\Tests\Commands
  */
 class ClearCacheCommandTest extends CommandTestBase {

--- a/tests/phpunit/src/Commands/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/NewCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Acquia\Cli\Tests\Commands;
 
-use Acquia\Cli\Command\NewCommand;
+use Acquia\Cli\Command\App\NewCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Command\Command;
@@ -12,7 +12,7 @@ use Symfony\Component\Process\Process;
 /**
  * Class NewCommandTest.
  *
- * @property \Acquia\Cli\Command\NewCommand $command
+ * @property \Acquia\Cli\Command\App\NewCommand $command
  * @package Acquia\Cli\Tests\Commands
  */
 class NewCommandTest extends CommandTestBase {

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -3,7 +3,7 @@
 namespace Acquia\Cli\Tests\Commands;
 
 use Acquia\Cli\Command\App\LinkCommand;
-use Acquia\Cli\Command\TelemetryCommand;
+use Acquia\Cli\Command\Self\TelemetryCommand;
 use Acquia\Cli\Helpers\DataStoreContract;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
@@ -12,7 +12,7 @@ use Symfony\Component\Filesystem\Path;
 /**
  * Class TelemetryCommandTest.
  *
- * @property \Acquia\Cli\Command\TelemetryCommand $command
+ * @property \Acquia\Cli\Command\Self\TelemetryCommand $command
  * @package Acquia\Cli\Tests\Commands
  */
 class TelemetryCommandTest extends CommandTestBase {

--- a/tests/phpunit/src/Commands/TelemetryDisableCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryDisableCommandTest.php
@@ -2,14 +2,14 @@
 
 namespace Acquia\Cli\Tests\Commands;
 
-use Acquia\Cli\Command\TelemetryDisableCommand;
+use Acquia\Cli\Command\Self\TelemetryDisableCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 
 /**
  * Class TelemetryDisableCommandTest.
  *
- * @property \Acquia\Cli\Command\TelemetryDisableCommand $command
+ * @property \Acquia\Cli\Command\Self\TelemetryDisableCommand $command
  * @package Acquia\Cli\Tests\Commands
  */
 class TelemetryDisableCommandTest extends CommandTestBase {

--- a/tests/phpunit/src/Commands/TelemetryEnableCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryEnableCommandTest.php
@@ -2,14 +2,14 @@
 
 namespace Acquia\Cli\Tests\Commands;
 
-use Acquia\Cli\Command\TelemetryEnableCommand;
+use Acquia\Cli\Command\Self\TelemetryEnableCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 
 /**
  * Class TelemetryEnableCommandTest.
  *
- * @property \Acquia\Cli\Command\TelemetryEnableCommand $command
+ * @property \Acquia\Cli\Command\Self\TelemetryEnableCommand $command
  * @package Acquia\Cli\Tests\Commands
  */
 class TelemetryEnableCommandTest extends CommandTestBase {

--- a/tests/phpunit/src/Commands/UnlinkCommandTest.php
+++ b/tests/phpunit/src/Commands/UnlinkCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Acquia\Cli\Tests\Commands;
 
-use Acquia\Cli\Command\UnlinkCommand;
+use Acquia\Cli\Command\App\UnlinkCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Exception;
 use Symfony\Component\Console\Command\Command;
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Command\Command;
 /**
  * Class UnlinkCommandTest.
  *
- * @property \Acquia\Cli\Command\UnlinkCommand $command
+ * @property \Acquia\Cli\Command\App\UnlinkCommand $command
  * @package Acquia\Cli\Tests\Commands
  */
 class UnlinkCommandTest extends CommandTestBase {

--- a/tests/phpunit/src/Misc/EnvDbCredsTest.php
+++ b/tests/phpunit/src/Misc/EnvDbCredsTest.php
@@ -2,7 +2,7 @@
 
 namespace Acquia\Cli\Tests\Misc;
 
-use Acquia\Cli\Command\ClearCacheCommand;
+use Acquia\Cli\Command\Self\ClearCacheCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Acquia\Cli\Tests\TestBase;
 use Symfony\Component\Console\Command\Command;

--- a/tests/phpunit/src/Misc/LandoInfoTest.php
+++ b/tests/phpunit/src/Misc/LandoInfoTest.php
@@ -2,7 +2,7 @@
 
 namespace Acquia\Cli\Tests\Misc;
 
-use Acquia\Cli\Command\ClearCacheCommand;
+use Acquia\Cli\Command\Self\ClearCacheCommand;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -5,7 +5,7 @@ namespace Acquia\Cli\Tests;
 use Acquia\Cli\Application;
 use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\CloudApi\CloudCredentials;
-use Acquia\Cli\Command\ClearCacheCommand;
+use Acquia\Cli\Command\Self\ClearCacheCommand;
 use Acquia\Cli\Command\Ssh\SshKeyCommandBase;
 use Acquia\Cli\Config\AcquiaCliConfig;
 use Acquia\Cli\Config\CloudDataConfig;


### PR DESCRIPTION
This moves commands to the following new locations:
- `app:new`
- `app:link`
- `app:unlink`
- `self:list`
- `self:telemetry:toggle`
- `self:telemetry:disable`
- `self:telemetry:enable`

It also adds aliases to preserve the original command.

Annoyingly, Symfony has marked the DumpCompletion command (`completion`) as final so we can't extend it to change the name: https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Console/Command/DumpCompletionCommand.php

We could open a PR with Symfony to change this but I'm not sure it's worth the effort.