### PR TITLE
CLI-825: Realm support for environment aliases

### DIFF
--- a/src/Helpers/AliasCache.php
+++ b/src/Helpers/AliasCache.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Acquia\Cli\Helpers;
+
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+class AliasCache extends FilesystemAdapter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get(string $key, callable $callback, float $beta = NULL, array &$metadata = NULL): mixed {
+    // Aliases format is `realm:name.env`, but `:` is not a legal character.
+    $key = str_replace(':', '.', $key);
+    return parent::get($key, $callback, $beta, $metadata);
+  }
+
+}

--- a/tests/phpunit/src/Application/HelpApplicationTest.php
+++ b/tests/phpunit/src/Application/HelpApplicationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Acquia\Cli\Tests\Application;
+
+use Acquia\Cli\Tests\ApplicationTestBase;
+
+/**
+ * Test the 'help' command.
+ *
+ * This must be run as an application test since the help command does not
+ * inherit from CommandBase and needs access to other commands in the service
+ * container.
+ */
+class HelpApplicationTest extends ApplicationTestBase {
+
+  /**
+   * @throws \Exception
+   */
+  public function testApplicationAliasHelp(): void {
+    $this->setInput([
+      'command' => 'help',
+      'command_name' => 'app:link',
+    ]);
+    $buffer = $this->runApp();
+    $this->assertStringContainsString('The Cloud Platform application UUID or alias (i.e. an application name optionally prefixed with the realm)', $buffer);
+    $this->assertStringContainsString('Usage:
+  app:link [<applicationUuid>]
+  link
+  app:link [<applicationAlias>]
+  app:link myapp
+  app:link prod:myapp
+  app:link abcd1234-1111-2222-3333-0e02b2c3d470', $buffer);
+  }
+
+  /**
+   * @throws \Exception
+   */
+  public function testEnvironmentAliasHelp(): void {
+    $this->setInput([
+      'command' => 'help',
+      'command_name' => 'log:tail',
+    ]);
+    $buffer = $this->runApp();
+    $this->assertStringContainsString('The Cloud Platform environment ID or alias (i.e. an application and environment name optionally prefixed with the realm)', $buffer);
+    $this->assertStringContainsString('Usage:
+  app:log:tail [<environmentId>]
+  tail
+  log:tail
+  app:log:tail [<environmentAlias>]
+  app:log:tail myapp.dev
+  app:log:tail prod:myapp.dev
+  app:log:tail 12345-abcd1234-1111-2222-3333-0e02b2c3d470', $buffer);
+  }
+
+}

--- a/tests/phpunit/src/ApplicationTestBase.php
+++ b/tests/phpunit/src/ApplicationTestBase.php
@@ -50,7 +50,7 @@ class ApplicationTestBase extends TestBase {
     return $output->fetch();
   }
 
-  protected function setInput($args): void {
+  protected function setInput(array $args): void {
     $input = new ArrayInput($args);
     $input->setInteractive(FALSE);
     $this->kernel->getContainer()->set(InputInterface::class, $input);

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -209,15 +209,31 @@ class ApiCommandTest extends CommandTestBase {
       $this->executeCommand(['applicationUuid' => $alias], []);
     }
     catch (AcquiaCliException $exception) {
-      $this->assertEquals("Multiple applications match the alias *:devcloud2", $exception->getMessage());
+      $output=$this->getDisplay();
+      $this->assertStringContainsString('Use a unique application alias: devcloud:devcloud2, devcloud:devcloud2', $output);
+      $this->assertEquals('Multiple applications match the alias *:devcloud2', $exception->getMessage());
     }
+    $this->prophet->checkPredictions();
+  }
+
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \Exception
+   */
+  public function testConvertApplicationAliasWithRealmToUuidArgument(): void {
+    $this->mockApplicationsRequest(1, FALSE);
+    $this->clientProphecy->addQuery('filter', 'hosting=@devcloud:devcloud2')->shouldBeCalled();
+    $this->mockApplicationRequest();
+    $this->mockAccountRequest();
+    $this->command = $this->getApiCommandByName('api:applications:find');
+    $alias = 'devcloud:devcloud2';
+    $this->executeCommand(['applicationUuid' => $alias], []);
     $this->prophet->checkPredictions();
   }
 
   public function testConvertEnvironmentAliasToUuidArgument(): void {
     $applications_response = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
-    $this->clientProphecy->clearQuery()->shouldBeCalled();
     $this->mockEnvironmentsRequest($applications_response);
     $this->mockAccountRequest();
 
@@ -245,7 +261,6 @@ class ApiCommandTest extends CommandTestBase {
   public function testConvertInvalidEnvironmentAliasToUuidArgument(): void {
     $applications_response = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
-    $this->clientProphecy->clearQuery()->shouldBeCalled();
     $this->mockEnvironmentsRequest($applications_response);
     $this->mockAccountRequest();
     $this->command = $this->getApiCommandByName('api:environments:find');

--- a/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
@@ -19,7 +19,6 @@ abstract class SshCommandTestBase extends CommandTestBase {
   protected function mockForGetEnvironmentFromAliasArg(): void {
     $applications_response = $this->mockApplicationsRequest(1);
     $this->mockEnvironmentsRequest($applications_response);
-    $this->clientProphecy->clearQuery()->shouldBeCalled();
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockAccountRequest();
   }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->

```
$ acli api:environments:ssl gardens-prod:c[snip]i.prod

In CacheItem.php line 159:

  Cache key "gardens-prod:c[snip]i.prod" contains reserved characters "{}()/\@:".
api:environments:ssl-settings-find <environmentId>
```

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Abstract cache to reduce code duplication so we don't overlook this again

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Try using an environment alias with realm again. Note that `gardens` is not 
