### PR TITLE
Allowing to setup the nextjs project with  command

### DIFF
--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -57,12 +57,12 @@ class NewCommand extends CommandBase {
     $output->writeln('<info>Creating project. This may take a few minutes.</info>');
 
     if ($project === 'acquia_next_acms') {
-      $success_message = "<info>New Next JS project created in $dir. 🎉";
+      $success_message = "<info>New Next JS project created in $dir. 🎉</info>";
       $this->localMachineHelper->checkRequiredBinariesExist(['node']);
       $this->createNextJsProject($dir);
     }
     else {
-      $success_message = "<info>New 💧 Drupal project created in $dir. 🎉";
+      $success_message = "<info>New 💧 Drupal project created in $dir. 🎉</info>";
       $this->localMachineHelper->checkRequiredBinariesExist(['composer']);
       $this->createDrupalProject($distros[$project], $dir);
     }
@@ -89,7 +89,7 @@ class NewCommand extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function createNextJsProject(string $dir): void {
+  private function createNextJsProject(string $dir): void {
     $process = $this->localMachineHelper->execute([
       'npx',
       'create-next-app',

--- a/tests/phpunit/src/Commands/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/NewCommandTest.php
@@ -61,7 +61,7 @@ class NewCommandTest extends CommandTestBase {
 
     $local_machine_helper = $this->mockLocalMachineHelper();
 
-    $this->mockGetFilesystem($local_machine_helper);
+    $mock_file_system = $this->mockGetFilesystem($local_machine_helper);
     $local_machine_helper->checkRequiredBinariesExist(["composer"])->shouldBeCalled();
     $this->mockExecuteComposerCreate($this->newProjectDir, $local_machine_helper, $process, $project);
     $local_machine_helper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
@@ -79,10 +79,11 @@ class NewCommandTest extends CommandTestBase {
     ], $inputs);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
+    $this->assertStringContainsString('Acquia recommends most customers use acquia/drupal-recommended-project to setup a Drupal project', $output);
     $this->assertStringContainsString('Choose a starting project', $output);
     $this->assertStringContainsString($project, $output);
+    $this->assertTrue($mock_file_system->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');
     $this->assertStringContainsString('New 💧 Drupal project created in ' . $this->newProjectDir, $output);
-
   }
 
   /**
@@ -106,7 +107,7 @@ class NewCommandTest extends CommandTestBase {
 
     $local_machine_helper = $this->mockLocalMachineHelper();
 
-    $this->mockGetFilesystem($local_machine_helper);
+    $mock_file_system = $this->mockGetFilesystem($local_machine_helper);
 
     $local_machine_helper->checkRequiredBinariesExist(["node"])->shouldBeCalled();
     $this->mockExecuteNpxCreate($this->newProjectDir, $local_machine_helper, $process);
@@ -125,8 +126,10 @@ class NewCommandTest extends CommandTestBase {
     ], $inputs);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
+    $this->assertStringContainsString('acquia/next-acms is a starter template for building a headless site', $output);
     $this->assertStringContainsString('Choose a starting project', $output);
     $this->assertStringContainsString($project, $output);
+    $this->assertTrue($mock_file_system->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');
     $this->assertStringContainsString('New Next JS project created in ' . $this->newProjectDir, $output);
   }
 


### PR DESCRIPTION
**Motivation**

Fixes https://github.com/acquia/cli/issues/1082 and adds to setup nextjs project from https://github.com/acquia/next-acms as

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

command to run -
```
./bin/acli new
```
<img width="1090" alt="Screenshot 2022-07-13 at 5 15 24 PM" src="https://user-images.githubusercontent.com/1336423/178726339-ff0374e9-4db0-4236-916a-25639b25c203.png">


