### PR TITLE
Fixes CLI-768: CLI string input with only digits should be interpretted as integer.

### DIFF
--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -301,7 +301,13 @@ class ApiBaseCommand extends CommandBase {
         new NotBlank(),
       ];
       if ($type = $this->getParamType($param_spec)) {
-        $constraints[] = new Type($type);
+        if (in_array($type, ['int', 'integer'])) {
+          // Need to evaluate whether a string contains only digits.
+          $constraints[] = new Type('digit');
+        }
+        else {
+          $constraints[] = new Type($type);
+        }
       }
       if (array_key_exists('schema', $param_spec)) {
         $schema = $param_spec['schema'];


### PR DESCRIPTION
**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `./bin/acli acsf:users:delete`
4.  Enter `80` as user id.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
