### PR TITLE
Fix #1043: Branch protection failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,17 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: build/acli.phar
+  # Require all checks to pass without having to enumerate them in the branch protection UI.
+  # @see https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957
+  check:
+    if: always()
+    needs:
+    - test
+    - build-release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
+

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,3 @@
-{
-    "name": "acquia/cli",
     "description": "Acquia CLI",
     "type": "library",
     "license": "GPL-2.0-only",

--- a/composer.json
+++ b/composer.json
@@ -1,3 +1,5 @@
+{
+    "name": "acquia/cli",
     "description": "Acquia CLI",
     "type": "library",
     "license": "GPL-2.0-only",


### PR DESCRIPTION
Fixes #1043

I updated the branch protection settings to require the new `check` job, which will always run (even if a prior job fails).

Proof that GitHub now blocks merging on test failures:
![Screen Shot 2022-06-13 at 8 02 19 AM](https://user-images.githubusercontent.com/1984514/173384330-44584fa0-1c46-4b9f-a058-ec55736b5775.png)
