### PR TITLE
IDE-2333: Detect PHP version in IDE via config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,13 +10,12 @@
   <arg name="cache" value="build/.phpcs-cache"/>
   <arg name="parallel" value="10"/>
 
-  <file>.</file>
+  <file>src</file>
+  <file>tests</file>
 
   <!-- Danger! Exclude patterns apply to the full file path, including parent directories of the current repository. -->
   <!-- Don't exclude common directory names like `build`, which will fail on Travis CI because of /home/travis/build/acquia/<project>. -->
   <!-- @see https://github.com/squizlabs/PHP_CodeSniffer/issues/981 -->
-  <exclude-pattern>var/</exclude-pattern>
-  <exclude-pattern>vendor/*</exclude-pattern>
   <exclude-pattern>tests/fixtures/*</exclude-pattern>
 
   <rule ref="AcquiaPHP" />

--- a/src/Command/Ide/IdeCommandBase.php
+++ b/src/Command/Ide/IdeCommandBase.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\Command\Ide;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\Cli\Helpers\IdeCommandTrait;
 use AcquiaCloudApi\Endpoints\Ides;
 use AcquiaCloudApi\Response\IdeResponse;
 
@@ -12,10 +13,7 @@ use AcquiaCloudApi\Response\IdeResponse;
  */
 abstract class IdeCommandBase extends CommandBase {
 
-  /**
-   * @var string
-   */
-  private $phpVersionFilePath;
+  use IdeCommandTrait;
 
   /**
    * @var string
@@ -108,13 +106,6 @@ abstract class IdeCommandBase extends CommandBase {
   }
 
   /**
-   * @return false|string
-   */
-  protected function getIdePhpVersion() {
-    return $this->localMachineHelper->readFile($this->getIdePhpVersionFilePath());
-  }
-
-  /**
    * @param string $file_path
    */
   public function setXdebugIniFilepath(string $file_path): void {
@@ -127,7 +118,7 @@ abstract class IdeCommandBase extends CommandBase {
    */
   public function getXdebugIniFilePath(): string {
     if (!isset($this->xdebugIniFilepath)) {
-      $this->xdebugIniFilepath = IdeCommandBase::DEFAULT_XDEBUG_INI_FILEPATH;
+      $this->xdebugIniFilepath = self::DEFAULT_XDEBUG_INI_FILEPATH;
     }
     return $this->xdebugIniFilepath;
   }
@@ -146,23 +137,6 @@ abstract class IdeCommandBase extends CommandBase {
       default:
         return '/home/ide/configs/php/xdebug3.ini';
     }
-  }
-
-  /**
-   * @param string $path
-   */
-  public function setPhpVersionFilePath(string $path): void {
-    $this->phpVersionFilePath = $path;
-  }
-
-  /**
-   * @return string
-   */
-  public function getIdePhpVersionFilePath(): string {
-    if (!isset($this->phpVersionFilePath)) {
-      $this->phpVersionFilePath = '/home/ide/configs/php/.version';
-    }
-    return $this->phpVersionFilePath;
   }
 
 }

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\Command\Pull;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\Cli\Helpers\IdeCommandTrait;
 use Acquia\Cli\Helpers\LoopHelper;
 use Acquia\Cli\Output\Checklist;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
@@ -34,6 +35,8 @@ use Symfony\Component\Filesystem\Path;
  * Class PullCommandBase.
  */
 abstract class PullCommandBase extends CommandBase {
+
+  use IdeCommandTrait;
 
   /**
    * @var Checklist
@@ -861,7 +864,7 @@ abstract class PullCommandBase extends CommandBase {
    */
   protected function checkEnvironmentPhpVersions(EnvironmentResponse $environment): void {
     if (!$this->environmentPhpVersionMatches($environment)) {
-      $this->io->warning("You are using PHP version {$this->getCurrentPhpVersion()} but the upstream environment {$environment->label} is using PHP version {$environment->configuration->php->version}");
+      $this->io->warning("You are using PHP version {$this->getIdePhpVersion()} but the upstream environment {$environment->label} is using PHP version {$environment->configuration->php->version}");
     }
   }
 
@@ -891,19 +894,8 @@ abstract class PullCommandBase extends CommandBase {
    * @return bool
    */
   protected function environmentPhpVersionMatches($environment): bool {
-    $current_php_version = $this->getCurrentPhpVersion();
+    $current_php_version = $this->getIdePhpVersion();
     return $environment->configuration->php->version === $current_php_version;
-  }
-
-  /**
-   * Get current PHP version using IDE-specific variables when possible.
-   *
-   * Disable mutation testing because we cannot mock PHP constants.
-   * @infection-ignore-all
-   * @return string
-   */
-  private function getCurrentPhpVersion(): string {
-    return getenv('PHP_VERSION') ?: PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
   }
 
   /**

--- a/src/Helpers/IdeCommandTrait.php
+++ b/src/Helpers/IdeCommandTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Acquia\Cli\Helpers;
+
+trait IdeCommandTrait {
+
+  /**
+   * @var string
+   */
+  private string $phpVersionFilePath;
+
+  /**
+   * @return string
+   */
+  protected function getIdePhpVersion(): string {
+    return $this->localMachineHelper->readFile($this->getIdePhpVersionFilePath());
+  }
+
+  /**
+   * @param string $path
+   */
+  public function setPhpVersionFilePath(string $path): void {
+    $this->phpVersionFilePath = $path;
+  }
+
+  /**
+   * @return string
+   */
+  public function getIdePhpVersionFilePath(): string {
+    if (!isset($this->phpVersionFilePath)) {
+      $this->phpVersionFilePath = '/home/ide/configs/php/.version';
+    }
+    return $this->phpVersionFilePath;
+  }
+
+}

--- a/src/Helpers/IdeCommandTrait.php
+++ b/src/Helpers/IdeCommandTrait.php
@@ -13,7 +13,7 @@ trait IdeCommandTrait {
    * @return string
    */
   protected function getIdePhpVersion(): string {
-    return $this->localMachineHelper->readFile($this->getIdePhpVersionFilePath());
+    return trim($this->localMachineHelper->readFile($this->getIdePhpVersionFilePath()));
   }
 
   /**

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -213,6 +213,7 @@ abstract class CommandTestBase extends TestBase {
     $local_machine_helper = $this->prophet->prophesize(LocalMachineHelper::class);
     $local_machine_helper->useTty()->willReturn(FALSE);
     $local_machine_helper->getLocalFilepath(Path::join($this->dataDir, 'acquia-cli.json'))->willReturn(Path::join($this->dataDir, 'acquia-cli.json'));
+    $local_machine_helper->readFile('/home/ide/configs/php/.version')->willReturn("7.1\n");
 
     return $local_machine_helper;
   }


### PR DESCRIPTION
**Motivation**

#1075 did not work as intended because the `PHP_VERSION` env var is not set when invoking ACLI via a specific version of PHP (rather than via the PHP wrapper)

**Proposed changes**

Revert functional changes in #1075 and instead read default PHP version from the version-selection config file.

**Alternatives considered**

Run `php --version` to discover the actual default PHP version, but then we're left with the challenge of parsing the version string which requires some ugly bash-fu.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Start an IDE (needs to have an active SSH agent, so probably in staging instead of local)
2. Apply changes to acli.sh from the IDE counterpart to this PR (to invoke ACLI via PHP 8)
3. Download the PR build of ACLI from transfer.sh and modify acli.sh to use it instead of the global ACLI version
4. Ensure that your IDE runs PHP 7.4 by default, and find a Cloud application that also runs PHP 7.4
5. Run `acli pull:code` and choose the PHP 7.4 application.

You should see that ACLI runs fine and without throwing any warnings. This implies that ACLI is running via PHP 8 while still properly detecting that the environment is PHP 7.4. 

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
