### PR TITLE
Composer warnings tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "guzzlehttp/guzzle": "^7.4",
         "http-interop/http-factory-guzzle": "^1.0",
         "kevinrob/guzzle-cache-middleware": "^4",
+        "laminas/laminas-validator": "2.20.0",
         "league/csv": "^9.8",
         "loophp/phposinfo": "^1.7.2",
         "ltd-beget/dns-zone-configurator": "dev-php-update",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "acquia/cli",
     "description": "Acquia CLI",
-    "type": "library",
+    "type": "project",
     "license": "GPL-2.0-only",
     "authors": [
         {
@@ -23,7 +23,8 @@
         "composer/semver": "^3.3",
         "consolidation/self-update": "^2.0.3",
         "cweagans/composer-patches": "^1.7",
-        "grasmash/expander": "^1.0",
+        "dflydev/dot-access-data": "^3",
+        "grasmash/expander": "^1 | ^2 | ^3",
         "guzzlehttp/guzzle": "^7.4",
         "http-interop/http-factory-guzzle": "^1.0",
         "kevinrob/guzzle-cache-middleware": "^4",
@@ -32,7 +33,7 @@
         "loophp/phposinfo": "^1.7.2",
         "ltd-beget/dns-zone-configurator": "dev-php-update",
         "m4tthumphrey/php-gitlab-api": "^11.5",
-        "psr/log": "^1.1",
+        "psr/log": "^2 | ^3",
         "ramsey/uuid": "^4.1",
         "react/event-loop": "^1.1",
         "symfony/cache": "^6",
@@ -44,7 +45,7 @@
         "symfony/expression-language": "^6",
         "symfony/filesystem": "^6",
         "symfony/finder": "^6",
-        "symfony/flex": "^1",
+        "symfony/flex": "^2",
         "symfony/http-kernel": "^6",
         "symfony/process": "^6",
         "symfony/validator": "^6",
@@ -191,6 +192,7 @@
         "coverage": "php -d pcov.enabled=1 vendor/bin/phpunit tests/phpunit --coverage-clover build/logs/clover.xml",
         "lint": "phplint",
         "test": [
+            "@abandoned",
             "@lint",
             "@cs",
             "@stan",
@@ -201,6 +203,9 @@
         ],
         "coveralls": [
             "php-coveralls -vvv"
+        ],
+        "abandoned":  [
+            "cat composer.lock | jq '.packages[] | select(.abandoned)' | grep -q ^ && echo 'Abandoned Composer packages found' && exit 1 || exit 0"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fd0478f82b6bfc924b3926825f440fd",
+    "content-hash": "7416c443c78f22f11c6b9e094606e777",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -317,38 +317,6 @@
                 "source": "https://github.com/consolidation/self-update/tree/2.0.5"
             },
             "time": "2022-02-09T22:44:24+00:00"
-        },
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
-                "shasum": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
-            },
-            "abandoned": "psr/container",
-            "time": "2014-12-30T15:22:37+00:00"
         },
         {
             "name": "cweagans/composer-patches",
@@ -1025,17 +993,108 @@
             "time": "2022-03-15T21:47:10+00:00"
         },
         {
-            "name": "laminas/laminas-stdlib",
-            "version": "3.7.1",
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "bcd869e2fe88d567800057c1434f2380354fe325"
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/bcd869e2fe88d567800057c1434f2380354fe325",
-                "reference": "bcd869e2fe88d567800057c1434f2380354fe325",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/05ac4b1fb1fe9333313eeafced9b6c7946589487",
+                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.2.1",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<3.3.1",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.6",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.8"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-06-13T16:20:56+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "0d669074845fc80a99add0f64025192f143ef836"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/0d669074845fc80a99add0f64025192f143ef836",
+                "reference": "0d669074845fc80a99add0f64025192f143ef836",
                 "shasum": ""
             },
             "require": {
@@ -1081,26 +1140,26 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-21T15:50:46+00:00"
+            "time": "2022-06-10T14:49:09+00:00"
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.17.0",
+            "version": "2.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "bdd503adc83d814a5c94e598ea0eb9fc7ca56339"
+                "reference": "ba665f5a52763dda5a747c4ad826d2adf1510486"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/bdd503adc83d814a5c94e598ea0eb9fc7ca56339",
-                "reference": "bdd503adc83d814a5c94e598ea0eb9fc7ca56339",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/ba665f5a52763dda5a747c4ad826d2adf1510486",
+                "reference": "ba665f5a52763dda5a747c4ad826d2adf1510486",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
-                "laminas/laminas-stdlib": "^3.6",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "laminas/laminas-servicemanager": "^3.12.0",
+                "laminas/laminas-stdlib": "^3.10",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "zendframework/zend-validator": "*"
@@ -1109,27 +1168,24 @@
                 "laminas/laminas-cache": "^2.6.1",
                 "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-db": "^2.7",
-                "laminas/laminas-filter": "^2.6",
+                "laminas/laminas-filter": "^2.14.0",
                 "laminas/laminas-http": "^2.14.2",
-                "laminas/laminas-i18n": "^2.6",
-                "laminas/laminas-math": "^2.6",
-                "laminas/laminas-servicemanager": "^2.7.11 || ^3.0.3",
-                "laminas/laminas-session": "^2.8",
-                "laminas/laminas-uri": "^2.7",
+                "laminas/laminas-i18n": "^2.15.0",
+                "laminas/laminas-session": "^2.12.1",
+                "laminas/laminas-uri": "^2.9.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
                 "psalm/plugin-phpunit": "^0.15.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0",
-                "vimeo/psalm": "^4.3"
+                "vimeo/psalm": "^4.23"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
                 "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
                 "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
                 "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
                 "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
                 "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
                 "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
@@ -1171,7 +1227,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-03-08T18:16:51+00:00"
+            "time": "2022-06-14T12:31:18+00:00"
         },
         {
             "name": "league/csv",
@@ -2350,27 +2406,22 @@
         },
         {
             "name": "psr/container",
-            "version": "2.0.2",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -2397,9 +2448,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-11-05T16:47:00+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -3301,16 +3352,16 @@
         },
         {
             "name": "react/promise-timer",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise-timer.git",
-                "reference": "0bbbcc79589e5bfdddba68a287f1cb805581a479"
+                "reference": "aa7a73c74b8d8c0f622f5982ff7b0351bc29e495"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/0bbbcc79589e5bfdddba68a287f1cb805581a479",
-                "reference": "0bbbcc79589e5bfdddba68a287f1cb805581a479",
+                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/aa7a73c74b8d8c0f622f5982ff7b0351bc29e495",
+                "reference": "aa7a73c74b8d8c0f622f5982ff7b0351bc29e495",
                 "shasum": ""
             },
             "require": {
@@ -3368,7 +3419,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise-timer/issues",
-                "source": "https://github.com/reactphp/promise-timer/tree/v1.8.0"
+                "source": "https://github.com/reactphp/promise-timer/tree/v1.9.0"
             },
             "funding": [
                 {
@@ -3380,7 +3431,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-06T11:08:48+00:00"
+            "time": "2022-06-13T13:41:03+00:00"
         },
         {
             "name": "react/socket",
@@ -5406,21 +5457,22 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.0.1",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "e517458f278c2131ca9f262f8fbaf01410f2c65c"
+                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e517458f278c2131ca9f262f8fbaf01410f2c65c",
-                "reference": "e517458f278c2131ca9f262f8fbaf01410f2c65c",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
+                "reference": "24d9dc654b83e91aa59f9d167b131bc3b5bea24c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "psr/container": "^2.0"
+                "php": ">=7.2.5",
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -5431,7 +5483,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -5468,7 +5520,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.0.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.1"
             },
             "funding": [
                 {
@@ -5484,7 +5536,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-13T20:10:05+00:00"
+            "time": "2022-03-13T20:07:29+00:00"
         },
         {
             "name": "symfony/string",
@@ -7205,16 +7257,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "247918972acd74356b0a91dfaa5adcaec069b6c0"
+                "reference": "5579edf28aee1190a798bfa5be8bc16c563bd524"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/247918972acd74356b0a91dfaa5adcaec069b6c0",
-                "reference": "247918972acd74356b0a91dfaa5adcaec069b6c0",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5579edf28aee1190a798bfa5be8bc16c563bd524",
+                "reference": "5579edf28aee1190a798bfa5be8bc16c563bd524",
                 "shasum": ""
             },
             "require": {
@@ -7293,7 +7345,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.6.0"
+                "source": "https://github.com/Seldaek/monolog/tree/2.7.0"
             },
             "funding": [
                 {
@@ -7305,7 +7357,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-10T09:36:00+00:00"
+            "time": "2022-06-09T08:59:12+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -8262,16 +8314,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.5.1",
+            "version": "1.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "981cc368a216c988e862a75e526b6076987d1b50"
+                "reference": "4a07085f74cb1f3fc7103efa537d9f00ebb74ec7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/981cc368a216c988e862a75e526b6076987d1b50",
-                "reference": "981cc368a216c988e862a75e526b6076987d1b50",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/4a07085f74cb1f3fc7103efa537d9f00ebb74ec7",
+                "reference": "4a07085f74cb1f3fc7103efa537d9f00ebb74ec7",
                 "shasum": ""
             },
             "require": {
@@ -8281,6 +8333,7 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
@@ -8300,9 +8353,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.5.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.3"
             },
-            "time": "2022-05-05T11:32:40+00:00"
+            "time": "2022-06-14T11:40:08+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -10295,5 +10348,5 @@
     "platform-overrides": {
         "php": "8.0.3"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7416c443c78f22f11c6b9e094606e777",
+    "content-hash": "99428c78c3d4de8d4efed4e9889d800a",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -368,30 +368,37 @@
         },
         {
             "name": "dflydev/dot-access-data",
-            "version": "v1.1.0",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
-                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a"
+                "reference": "0992cc19268b259a39e86f296da5f0677841f42c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/3fbd874921ab2c041e899d044585a2ab9795df8a",
-                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/0992cc19268b259a39e86f296da5f0677841f42c",
+                "reference": "0992cc19268b259a39e86f296da5f0677841f42c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
+                "scrutinizer/ocular": "1.6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^3.14"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Dflydev\\DotAccessData": "src"
+                "psr-4": {
+                    "Dflydev\\DotAccessData\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -413,6 +420,11 @@
                     "name": "Carlos Frutos",
                     "email": "carlos@kiwing.it",
                     "homepage": "https://github.com/cfrutos"
+                },
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com"
                 }
             ],
             "description": "Given a deep data structure, access data by dot notation.",
@@ -425,9 +437,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
-                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/master"
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.1"
             },
-            "time": "2017-01-20T21:14:22+00:00"
+            "time": "2021-08-13T13:06:58+00:00"
         },
         {
             "name": "evenement/evenement",
@@ -478,27 +490,28 @@
         },
         {
             "name": "grasmash/expander",
-            "version": "1.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/grasmash/expander.git",
-                "reference": "95d6037344a4be1dd5f8e0b0b2571a28c397578f"
+                "reference": "bb1c1a2430957945cf08c5a62f5d72a6aa6a2c82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grasmash/expander/zipball/95d6037344a4be1dd5f8e0b0b2571a28c397578f",
-                "reference": "95d6037344a4be1dd5f8e0b0b2571a28c397578f",
+                "url": "https://api.github.com/repos/grasmash/expander/zipball/bb1c1a2430957945cf08c5a62f5d72a6aa6a2c82",
+                "reference": "bb1c1a2430957945cf08c5a62f5d72a6aa6a2c82",
                 "shasum": ""
             },
             "require": {
-                "dflydev/dot-access-data": "^1.1.0",
-                "php": ">=5.4"
+                "dflydev/dot-access-data": "^3.0.0",
+                "php": ">=8.0",
+                "psr/log": "^2 | ^3"
             },
             "require-dev": {
                 "greg-1-anderson/composer-test-scenarios": "^1",
-                "phpunit/phpunit": "^4|^5.5.4",
-                "satooshi/php-coveralls": "^1.0.2|dev-master",
-                "squizlabs/php_codesniffer": "^2.7"
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpunit/phpunit": "^9",
+                "squizlabs/php_codesniffer": "^3.3"
             },
             "type": "library",
             "extra": {
@@ -523,9 +536,9 @@
             "description": "Expands internal property references in PHP arrays file.",
             "support": {
                 "issues": "https://github.com/grasmash/expander/issues",
-                "source": "https://github.com/grasmash/expander/tree/master"
+                "source": "https://github.com/grasmash/expander/tree/3.0.0"
             },
-            "time": "2017-12-21T22:14:55+00:00"
+            "time": "2022-05-10T13:14:49+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2664,30 +2677,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2708,9 +2721,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:41:46+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4591,28 +4604,28 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.19.2",
+            "version": "v2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "d1a692369be53445af6e391170b509d7f5d026cf"
+                "reference": "78510b1be591433513c8087deec24e9fd90d110d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/d1a692369be53445af6e391170b509d7f5d026cf",
-                "reference": "d1a692369be53445af6e391170b509d7f5d026cf",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/78510b1be591433513c8087deec24e9fd90d110d",
+                "reference": "78510b1be591433513c8087deec24e9fd90d110d",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0|^2.0",
-                "php": ">=7.1"
+                "composer-plugin-api": "^2.1",
+                "php": ">=8.0"
             },
             "require-dev": {
-                "composer/composer": "^1.0.2|^2.0",
-                "symfony/dotenv": "^4.4|^5.0|^6.0",
-                "symfony/filesystem": "^4.4|^5.0|^6.0",
-                "symfony/phpunit-bridge": "^4.4.12|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0"
+                "composer/composer": "^2.1",
+                "symfony/dotenv": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/phpunit-bridge": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -4636,7 +4649,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v1.19.2"
+                "source": "https://github.com/symfony/flex/tree/v2.2.2"
             },
             "funding": [
                 {
@@ -4652,7 +4665,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-14T21:13:39+00:00"
+            "time": "2022-06-15T06:51:57+00:00"
         },
         {
             "name": "symfony/http-foundation",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -22,5 +22,6 @@
   <rule ref="AcquiaPHP" />
 
   <rule ref="Drupal.Classes.UnusedUseStatement" />
+  <rule ref="Drupal.ControlStructures.ControlSignature" />
 
 </ruleset>

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -123,11 +123,11 @@ class ApiCommandHelper {
         if ($parameter_specification['in'] === 'query') {
           $command->addQueryParameter($parameter_definition->getName(), $parameter_specification);
         }
-        elseif($parameter_specification['in'] === 'path') {
+        elseif ($parameter_specification['in'] === 'path') {
           $command->addPathParameter($parameter_definition->getName(), $parameter_specification);
         }
         // @todo Remove this! It is a workaround for CLI-769.
-        elseif($parameter_specification['in'] === 'header') {
+        elseif ($parameter_specification['in'] === 'header') {
           $command->addPostParameter($parameter_definition->getName(), $parameter_specification);
         }
       }

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -50,7 +50,8 @@ class NewCommand extends CommandBase {
     }
     else if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
       $dir = '/home/ide/project';
-    } else {
+    }
+    else {
       $dir = Path::makeAbsolute('drupal', getcwd());
     }
 

--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -159,7 +159,8 @@ trait CodeStudioCommandTrait {
     $this->getGitLabClient();
     try {
       $this->gitLabAccount = $this->gitLabClient->users()->me();
-    } catch (RuntimeException $exception) {
+    }
+    catch (RuntimeException $exception) {
       $this->io->error([
         "Unable to authenticate with Code Studio",
         "Did you set a valid token with the <options=bold>api</> and <options=bold>write_repository</> scopes?",

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -258,7 +258,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
                     $code_studio_jobs[$script_name]['script'][] = $command;
                     $code_studio_jobs[$script_name]['script']=array_values(array_unique($code_studio_jobs[$script_name]['script']));
                   }
-                  else{
+                  else {
                     if (($key = array_search($command, $code_studio_jobs[$script_name]['script'])) !== FALSE) {
                       unset($code_studio_jobs[$script_name]['script'][$key]);
                     }
@@ -273,10 +273,10 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
                 break;
               }
               else {
-                if(array_key_exists($script_name, $code_studio_jobs) && array_key_exists('script', $code_studio_jobs[$script_name]) && in_array($command, $code_studio_jobs[$script_name]['script'])){
+                if (array_key_exists($script_name, $code_studio_jobs) && array_key_exists('script', $code_studio_jobs[$script_name]) && in_array($command, $code_studio_jobs[$script_name]['script'])) {
                   break;
                 }
-                if(!array_key_exists($script_name, $event_map['skip']) ){
+                if (!array_key_exists($script_name, $event_map['skip']) ) {
                   $code_studio_jobs[$script_name]['script'][] = $command;
                   $code_studio_jobs[$script_name]['script']=array_values(array_unique($code_studio_jobs[$script_name]['script']));
                 }
@@ -311,8 +311,8 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    * Removing empty script.
    */
   protected function removeEmptyScript(array &$gitlab_ci_file_contents) {
-    foreach($gitlab_ci_file_contents as $key => $value){
-      if(array_key_exists('script', $value) && empty($value['script'])){
+    foreach ($gitlab_ci_file_contents as $key => $value) {
+      if (array_key_exists('script', $value) && empty($value['script'])) {
         unset($gitlab_ci_file_contents[$key]);
       }
     }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1211,7 +1211,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       if ($latest = $this->hasUpdate()) {
         return $latest;
       }
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       $this->logger->debug("Could not determine if Acquia CLI has a new version available.");
     }
     return FALSE;
@@ -1731,13 +1732,15 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected function validateApplicationUuid($application_uuid_argument) {
     try {
       self::validateUuid($application_uuid_argument);
-    } catch (ValidatorException $validator_exception) {
+    }
+    catch (ValidatorException $validator_exception) {
       // Since this isn't a valid UUID, let's see if it's a valid alias.
       $alias = $this->normalizeAlias($application_uuid_argument);
       try {
         $customer_application = $this->getApplicationFromAlias($alias);
         return $customer_application->uuid;
-      } catch (AcquiaCliException $exception) {
+      }
+      catch (AcquiaCliException $exception) {
         throw new AcquiaCliException("The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.");
       }
     }
@@ -1759,7 +1762,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       unset($uuid_parts[0]);
       $application_uuid = implode('-', $uuid_parts);
       self::validateUuid($application_uuid);
-    } catch (ValidatorException $validator_exception) {
+    }
+    catch (ValidatorException $validator_exception) {
       try {
         // Since this isn't a valid environment ID, let's see if it's a valid alias.
         $alias = $env_uuid_argument;
@@ -1767,7 +1771,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
         $alias = self::validateEnvironmentAlias($alias);
         $environment = $this->getEnvironmentFromAliasArg($alias);
         return $environment->uuid;
-      } catch (AcquiaCliException $exception) {
+      }
+      catch (AcquiaCliException $exception) {
         throw new AcquiaCliException("{{$argument_name}} must be a valid UUID or site alias.");
       }
     }

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -235,7 +235,8 @@ class ConfigurePlatformEmailCommand extends CommandBase {
       try {
         $response = $client->request('post', "/applications/{$application->uuid}/email/domains/{$domain_uuid}/actions/associate");
         $this->io->success("Domain $base_domain has been associated with Application {$application->name}");
-      } catch (ApiErrorException $e) {
+      }
+      catch (ApiErrorException $e) {
         if (!$this->domainAlreadyAssociated($application, $e)) {
           return FALSE;
         }
@@ -388,7 +389,8 @@ class ConfigurePlatformEmailCommand extends CommandBase {
         $this->logger->debug(json_encode($response));
         return FALSE;
       }
-    } catch (AcquiaCliException $exception) {
+    }
+    catch (AcquiaCliException $exception) {
       $this->logger->debug($exception->getMessage());
       return FALSE;
     }

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -139,7 +139,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
         $this->showHumanReadableStatus($domain->health->code) . ' - ' . $domain->health->code
       ]);
 
-      foreach($domain->dns_records as $index => $record) {
+      foreach ($domain->dns_records as $index => $record) {
         if ($index === 0) {
           $writer_all_domains_dns_health->insertOne([
             $domain->domain_name,
@@ -234,15 +234,15 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
     $apps_domains_header = ['Application', 'Domain Name', 'Associated?'];
     $writer_apps_domains->insertOne($apps_domains_header);
 
-    foreach($subscription_applications as $index => $app) {
+    foreach ($subscription_applications as $index => $app) {
       $app_domains = $client->request('get', "/applications/{$app->uuid}/email/domains");
 
       if ($index !== 0) {
         $apps_domains_table->addRow([new TableSeparator(['colspan' => 2])]);
       }
       $apps_domains_table->addRow([new TableCell("Application: {$app->name}", ['colspan' => 2])]);
-      if(count($app_domains)) {
-        foreach($app_domains as $domain) {
+      if (count($app_domains)) {
+        foreach ($app_domains as $domain) {
           $apps_domains_table->addRow([
             $domain->domain_name,
             var_export($domain->flags->associated, TRUE)

--- a/src/Command/Env/EnvCopyCronCommand.php
+++ b/src/Command/Env/EnvCopyCronCommand.php
@@ -95,7 +95,8 @@ class EnvCopyCronCommand extends CommandBase {
             $cron->label,
           );
 
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
           $this->io->error('There was some error while copying the cron task "' . $cron->label . '"');
           // Log the error for debugging purpose.
           $this->logger->debug('Error @error while copying the cron task @cron from @source env to @dest env', [

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -52,10 +52,12 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
     if ($this->getXDebugStatus() === FALSE) {
       $this->enableXDebug($ini_file, $contents);
       $this->restartService('php-fpm');
-    } elseif ($this->getXDebugStatus() === TRUE) {
+    }
+    elseif ($this->getXDebugStatus() === TRUE) {
       $this->disableXDebug($ini_file, $contents);
       $this->restartService('php-fpm');
-    } else {
+    }
+    else {
       $this->logger->error("Could not find xdebug zend extension in $ini_file!");
     }
 
@@ -71,9 +73,11 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
   protected function setXDebugStatus($contents): void {
     if (strpos($contents, ';zend_extension=xdebug.so') !== FALSE) {
       $this->xDebugEnabled = FALSE;
-    } elseif (strpos($contents, 'zend_extension=xdebug.so') !== FALSE) {
+    }
+    elseif (strpos($contents, 'zend_extension=xdebug.so') !== FALSE) {
       $this->xDebugEnabled = TRUE;
-    } else {
+    }
+    else {
       $this->xDebugEnabled = NULL;
     }
   }

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -391,7 +391,8 @@ abstract class PullCommandBase extends CommandBase {
           $this->output->writeln('');
           $this->output->writeln('<info>Database backup is ready!</info>');
         }
-      } catch (Exception $e) {
+      }
+      catch (Exception $e) {
         $this->logger->debug($e->getMessage());
       }
     };

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -167,7 +167,8 @@ EOT
           else {
             $this->logger->debug($process->getOutput() . $process->getErrorOutput());
           }
-        } catch (AcquiaCliException $exception) {
+        }
+        catch (AcquiaCliException $exception) {
           $this->logger->debug($exception->getMessage());
         }
       }

--- a/src/DataStore/Datastore.php
+++ b/src/DataStore/Datastore.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\DataStore;
 
 use Dflydev\DotAccessData\Data;
+use Dflydev\DotAccessData\Exception\MissingPathException;
 use Grasmash\Expander\Expander;
 use Grasmash\Expander\Stringifier;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -60,7 +61,12 @@ abstract class Datastore implements DataStoreInterface {
    * @return array|mixed|null
    */
   public function get(string $key, $default = NULL) {
-    return $this->data->get($key);
+    try {
+      return $this->data->get($key);
+    }
+    catch (MissingPathException $e) {
+      return NULL;
+    }
   }
 
   /**

--- a/src/Descriptor/ReStructuredTextDescriptor.php
+++ b/src/Descriptor/ReStructuredTextDescriptor.php
@@ -279,7 +279,8 @@ class ReStructuredTextDescriptor extends MarkdownDescriptor
           // If the namespace contained only aliases or hidden commands, skip the namespace.
           continue;
         }
-      } catch (\Exception $exception) {
+      }
+      catch (\Exception $exception) {
 
       }
       $this->visibleNamespaces[] = $namespace['id'];

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -138,7 +138,8 @@ class ExceptionListener {
         $this->helpMessages[] = $message;
       }
       // This command may not exist during some testing.
-    } catch (CommandNotFoundException $exception) {
+    }
+    catch (CommandNotFoundException $exception) {
     }
   }
 

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -84,7 +84,8 @@ class TelemetryHelper {
       $amplitude->setUserProperties($this->getTelemetryUserData());
       $amplitude->setUserId($this->getUserId());
       $amplitude->logQueuedEvents();
-    } catch (IdentityProviderException $e) {
+    }
+    catch (IdentityProviderException $e) {
       // If something is wrong with the Cloud API client, don't bother users.
     }
   }

--- a/symfony.lock
+++ b/symfony.lock
@@ -41,9 +41,6 @@
     "consolidation/self-update": {
         "version": "2.0.0-alpha1"
     },
-    "container-interop/container-interop": {
-        "version": "1.2.0"
-    },
     "cweagans/composer-patches": {
         "version": "1.7.2"
     },

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -102,10 +102,11 @@ abstract class CommandTestBase extends TestBase {
     try {
       $tester->execute($args, ['verbosity' => Output::VERBOSITY_VERY_VERBOSE]);
     }
-    catch (Exception $e) {if (getenv('ACLI_PRINT_COMMAND_OUTPUT')) {
+    catch (Exception $e) {
+      if (getenv('ACLI_PRINT_COMMAND_OUTPUT')) {
         print $this->getDisplay();
-    }
-    throw $e;
+      }
+      throw $e;
     }
 
     if (getenv('ACLI_PRINT_COMMAND_OUTPUT')) {

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -114,8 +114,8 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase {
     $contents = Yaml::parseFile($gitlab_ci_yml_file_path);
     $array_skip_map = ['composer install','${BLT_DIR}','launch_ode'];
     foreach ($contents as $values) {
-      if(array_key_exists('script', $values)){
-        foreach($array_skip_map as $map){
+      if (array_key_exists('script', $values)) {
+        foreach ($array_skip_map as $map) {
           $this->assertNotContains($map, $values['script'], "Skip option found");
         }
       }

--- a/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
@@ -264,7 +264,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
     $this->assertEquals($expected_exit_code, $this->getStatusCode());
-    foreach($expected_text as $text) {
+    foreach ($expected_text as $text) {
       $this->assertStringContainsString($text, $output);
     }
   }
@@ -518,7 +518,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
     $this->assertEquals($expected_exit_code, $this->getStatusCode());
-    foreach($expected_text as $text) {
+    foreach ($expected_text as $text) {
       $this->assertStringContainsString($text, $output);
     }
   }
@@ -575,7 +575,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase {
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
     $this->assertEquals($expected_exit_code, $this->getStatusCode());
-    foreach($expected_text as $text) {
+    foreach ($expected_text as $text) {
       $this->assertStringContainsString($text, $output);
     }
 

--- a/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
@@ -70,7 +70,7 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
     $output = $this->getDisplay();
     $this->assertEquals(0, $this->getStatusCode());
     $this->assertStringContainsString('Application: ', $output);
-    foreach($get_app_domains_response->_embedded->items as $app_domain) {
+    foreach ($get_app_domains_response->_embedded->items as $app_domain) {
       $this->assertEquals(3, substr_count($output, $app_domain->domain_name));
     }
 
@@ -145,7 +145,7 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
 
     $this->clientProphecy->request('get', '/applications')->willReturn($applications_response->_embedded->items);
 
-    foreach($applications_response->_embedded->items as $app) {
+    foreach ($applications_response->_embedded->items as $app) {
       $this->clientProphecy->request('get', "/applications/{$app->uuid}/email/domains")->willReturn([]);
     }
 

--- a/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Command\Command;
  * @property \Acquia\Cli\Command\Env\EnvCreateCommand $command
  * @package Acquia\Cli\Tests\Commands\Env
  */
-class CreateCdeCommandTest extends CommandTestBase {
+class EnvCreateCommandTest extends CommandTestBase {
 
   /**
    * {@inheritdoc}

--- a/tests/phpunit/src/Commands/Env/EnvMirrorCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvMirrorCommandTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Command\Command;
  * @property \Acquia\Cli\Command\Env\EnvMirrorCommand $command
  * @package Acquia\Cli\Tests\Commands
  */
-class EnvironmentMirrorCommandTest extends CommandTestBase {
+class EnvMirrorCommandTest extends CommandTestBase {
 
   /**
    * {@inheritdoc}

--- a/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
@@ -136,7 +136,8 @@ class PullCodeCommandTest extends PullCommandTestBase {
       $this->executeCommand([
       '--no-scripts' => TRUE,
     ], $inputs);
-    } catch (AcquiaCliException $exception) {
+    }
+    catch (AcquiaCliException $exception) {
       $this->assertStringContainsString('Pulling code from your Cloud Platform environment was aborted because your local Git repository has uncommitted changes', $exception->getMessage());
     }
   }
@@ -172,7 +173,8 @@ class PullCodeCommandTest extends PullCommandTestBase {
       $this->executeCommand([
         '--no-scripts' => TRUE,
       ], $inputs);
-    } catch (AcquiaCliException $exception) {
+    }
+    catch (AcquiaCliException $exception) {
       $this->assertStringContainsString('unable to determine', $exception->getMessage());
     }
 

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -68,7 +68,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
       $this->executeCommand([
         '--no-scripts' => TRUE,
       ], $inputs);
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       $this->assertStringContainsString('Unable to connect', $e->getMessage());
     }
   }
@@ -115,7 +116,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
       '--no-scripts' => TRUE,
       '--multiple-dbs' => TRUE,
     ], $inputs);
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       $this->assertEquals('The --multiple-dbs option is not supported in Cloud IDE.', $e->getMessage());
     }
     IdeHelper::unsetCloudIdeEnvVars();
@@ -221,7 +223,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
 
     try {
       $this->executeCommand(['--no-scripts' => TRUE], $inputs);
-    } catch (AcquiaCliException $exception) {
+    }
+    catch (AcquiaCliException $exception) {
       $this->assertStringContainsString('Could not download remote database dump', $exception->getMessage());
     }
   }
@@ -236,7 +239,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
 
     try {
       $this->executeCommand(['--no-scripts' => TRUE], $inputs);
-    } catch (AcquiaCliException $exception) {
+    }
+    catch (AcquiaCliException $exception) {
       $this->assertStringContainsString('Unable to drop a local database', $exception->getMessage());
     }
   }
@@ -251,7 +255,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
 
     try {
       $this->executeCommand(['--no-scripts' => TRUE], $inputs);
-    } catch (AcquiaCliException $exception) {
+    }
+    catch (AcquiaCliException $exception) {
       $this->assertStringContainsString('Unable to create a local database', $exception->getMessage());
     }
   }
@@ -266,7 +271,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
 
     try {
       $this->executeCommand(['--no-scripts' => TRUE], $inputs);
-    } catch (AcquiaCliException $exception) {
+    }
+    catch (AcquiaCliException $exception) {
       $this->assertStringContainsString('Unable to import local database', $exception->getMessage());
     }
   }

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -113,7 +113,8 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $this->command->localMachineHelper = $local_machine_helper->reveal();
     try {
       $this->executeCommand([], []);
-    } catch (AcquiaCliException $exception) {
+    }
+    catch (AcquiaCliException $exception) {
       $this->assertStringContainsString('Please run this command from the ', $exception->getMessage());
     }
     IdeHelper::unsetCloudIdeEnvVars();


### PR DESCRIPTION
This fixes numerous issues related to code sniffing, tests, and outdated Composer packages:

- PHPCS should enforce control structure styles: https://github.com/acquia/coding-standards-php/pull/44
- Remove deprecated interop-container package
- Fix namespace of several tests that prevented them from running
- Several Composer packages were severely out of date due to version conflicts (see also https://github.com/zumba/amplitude-php/pull/35 and https://github.com/php-coveralls/php-coveralls/pull/347)