### PR TITLE
Fixes CLI-779: Support multiple data types in arguments.

### DIFF
--- a/src/Command/Acsf/AcsfApiBaseCommand.php
+++ b/src/Command/Acsf/AcsfApiBaseCommand.php
@@ -24,6 +24,7 @@ class AcsfApiBaseCommand extends ApiBaseCommand {
 
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @todo Remove this method when CLI-791 is resolved.
    *
    * @return string
    */

--- a/src/Command/Acsf/AcsfApiBaseCommand.php
+++ b/src/Command/Acsf/AcsfApiBaseCommand.php
@@ -40,7 +40,7 @@ class AcsfApiBaseCommand extends ApiBaseCommand {
       }
     }
 
-    return $path;
+    return parent::getRequestPath($input);
   }
 
 }

--- a/src/Command/Acsf/AcsfApiBaseCommand.php
+++ b/src/Command/Acsf/AcsfApiBaseCommand.php
@@ -36,7 +36,7 @@ class AcsfApiBaseCommand extends ApiBaseCommand {
     foreach ($arguments as $key => $value) {
       $token = '%' . $key;
       if (str_contains($path, $token)) {
-        $path = str_replace($token, $value, $path);
+        return str_replace($token, $value, $path);
       }
     }
 

--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -251,15 +251,39 @@ class ApiBaseCommand extends CommandBase {
    * @return bool|int|string
    */
   protected function castParamType(array $param_spec, $value) {
+    if (array_key_exists('schema', $param_spec) && array_key_exists('oneOf', $param_spec['schema'])) {
+      $types = [];
+      foreach ($param_spec['schema']['oneOf'] as $type) {
+        $types[] = $type['type'];
+      }
+      if (array_search('array', $types) && str_contains($value, ',')) {
+        return $this->doCastParamType('array', $value);
+      }
+      if ((array_search('integer', $types) !== FALSE || array_search('int', $types) !== FALSE)
+        && ctype_digit($value)) {
+        return $this->doCastParamType('integer', $value);
+      }
+    }
+
     $type = $this->getParamType($param_spec);
     if (!$type) {
       return $value;
     }
 
+    return $this->doCastParamType($type, $value);
+  }
+
+  /**
+   * @param array $param_spec
+   * @param string|array $value
+   *
+   * @return bool|int|string
+   */
+  protected function doCastParamType($type, $value) {
     return match ($type) {
       'int', 'integer' => (int) $value,
       'bool', 'boolean' => (bool) $value,
-      'array' => (array) $value,
+      'array' => explode(',', $value),
       'string' => (string) $value,
     };
   }

--- a/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
@@ -41,6 +41,25 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
     return $this->injectCommand(AcsfApiBaseCommand::class);
   }
 
+  public function testAcsfCommandExecutionForHttpPostWithMultipleDataTypes(): void {
+    $mock_body = $this->getMockResponseFromSpec('/api/v1/groups/{group_id}/members', 'post', '200');
+    $this->clientProphecy->request('post', '/api/v1/groups/1/members')->willReturn($mock_body)->shouldBeCalled();
+    $this->clientProphecy->addOption('json', ["uids" => ["1", "2", "3"]])->shouldBeCalled();
+    $this->command = $this->getApiCommandByName('acsf:groups:add-members');
+    $this->executeCommand([
+      'group_id' => '1',
+      'uids' => '1,2,3',
+    ]);
+
+    // Assert.
+    $this->prophet->checkPredictions();
+    $output = $this->getDisplay();
+    $this->assertNotNull($output);
+    $this->assertJson($output);
+    $contents = json_decode($output, TRUE);
+    $this->assertEquals((array) $mock_body, $contents);
+  }
+
   public function testAcsfCommandExecutionForHttpGet(): void {
     $mock_body = $this->getMockResponseFromSpec('/api/v1/audit', 'get', '200');
     $this->clientProphecy->addQuery('limit', '1')->shouldBeCalled();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-779: Support multiple data types in arguments.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `./bin/acli acsf:groups:make-members-admins`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
