### PR TITLE
CLI-549: Allow for realm specificity

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -133,7 +133,7 @@ trait CodeStudioCommandTrait {
       $this->io->writeln([
         "",
         "This will configure AutoDevOps for a Code Studio project using credentials",
-        "(an API Token and SSH Key) belonging to your current Acquia Cloud Platform user account.",
+        "(an API Token and SSH Key) belonging to your current Acquia Cloud user account.",
         "Before continuing, make sure that you're logged into the right Acquia Cloud Platform user account.",
         "",
         "<comment>Typically this command should only be run once per application</comment>",

--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -133,7 +133,7 @@ trait CodeStudioCommandTrait {
       $this->io->writeln([
         "",
         "This will configure AutoDevOps for a Code Studio project using credentials",
-        "(an API Token and SSH Key) belonging to your current Acquia Cloud user account.",
+        "(an API Token and SSH Key) belonging to your current Acquia Cloud Platform user account.",
         "Before continuing, make sure that you're logged into the right Acquia Cloud Platform user account.",
         "",
         "<comment>Typically this command should only be run once per application</comment>",

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -407,7 +407,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * Add argument and usage examples for applicationUuid.
    */
   protected function acceptApplicationUuid() {
-    $this->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The Cloud Platform application UUID or alias (i.e. a sitegroup optionally prefixed with the realm)')
+    $this->addArgument('applicationUuid', InputArgument::OPTIONAL, 'The Cloud Platform application UUID or alias (i.e. an application name optionally prefixed with the realm)')
       ->addUsage(self::getDefaultName() . ' [<applicationAlias>]')
       ->addUsage(self::getDefaultName() . ' myapp')
       ->addUsage(self::getDefaultName() . ' prod:myapp')

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1134,7 +1134,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     }
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $acquia_cloud_client->addQuery('filter', 'hosting=@' . $application_alias);
-    // Allow Cloud users with 'support' role to resolve aliases for applications to
+    // Allow Cloud Platform users with 'support' role to resolve aliases for applications to
     // which they don't explicitly belong.
     $account_resource = new Account($acquia_cloud_client);
     $account = $account_resource->get();
@@ -1742,7 +1742,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
         return $customer_application->uuid;
       }
       catch (AcquiaCliException $exception) {
-        throw new AcquiaCliException("The {applicationUuid} argument must be a valid UUID or unique application alias accessible to your Cloud user.");
+        throw new AcquiaCliException("The {applicationUuid} argument must be a valid UUID or unique application alias accessible to your Cloud Platform user.");
       }
     }
     return $application_uuid_argument;

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1133,6 +1133,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       $application_alias = '*:' . $application_alias;
     }
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    // No need to clear this query later since getClient() is a factory method.
     $acquia_cloud_client->addQuery('filter', 'hosting=@' . $application_alias);
     // Allow Cloud Platform users with 'support' role to resolve aliases for applications to
     // which they don't explicitly belong.

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -51,8 +51,9 @@ class ExceptionListener {
     }
 
     if ($error instanceof AcquiaCliException) {
-      switch ($errorMessage) {
-        case 'The {applicationUuid} argument must be a valid UUID or unique application alias accessible to your Cloud Platform user.':
+      switch ($error->getRawMessage()) {
+        case 'No applications match the alias {applicationAlias}':
+        case 'Multiple applications match the alias {applicationAlias}':
           $this->writeApplicationAliasHelp();
           break;
         case '{environmentId} must be a valid UUID or site alias.':
@@ -101,7 +102,8 @@ class ExceptionListener {
    *
    */
   protected function writeApplicationAliasHelp(): void {
-    $this->helpMessages[] = "<bg={$this->messagesBgColor};options=bold>applicationUuid</> can also be an application alias. E.g. <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>myapp</>." . PHP_EOL
+    $this->helpMessages[] = "The <bg={$this->messagesBgColor};options=bold>applicationUuid</> argument must be a valid UUID or unique application alias accessible to your Cloud Platform user." . PHP_EOL . PHP_EOL
+      . "An alias consists of an application name optionally prefixed with a hosting realm, e.g. <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>myapp</> or <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>prod.myapp</>." . PHP_EOL . PHP_EOL
       . "Run <bg={$this->messagesBgColor};options=bold>acli remote:aliases:list</> to see a list of all available aliases.";
   }
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -52,7 +52,7 @@ class ExceptionListener {
 
     if ($error instanceof AcquiaCliException) {
       switch ($errorMessage) {
-        case 'The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.':
+        case 'The {applicationUuid} argument must be a valid UUID or unique application alias accessible to your Cloud Platform user.':
           $this->writeApplicationAliasHelp();
           break;
         case '{environmentId} must be a valid UUID or site alias.':

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -63,6 +63,9 @@ class ExceptionApplicationTest extends ApplicationTestBase {
     self::assertStringContainsString('Delete an existing IDE', $buffer);
   }
 
+  /**
+   * @throws \Exception
+   */
   public function testMissingEnvironmentUuid(): void {
     $this->setInput([
       'command' => 'log:tail',
@@ -71,8 +74,13 @@ class ExceptionApplicationTest extends ApplicationTestBase {
     self::assertStringContainsString('can also be a site alias.', $buffer);
   }
 
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \Exception
+   */
   public function testInvalidEnvironmentUuid(): void {
     $this->mockAccountRequest();
+    $this->mockApplicationsRequest();
     $this->setInput([
       'command' => 'log:tail',
       'environmentId' => 'aoeuth.aoeu',
@@ -81,6 +89,9 @@ class ExceptionApplicationTest extends ApplicationTestBase {
     self::assertStringContainsString('can also be a site alias.', $buffer);
   }
 
+  /**
+   * @throws \Exception
+   */
   public function testMissingApplicationUuid(): void {
     $this->setInput([
       'command' => 'ide:open',
@@ -89,8 +100,13 @@ class ExceptionApplicationTest extends ApplicationTestBase {
     self::assertStringContainsString('Could not determine Cloud Application.', $buffer);
   }
 
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \Exception
+   */
   public function testInvalidApplicationUuid(): void {
     $this->mockAccountRequest();
+    $this->mockApplicationsRequest();
     $this->setInput([
       'command' => 'ide:open',
       'applicationUuid' => 'aoeuthao',

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -112,7 +112,7 @@ class ExceptionApplicationTest extends ApplicationTestBase {
       'applicationUuid' => 'aoeuthao',
     ]);
     $buffer = $this->runApp();
-    self::assertStringContainsString('can also be an application alias.', $buffer);
+    self::assertStringContainsString('An alias consists of an application name', $buffer);
   }
 
 }

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -162,12 +162,11 @@ class ApiCommandTest extends CommandTestBase {
    * @throws \Psr\Cache\InvalidArgumentException
    */
   public function testConvertApplicationAliasToUuidArgument($support): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $this->mockApplicationsRequest();
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockApplicationRequest();
     $this->command = $this->getApiCommandByName('api:applications:find');
     $alias = 'devcloud2';
-    $this->clientProphecy->clearQuery()->shouldBeCalled();
     $this->mockAccountRequest($support);
 
     $this->executeCommand(['applicationUuid' => $alias], [
@@ -195,7 +194,7 @@ class ApiCommandTest extends CommandTestBase {
       $this->executeCommand(['applicationUuid' => $alias], []);
     }
     catch (AcquiaCliException $exception) {
-      $this->assertEquals("The {applicationUuid} argument must be a valid UUID or application alias that is accessible to your Cloud user.", $exception->getMessage());
+      $this->assertEquals("The {applicationUuid} argument must be a valid UUID or unique application alias accessible to your Cloud user.", $exception->getMessage());
     }
     $this->prophet->checkPredictions();
   }

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -185,7 +185,7 @@ class ApiCommandTest extends CommandTestBase {
   }
 
   public function testConvertInvalidApplicationAliasToUuidArgument(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $this->mockApplicationsRequest(0);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:invalidalias')->shouldBeCalled();
     $this->mockAccountRequest();
     $this->command = $this->getApiCommandByName('api:applications:find');
@@ -194,7 +194,22 @@ class ApiCommandTest extends CommandTestBase {
       $this->executeCommand(['applicationUuid' => $alias], []);
     }
     catch (AcquiaCliException $exception) {
-      $this->assertEquals("The {applicationUuid} argument must be a valid UUID or unique application alias accessible to your Cloud Platform user.", $exception->getMessage());
+      $this->assertEquals("No applications match the alias *:invalidalias", $exception->getMessage());
+    }
+    $this->prophet->checkPredictions();
+  }
+
+  public function testConvertNonUniqueApplicationAliasToUuidArgument(): void {
+    $this->mockApplicationsRequest(2, FALSE);
+    $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
+    $this->mockAccountRequest();
+    $this->command = $this->getApiCommandByName('api:applications:find');
+    $alias = 'devcloud2';
+    try {
+      $this->executeCommand(['applicationUuid' => $alias], []);
+    }
+    catch (AcquiaCliException $exception) {
+      $this->assertEquals("Multiple applications match the alias *:devcloud2", $exception->getMessage());
     }
     $this->prophet->checkPredictions();
   }

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -194,7 +194,7 @@ class ApiCommandTest extends CommandTestBase {
       $this->executeCommand(['applicationUuid' => $alias], []);
     }
     catch (AcquiaCliException $exception) {
-      $this->assertEquals("The {applicationUuid} argument must be a valid UUID or unique application alias accessible to your Cloud user.", $exception->getMessage());
+      $this->assertEquals("The {applicationUuid} argument must be a valid UUID or unique application alias accessible to your Cloud Platform user.", $exception->getMessage());
     }
     $this->prophet->checkPredictions();
   }

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -162,7 +162,7 @@ class ApiCommandTest extends CommandTestBase {
    * @throws \Psr\Cache\InvalidArgumentException
    */
   public function testConvertApplicationAliasToUuidArgument($support): void {
-    $this->mockApplicationsRequest();
+    $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockApplicationRequest();
     $this->command = $this->getApiCommandByName('api:applications:find');
@@ -200,7 +200,7 @@ class ApiCommandTest extends CommandTestBase {
   }
 
   public function testConvertEnvironmentAliasToUuidArgument(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applications_response = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->clientProphecy->clearQuery()->shouldBeCalled();
     $this->mockEnvironmentsRequest($applications_response);
@@ -228,7 +228,7 @@ class ApiCommandTest extends CommandTestBase {
   }
 
   public function testConvertInvalidEnvironmentAliasToUuidArgument(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applications_response = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->clientProphecy->clearQuery()->shouldBeCalled();
     $this->mockEnvironmentsRequest($applications_response);

--- a/tests/phpunit/src/Commands/ClearCacheCommandTest.php
+++ b/tests/phpunit/src/Commands/ClearCacheCommandTest.php
@@ -29,6 +29,7 @@ class ClearCacheCommandTest extends CommandTestBase {
     // Request for applications.
     $applications_response = $this->getMockResponseFromSpec('/applications',
       'get', '200');
+    $applications_response = $this->filterApplicationsResponse($applications_response, 1);
     $this->clientProphecy->request('get', '/applications')
       ->willReturn($applications_response->{'_embedded'}->items)
       // Ensure this is only called once, even though we execute the command twice.
@@ -40,7 +41,6 @@ class ClearCacheCommandTest extends CommandTestBase {
     $this->mockAccountRequest();
 
     $alias = 'devcloud2';
-    $this->clientProphecy->clearQuery()->shouldBeCalled();
     $args = ['applicationUuid' => $alias];
     $inputs = [
       // Would you like to link the Cloud application Sample application to this repository?

--- a/tests/phpunit/src/Commands/ClearCacheCommandTest.php
+++ b/tests/phpunit/src/Commands/ClearCacheCommandTest.php
@@ -29,7 +29,7 @@ class ClearCacheCommandTest extends CommandTestBase {
     // Request for applications.
     $applications_response = $this->getMockResponseFromSpec('/applications',
       'get', '200');
-    $applications_response = $this->filterApplicationsResponse($applications_response, 1);
+    $applications_response = $this->filterApplicationsResponse($applications_response, 1, TRUE);
     $this->clientProphecy->request('get', '/applications')
       ->willReturn($applications_response->{'_embedded'}->items)
       // Ensure this is only called once, even though we execute the command twice.

--- a/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
@@ -17,7 +17,7 @@ abstract class SshCommandTestBase extends CommandTestBase {
    * @throws \Psr\Cache\InvalidArgumentException
    */
   protected function mockForGetEnvironmentFromAliasArg(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applications_response = $this->mockApplicationsRequest(1);
     $this->mockEnvironmentsRequest($applications_response);
     $this->clientProphecy->clearQuery()->shouldBeCalled();
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -189,17 +189,19 @@ abstract class TestBase extends TestCase {
    * While hosting ids are not guaranteed to be unique, in practice they are
    * unique. This renames one of the applications to be unique.
    *
-   * @see CXAPI-9647
-   *
    * @param object $applications_response
-   * @param int $filter_results
+   * @param int $count
    *
    * @return object
+   *@see CXAPI-9647
+   *
    */
-  public function filterApplicationsResponse(object $applications_response, int $filter_results): object {
-    $applications_response->{'_embedded'}->items[1]->hosting->id = 'devcloud:devcloud3';
-    $applications_response->total = $filter_results;
-    $applications_response->{'_embedded'}->items = array_slice($applications_response->{'_embedded'}->items, 0, $filter_results);
+  public function filterApplicationsResponse(object $applications_response, int $count, bool $unique): object {
+    if ($unique) {
+      $applications_response->{'_embedded'}->items[1]->hosting->id = 'devcloud:devcloud3';
+    }
+    $applications_response->total = $count;
+    $applications_response->{'_embedded'}->items = array_slice($applications_response->{'_embedded'}->items, 0, $count);
     return $applications_response;
   }
 
@@ -522,17 +524,17 @@ abstract class TestBase extends TestCase {
   }
 
   /**
-   * @param int $filter_results
+   * @param int $count
    *   The number of applications to return. Use this to simulate query filters.
    *
    * @return object
    * @throws \Psr\Cache\InvalidArgumentException
    */
-  public function mockApplicationsRequest(int $filter_results = 2): object {
+  public function mockApplicationsRequest(int $count = 2, bool $unique = TRUE): object {
     // Request for applications.
     $applications_response = $this->getMockResponseFromSpec('/applications',
       'get', '200');
-    $applications_response = $this->filterApplicationsResponse($applications_response, $filter_results);
+    $applications_response = $this->filterApplicationsResponse($applications_response, $count, $unique);
     $this->clientProphecy->request('get', '/applications')
       ->willReturn($applications_response->{'_embedded'}->items)
       ->shouldBeCalled();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->

We consider an application alias to be equivalent to an application name (nee "sitegroup"). The problem is that multiple realms can have identically-named applications, leading to undefined behavior for applications that exist across multiple realms. A fully-qualified application alias should include both the realm and name (together, the "hosting id").

**Proposed changes**

Make the application equivalent to a "hosting id", which is a combination of application realm and name in the form `realm:name`. If realm is omitted but the alias is still unique (i.e. matching only one app), the alias will work as before and return that app. If the realm is omitted and multiple applications match, throw an exception.

Theoretically it is possible for multiple applications in the _same_ realm to have an identical name, but in practice I don't think this ever happens. If it ever does happen, still throw an exception and the user will need to use an application uuid instead of an alias.

**Testing steps**

Run `acli ckc` and `acli self:clear-caches`.

```
$ acli ide:list pipelinesvalidation2
# Should return IDEs for this app without prompts or errors

$ acli ide:list pipelinesvalida
# Should throw an error due to invalid alias as well as help text about aliases

$ acli ide:list b[REDACTED]t
# Should throw an error due to a non-unique alias and list matching valid aliases as well as help text

$ acli ide:list prod:b[REDACTED]t
# Should list IDEs for this application, if any
```


