### PR TITLE
Fixes CLI-773: Change "password" to "key" for ACSF commands.

### DIFF
--- a/src/AcsfApi/AcsfClient.php
+++ b/src/AcsfApi/AcsfClient.php
@@ -27,6 +27,11 @@ class AcsfClient extends Client {
     if (property_exists($body, 'error') && property_exists($body, 'message')) {
       throw new ApiErrorException($body);
     }
+    // Throw error for 4xx and 5xx responses.
+    if (in_array(substr($response->getStatusCode(), 0, 1), [4, 5]) && property_exists($body, 'message')) {
+      $body->error = $response->getStatusCode();
+      throw new ApiErrorException($body);
+    }
 
     return $body;
   }

--- a/src/AcsfApi/AcsfClientService.php
+++ b/src/AcsfApi/AcsfClientService.php
@@ -39,7 +39,7 @@ class AcsfClientService extends ClientService {
       return $this->machineIsAuthenticated;
     }
 
-    if (getenv('ACSF_USERNAME') && getenv('ACSF_PASSWORD') ) {
+    if (getenv('ACSF_USERNAME') && getenv('ACSF_KEY') ) {
       $this->machineIsAuthenticated = TRUE;
       return $this->machineIsAuthenticated;
     }

--- a/src/AcsfApi/AcsfCredentials.php
+++ b/src/AcsfApi/AcsfCredentials.php
@@ -75,13 +75,14 @@ class AcsfCredentials implements ApiCredentialsInterface {
    * @return string|null
    */
   public function getCloudSecret(): ?string {
-    if (getenv('ACSF_PASSWORD')) {
-      return getenv('ACSF_PASSWORD');
+    if (getenv('ACSF_KEY')) {
+      $this->output->writeln('Setting ACSF key using environment variable ACSF_KEY', OutputInterface::VERBOSITY_VERBOSE);
+      return getenv('ACSF_KEY');
     }
 
     if ($current_factory = $this->getCurrentFactory()) {
       if ($active_user = $this->getFactoryActiveUser($current_factory)) {
-        return $active_user['password'];
+        return $active_user['key'];
       }
     }
 

--- a/src/AcsfApi/AcsfCredentials.php
+++ b/src/AcsfApi/AcsfCredentials.php
@@ -76,7 +76,6 @@ class AcsfCredentials implements ApiCredentialsInterface {
    */
   public function getCloudSecret(): ?string {
     if (getenv('ACSF_KEY')) {
-      $this->output->writeln('Setting ACSF key using environment variable ACSF_KEY', OutputInterface::VERBOSITY_VERBOSE);
       return getenv('ACSF_KEY');
     }
 

--- a/src/Command/Acsf/AcsfApiAuthLoginCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLoginCommand.php
@@ -20,7 +20,7 @@ class AcsfApiAuthLoginCommand extends AcsfCommandBase {
   protected function configure() {
     $this->setDescription('Register your Site Factory API key and secret to use API functionality')
       ->addOption('username', 'u', InputOption::VALUE_REQUIRED, "The username for the Site Factory that you'd like to login to")
-      ->addOption('password', 'p', InputOption::VALUE_REQUIRED, "The password for your Site Factory user")
+      ->addOption('key', 'k', InputOption::VALUE_REQUIRED, "The key for your Site Factory user")
       ->addOption('factory-url', 'f', InputOption::VALUE_REQUIRED, "The URL of your factory. E.g., https://www.acquia.com");
   }
 
@@ -85,11 +85,11 @@ class AcsfApiAuthLoginCommand extends AcsfCommandBase {
     }
 
     $this->askForOptionValue($input, 'username');
-    $this->askForOptionValue($input, 'password', TRUE);
+    $this->askForOptionValue($input, 'key', TRUE);
 
     $username = $input->getOption('username');
-    $password = $input->getOption('password');
-    $this->writeAcsfCredentialsToDisk($factory_url, $username, $password);
+    $key = $input->getOption('key');
+    $this->writeAcsfCredentialsToDisk($factory_url, $username, $key);
     $output->writeln("<info>Saved credentials</info>");
 
     return 0;
@@ -98,14 +98,14 @@ class AcsfApiAuthLoginCommand extends AcsfCommandBase {
   /**
    * @param string $factory_url
    * @param string $username
-   * @param string $password
+   * @param string $key
    *
    */
-  protected function writeAcsfCredentialsToDisk($factory_url, string $username, string $password): void {
+  protected function writeAcsfCredentialsToDisk($factory_url, string $username, string $key): void {
     $keys = $this->datastoreCloud->get('acsf_factories');
     $keys[$factory_url]['users'][$username] = [
       'username' => $username,
-      'password' => $password,
+      'key' => $key,
     ];
     $keys[$factory_url]['url'] = $factory_url;
     $keys[$factory_url]['active_user'] = $username;

--- a/src/Config/CloudDataConfig.php
+++ b/src/Config/CloudDataConfig.php
@@ -59,7 +59,7 @@ class CloudDataConfig implements ConfigurationInterface {
                         ->arrayPrototype()
                             ->children()
                                 ->scalarNode('username')->end()
-                                ->scalarNode('password')->end()
+                                ->scalarNode('key')->end()
                             ->end()
                         ->end()
                     ->end()

--- a/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
+++ b/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
@@ -19,19 +19,19 @@ class AcsfServiceTest extends TestBase {
   public function providerTestIsMachineAuthenticated(): array {
     return [
       [
-        ['ACSF_USERNAME' => 'key', 'ACSF_PASSWORD' => 'secret'],
+        ['ACSF_USERNAME' => 'key', 'ACSF_KEY' => 'secret'],
         TRUE,
       ],
       [
-        ['ACSF_USERNAME' => 'key', 'ACSF_PASSWORD' => 'secret'],
+        ['ACSF_USERNAME' => 'key', 'ACSF_KEY' => 'secret'],
         TRUE,
       ],
       [
-        ['ACSF_USERNAME' => NULL, 'ACSF_PASSWORD' => NULL],
+        ['ACSF_USERNAME' => NULL, 'ACSF_KEY' => NULL],
         FALSE,
       ],
       [
-        ['ACSF_USERNAME' => 'key', 'ACSF_PASSWORD' => NULL],
+        ['ACSF_USERNAME' => 'key', 'ACSF_KEY' => NULL],
         FALSE,
       ],
     ];

--- a/tests/phpunit/src/AcsfApi/EnvVarAcsfAuthenticationTest.php
+++ b/tests/phpunit/src/AcsfApi/EnvVarAcsfAuthenticationTest.php
@@ -16,14 +16,14 @@ class EnvVarAcsfAuthenticationTest extends TestBase {
     parent::setUp();
     $this->cloudCredentials = new AcsfCredentials($this->datastoreCloud);
     putenv('ACSF_USERNAME=' . $this->key);
-    putenv('ACSF_PASSWORD=' . $this->secret);
+    putenv('ACSF_KEY=' . $this->secret);
     putenv('ACSF_FACTORY_URI=' . $this->acsfCurrentFactoryUrl);
   }
 
   protected function tearDown(): void {
     parent::tearDown();
     putenv('ACSF_USERNAME');
-    putenv('ACSF_PASSWORD');
+    putenv('ACSF_KEY');
   }
 
   public function testKeyAndSecret() {

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 /**
  * Class AuthCommandTest.
  *
- * @property AuthLoginCommand $command
+ * @property \Acquia\Cli\Command\Auth\AuthLoginCommand $command
  * @package Acquia\Cli\Tests
  */
 class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
@@ -40,8 +40,8 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
           $this->acsfCurrentFactoryUrl,
           // Please enter a value for username
           $this->acsfUsername,
-          //  Please enter a value for password
-          $this->acsfPassword,
+          //  Please enter a value for key
+          $this->acsfKey,
         ],
         // No arguments, all interactive.
         [],
@@ -60,8 +60,8 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
           '--factory-url' => $this->acsfCurrentFactoryUrl,
           // Please enter a value for username
           '--username' => $this->acsfUsername,
-          //  Please enter a value for password
-          '--password' => $this->acsfPassword,
+          //  Please enter a value for key
+          '--key' => $this->acsfKey,
         ],
         // Output to assert.
         'Saved credentials',
@@ -120,7 +120,7 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
     $this->assertStringContainsString($output_to_assert, $output);
     $this->assertKeySavedCorrectly();
     $this->assertEquals($this->acsfActiveUser, $this->cloudCredentials->getCloudKey());
-    $this->assertEquals($this->acsfPassword, $this->cloudCredentials->getCloudSecret());
+    $this->assertEquals($this->acsfKey, $this->cloudCredentials->getCloudSecret());
     $this->assertEquals($this->acsfCurrentFactoryUrl, $this->cloudCredentials->getBaseUri());
 
   }
@@ -129,15 +129,15 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
     return [
       [
         [],
-        ['--username' => 'no spaces are allowed' , '--password' => $this->acsfPassword]
+        ['--username' => 'no spaces are allowed' , '--key' => $this->acsfKey]
       ],
       [
         [],
-        ['--username' => 'shorty' , '--password' => $this->acsfPassword]
+        ['--username' => 'shorty' , '--key' => $this->acsfKey]
       ],
       [
         [],
-        ['--username' => ' ', '--password' => $this->acsfPassword]
+        ['--username' => ' ', '--key' => $this->acsfKey]
       ],
     ];
   }
@@ -185,9 +185,9 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
     $this->assertArrayHasKey($factory['active_user'], $users);
     $user = $users[$factory['active_user']];
     $this->assertArrayHasKey('username', $user);
-    $this->assertArrayHasKey('password', $user);
+    $this->assertArrayHasKey('key', $user);
     $this->assertEquals($this->acsfUsername, $user['username']);
-    $this->assertEquals($this->acsfPassword, $user['password']);
+    $this->assertEquals($this->acsfKey, $user['key']);
   }
 
 }

--- a/tests/phpunit/src/Commands/Acsf/AcsfCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfCommandTestBase.php
@@ -19,7 +19,7 @@ abstract class AcsfCommandTestBase extends CommandTestBase {
 
   protected $acsfUsername = 'tester';
 
-  protected $acsfPassword = 'h@x0r';
+  protected $acsfKey = 'h@x0r';
 
   /**
    * @return array
@@ -34,7 +34,7 @@ abstract class AcsfCommandTestBase extends CommandTestBase {
           'users' => [
             $this->acsfUsername => [
               'username' => $this->acsfUsername,
-              'password' => $this->acsfPassword,
+              'key' => $this->acsfKey,
             ],
           ],
         ],


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-773

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
