### PR TITLE
Set value of unset options to NULL.

### DIFF
--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -244,7 +244,7 @@ class ApiBaseCommand extends CommandBase {
     if ($input->hasArgument($param_name)) {
       return $input->getArgument($param_name);
     }
-    elseif ($input->hasParameterOption($param_name)) {
+    elseif ($input->hasParameterOption('--' . $param_name)) {
       return $input->getOption($param_name);
     }
     return NULL;

--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -242,12 +242,12 @@ class ApiBaseCommand extends CommandBase {
    */
   protected function getParamFromInput(InputInterface $input, string $param_name) {
     if ($input->hasArgument($param_name)) {
-      $param = $input->getArgument($param_name);
+      return $input->getArgument($param_name);
     }
-    else {
-      $param = $input->getOption($param_name);
+    elseif ($input->hasParameterOption($param_name)) {
+      return $input->getOption($param_name);
     }
-    return $param;
+    return NULL;
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes issue that causes `acli api:environments:code-switch` to throw error `Cloud Actions are not enabled on this environment.`.

**Proposed changes**
Previously, an option of type array would have a value of `[]` when unset. Now it will have a null value.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `./bin/acli api:environments:code-switch`

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
