### PR TITLE
ACLI migrate command fix.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -144,7 +144,7 @@ trait CodeStudioCommandTrait {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   protected function validateEnvironment() {
-    if (self::isAcquiaCloudIde() && !getenv('GITLAB_HOST')) {
+    if (empty(self::isAcquiaCloudIde()) && !getenv('GITLAB_HOST')) {
       throw new AcquiaCliException('The GITLAB_HOST environment variable must be set or the `--gitlab-host-name` option must be passed.');
     }
   }
@@ -153,6 +153,7 @@ trait CodeStudioCommandTrait {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   protected function authenticateWithGitLab(): void {
+    $this->validateEnvironment();
     $this->gitLabHost = $this->getGitLabHost();
     $this->gitLabToken = $this->getGitLabToken($this->gitLabHost);
     $this->getGitLabClient();

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -66,12 +66,14 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
     // Migrate acquia-pipeline file
     $this->checkGitLabCiCdVariables($project);
     $this->validateCwdIsValidDrupalProject();
-    $acquia_pipelines_file_contents = $this->getAcquiaPipelinesFileContents($project);
+    $acquia_pipelines_file_details = $this->getAcquiaPipelinesFileContents($project);
+    $acquia_pipelines_file_contents = $acquia_pipelines_file_details['file_contents'];
+    $acquia_pipelines_file_name = $acquia_pipelines_file_details['filename'];
     $gitlab_ci_file_contents = $this->getGitLabCiFileTemplate();
     $this->migrateVariablesSection($acquia_pipelines_file_contents, $gitlab_ci_file_contents);
     $this->migrateEventsSection($acquia_pipelines_file_contents, $gitlab_ci_file_contents);
     $this->removeEmptyScript($gitlab_ci_file_contents);
-    $this->createGitLabCiFile($gitlab_ci_file_contents);
+    $this->createGitLabCiFile($gitlab_ci_file_contents, $acquia_pipelines_file_name);
     $this->io->success([
       "",
       "Migration completed successfully.",
@@ -125,7 +127,10 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
       $this->gitLabClient->projects()->update($project['id'], ['ci_config_path' => '']);
       $filename = implode('', glob("acquia-pipelines.*"));
       $file_contents = file_get_contents($filename);
-      return Yaml::parse($file_contents, Yaml::PARSE_OBJECT);
+      return [
+        'file_contents' => Yaml::parse($file_contents, Yaml::PARSE_OBJECT),
+         'filename' =>  $filename
+        ];
     }
     else {
       throw new AcquiaCliException("Missing 'acquia-pipelines.yml' file which is required to migrate the project to Code Studio.");
@@ -210,7 +215,10 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
           'artifact' => 'Deploy Drupal',
           'deploy' => 'Deploy Drupal',
         ],
-        'needs' => [],
+        'needs' => [
+          'Build Code',
+          'Manage Secrets'
+        ],
       ],
       'post-deploy' => [
         'skip' => [
@@ -313,9 +321,10 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
   /**
    * Creating .gitlab-ci.yml file.
    */
-  protected function createGitLabCiFile(array $contents) {
+  protected function createGitLabCiFile(array $contents,$acquia_pipelines_file_name) {
     $gitlab_ci_filepath = Path::join($this->repoRoot, '.gitlab-ci.yml');
     $this->localMachineHelper->getFilesystem()->dumpFile($gitlab_ci_filepath, Yaml::dump($contents, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
+    $this->localMachineHelper->getFilesystem()->remove($acquia_pipelines_file_name);
   }
 
   /**

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -112,12 +112,6 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase {
     $this->assertFileExists($gitlab_ci_yml_file_path);
     // @todo Assert things about skips. Composer install, BLT, launch_ode.
     $contents = Yaml::parseFile($gitlab_ci_yml_file_path);
-
-    $testArray = ["a" => "value ba", "b" => "value b"];
-    $value = "value";
-    // assert function to test whether 'value' is a value of array
-    $this->assertNotContains($value, $testArray, "testArray contains value as value");
-
     $array_skip_map = ['composer install','${BLT_DIR}','launch_ode'];
     foreach ($contents as $values) {
       if(array_key_exists('script', $values)){

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -127,7 +127,7 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase {
     $this->assertArrayHasKey('stage', $contents['setup']);
     $this->assertEquals('Build Drupal', $contents['setup']['stage']);
     $this->assertArrayHasKey('needs', $contents['setup']);
-    $this->assertEmpty($contents['setup']['needs']);
+    $this->assertIsArray($contents['setup']['needs']);
   }
 
 }


### PR DESCRIPTION
This PR consist following fixes:

1. Added needs for build job, so that new "build drupal" job will be dependent on "'Build Code','Manage Secrets'" job.
2. At the end of the command it will remove the acquia-pipelines.yml file from the root repository.
3. "validateEnvironment" method was not getting called which is used to check GITLAB_HOST environment variable is set or not.so added it in "authenticateWithGitLab" method.