### PR TITLE
GL-703 | Bug fix for acli migrate command.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -177,7 +177,7 @@ trait CodeStudioCommandTrait {
    *
    * @return array
    */
-  protected function determineGitLabProject(ApplicationResponse $cloud_application): array {
+  protected function determineGitLabProject(ApplicationResponse $cloud_application, Bool $create_new_cs_project = TRUE): array {
     // Use command option.
     if ($this->input->getOption('gitlab-project-id')) {
       $id = $this->input->getOption('gitlab-project-id');
@@ -201,11 +201,16 @@ trait CodeStudioCommandTrait {
     }
     // Prompt to create project.
     else {
-      $this->io->writeln([
+      $error_message = [
         "",
-        "Could not find any existing Code Studio project for Acquia Cloud Platform application <comment>{$cloud_application->name}</comment>.",
-        "Searched for UUID <comment>{$cloud_application->uuid}</comment> in project descriptions.",
-      ]);
+        "Could not find any existing Code Studio project for Acquia Cloud Platform application {$cloud_application->name}.",
+        "Searched for UUID {$cloud_application->uuid} in project descriptions.",
+      ];
+      if (!$create_new_cs_project) {
+        $this->io->error($error_message);
+        throw new AcquiaCliException("Contact an account manager for further assistance");
+      }
+      $this->io->writeln($error_message);
       $create_project = $this->io->confirm('Would you like to create a new Code Studio project? If you select "no" you may choose from a full list of existing projects.');
       if ($create_project) {
         return $this->createGitLabProject($cloud_application);

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -61,7 +61,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
 
     // Get Cloud application.
     $cloud_application = $this->getCloudApplication($cloud_application_uuid);
-    $project = $this->determineGitLabProject($cloud_application, $create_new_cs_project=FALSE);
+    $project = $this->determineGitLabProject($cloud_application, FALSE);
 
     // Migrate acquia-pipeline file
     $this->checkGitLabCiCdVariables($project);

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -61,7 +61,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
 
     // Get Cloud application.
     $cloud_application = $this->getCloudApplication($cloud_application_uuid);
-    $project = $this->determineGitLabProject($cloud_application);
+    $project = $this->determineGitLabProject($cloud_application, $create_new_cs_project=FALSE);
 
     // Migrate acquia-pipeline file
     $this->checkGitLabCiCdVariables($project);

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -4,9 +4,11 @@ namespace Acquia\Cli\Tests\Commands\CodeStudio;
 
 use Acquia\Cli\Command\CodeStudio\CodeStudioCiCdVariables;
 use Acquia\Cli\Command\CodeStudio\CodeStudioPipelinesMigrateCommand;
+use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\Commands\Ide\IdeRequiredTestTrait;
 use Acquia\Cli\Tests\CommandTestBase;
 use Acquia\Cli\Tests\TestBase;
+use AcquiaCloudApi\Response\ApplicationResponse;
 use Gitlab\Client;
 use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
@@ -131,6 +133,39 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase {
     $this->assertEquals('Build Drupal', $contents['setup']['stage']);
     $this->assertArrayHasKey('needs', $contents['setup']);
     $this->assertIsArray($contents['setup']['needs']);
+  }
+
+  public function testdetermineGitLabProjectMethod() {
+    $this->expectException(AcquiaCliException::class);
+
+    $class = new \ReflectionClass(CodeStudioPipelinesMigrateCommand::class);
+    $sut = $this->getMockBuilder(CodeStudioPipelinesMigrateCommand::class)
+      ->setMethods(['determineGitLabProject', 'setInput'])
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $input = $this->getMockBuilder(InputInterface::class)
+      ->setMethods(['getOption'])
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $input->expects($this->any())
+      ->method('getOption')
+      ->willReturn('');
+
+    $property = $class->getProperty('input');
+    $property->setAccessible(TRUE);
+    $property->setValue($class, $input);
+
+    // $sut->setInput($input);
+
+    $app_response = $this->getMockBuilder(ApplicationResponse::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $method = $class->getMethod('determineGitLabProject');
+    $method->setAccessible(TRUE);
+    return $method->invokeArgs($sut, [$app_response, FALSE]);
   }
 
 }


### PR DESCRIPTION
As discussed on GL-635 ticket, removing creation of code studio project from acli migrate command and throwing error messages.