### PR TITLE
IDE-2333: Upgrade to ACLI 2 in IDE

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -899,7 +899,7 @@ abstract class PullCommandBase extends CommandBase {
    * @return string
    */
   protected function getCurrentPhpVersion(): string {
-    return PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
+    return getenv('PHP_VERSION') ?: PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
   }
 
   /**


### PR DESCRIPTION
**Motivation**

Before running external commands (namely Composer as part of `pull:code`), ACLI tries to verify that the local PHP version matches the application version. ACLI assumes that the invoked PHP version is the default PHP version for an environment. That's not always true, and causes problems if you try to pull code while invoking ACLI with a specific PHP version (e.g. `/usr/bin/php8.1 acli`).

**Proposed changes**

PHP_VERSION is the actual default PHP version in IDE environments. Use PHP_VERSION if available, otherwise fall back to the version invoking ACLI.

**Alternatives considered**

There's still some edge cases this won't catch, such as if a customer has aliased `composer` to use a specific PHP version, but it's the best we can reasonably do.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `acli pull:code` and pick an application with a different PHP version than you run locally. See that you get a warning about mismatched PHP version.
4. Run `PHP_VERSION=[x.y] wacli pull:code`, where x.y matches your remote PHP version, to simulate pulling code in an IDE with PHP_VERSION set. See that the warning is avoided.

**Merge requirements**
- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
