### PR TITLE
CLI-827: Deprecated usage of reactphp/event-loop

### DIFF
--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -54,7 +54,7 @@ class TaskWaitCommand extends CommandBase {
       throw new AcquiaCliException("Input JSON must contain the _links.notification.href property.");
     }
 
-    return $this->validateUuid($input->getArgument('notification-uuid'));
+    return self::validateUuid($input->getArgument('notification-uuid'));
   }
 
 }

--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -7,7 +7,6 @@ use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\LoopHelper;
 use AcquiaCloudApi\Endpoints\Notifications;
 use AcquiaCloudApi\Response\NotificationResponse;
-use React\EventLoop\Factory;
 use React\EventLoop\Loop;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,7 +22,7 @@ class TaskWaitCommand extends CommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Wait for a task to complete')
       ->addArgument('notification-uuid', InputArgument::REQUIRED, 'The UUID of the task notification returned by the Cloud API')
       ->setHelp('This command will accepts either a notification uuid as an argument or else a json string passed through standard input. The json string must contain the _links->notification->href property.')
@@ -37,13 +36,9 @@ class TaskWaitCommand extends CommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $notification_uuid = $this->getNotificationUuid($input);
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    // $loop is statically cached by Loop::get(). To prevent it
-    // persisting into other instances we must use Factory::create() to reset it.
-    // @phpstan-ignore-next-line
-    Loop::set(Factory::create());
     $loop = Loop::get();
     $spinner = LoopHelper::addSpinnerToLoop($loop, "Waiting for task $notification_uuid to complete", $this->output);
     $notifications_resource = new Notifications($acquia_cloud_client);

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -26,6 +26,7 @@ use AcquiaCloudApi\Endpoints\Subscriptions;
 use AcquiaCloudApi\Response\AccountResponse;
 use AcquiaCloudApi\Response\ApplicationResponse;
 use AcquiaCloudApi\Response\EnvironmentResponse;
+use AcquiaCloudApi\Response\NotificationResponse;
 use AcquiaCloudApi\Response\SubscriptionResponse;
 use AcquiaLogstream\LogstreamManager;
 use Closure;
@@ -39,7 +40,6 @@ use loophp\phposinfo\OsInfo;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
-use React\EventLoop\Loop;
 use stdClass;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Console\Command\Command;
@@ -1788,41 +1788,33 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @param \AcquiaCloudApi\Connector\Client $acquia_cloud_client
    * @param string $uuid
    * @param string $message
-   *
-   * @return bool
    */
-  protected function waitForNotificationToComplete(Client $acquia_cloud_client, string $uuid, string $message): bool {
-    $loop = Loop::get();
-    [$spinner, $timer] = LoopHelper::addSpinnerToLoop($loop, $message, $this->output);
+  protected function waitForNotificationToComplete(Client $acquia_cloud_client, string $uuid, string $message, $success = NULL): void {
     $notifications_resource = new Notifications($acquia_cloud_client);
-
-    $callback = function () use ($loop, $spinner, $notifications_resource, $uuid) {
-      try {
-        $notification = $notifications_resource->get($uuid);
-        if ($notification->progress === 100) {
-          LoopHelper::finishSpinner($spinner);
-          $this->logger->debug("Notification is complete with status {$notification->status}.");
-        }
-      }
-      catch (\Exception $e) {
-        $this->logger->debug($e->getMessage());
-      }
+    $checkNotificationStatus = static function () use ($notifications_resource, $uuid) {
+      return $notifications_resource->get($uuid)->progress === 100;
     };
-    // Run once immediately to speed up tests.
-    $loop->addTimer(0.1, $callback);
-    $loop->addPeriodicTimer(5, $callback);
-    LoopHelper::addTimeoutToLoop($loop, 45, $spinner);
-
-    // Start the loop.
-    try {
-      $loop->run();
+    if ($success === NULL) {
+      $success = function () use ($notifications_resource, $uuid) {
+        $this->writeCompletedMessage($notifications_resource->get($uuid));
+      };
     }
-    catch (AcquiaCliException $exception) {
-      $this->io->error($exception->getMessage());
-      return FALSE;
-    }
+    LoopHelper::getLoopy($this->output, $this->io, $message, $checkNotificationStatus, $success);
+  }
 
-    return TRUE;
+  /**
+   * @param \AcquiaCloudApi\Response\NotificationResponse $notification
+   * @param string $notification_uuid
+   */
+  protected function writeCompletedMessage(NotificationResponse $notification): void {
+    $duration = strtotime($notification->completed_at) - strtotime($notification->created_at);
+    $completed_at = date("D M j G:i:s T Y", strtotime($notification->completed_at));
+    $this->io->success([
+      "The task with notification uuid {$notification->uuid} completed with status \"{$notification->status}\"" . PHP_EOL .
+      "on " . $completed_at,
+      "Task type: " . $notification->label . PHP_EOL .
+      "Duration: $duration seconds",
+    ]);
   }
 
   /**

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1799,7 +1799,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
         $this->writeCompletedMessage($notifications_resource->get($uuid));
       };
     }
-    LoopHelper::getLoopy($this->output, $this->io, $message, $checkNotificationStatus, $success);
+    LoopHelper::getLoopy($this->output, $this->io, $this->logger, $message, $checkNotificationStatus, $success);
   }
 
   /**

--- a/src/Command/Env/EnvCreateCommand.php
+++ b/src/Command/Env/EnvCreateCommand.php
@@ -74,7 +74,7 @@ class EnvCreateCommand extends CommandBase {
     };
     $this->waitForNotificationToComplete($acquia_cloud_client, $notification_uuid, "Waiting for the environment to be ready. This usually takes 2 - 15 minutes.", $success);
 
-    return 1;
+    return 0;
   }
 
   /**

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -124,7 +124,7 @@ class IdeCreateCommand extends IdeCommandBase {
       $this->writeIdeLinksToScreen();
     };
     $spinnerMessage = 'Waiting for the IDE to be ready. This usually takes 2 - 15 minutes.';
-    LoopHelper::getLoopy($this->output, $this->io, $spinnerMessage, $checkIdeStatus, $success, $failure);
+    LoopHelper::getLoopy($this->output, $this->io, $this->logger, $spinnerMessage, $checkIdeStatus, $success, $failure);
 
     return 0;
   }

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -132,7 +132,7 @@ abstract class PullCommandBase extends CommandBase {
     }
     if (!$no_import) {
       // Verify database connection.
-      //$this->connectToLocalDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $this->getOutputCallback($output, $this->checklist));
+      $this->connectToLocalDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $this->getOutputCallback($output, $this->checklist));
     }
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $source_environment = $this->determineEnvironment($input, $output, TRUE);

--- a/src/Helpers/LoopHelper.php
+++ b/src/Helpers/LoopHelper.php
@@ -7,13 +7,13 @@ use React\EventLoop\Loop;
 
 class LoopHelper {
 
-  public static function getLoopy($output, $io, $spinnerMessage, $statusCallback, $successCallback, $timeoutCallback = NULL): void {
+  public static function getLoopy($output, $io, $logger, $spinnerMessage, $statusCallback, $successCallback, $timeoutCallback = NULL): void {
     $timers = [];
     $spinner = new Spinner($output, 4);
     $spinner->setMessage($spinnerMessage);
     $spinner->start();
 
-    $periodicCallback = static function () use (&$timers, $spinner, $io, $statusCallback, $successCallback) {
+    $periodicCallback = static function () use (&$timers, $spinner, $logger, $statusCallback, $successCallback) {
       try {
         if ($statusCallback()) {
           foreach ($timers as $timer) {
@@ -25,7 +25,7 @@ class LoopHelper {
         }
       }
       catch (\Exception $e) {
-        $io->error($e->getMessage());
+        $logger->debug($e->getMessage());
       }
     };
 

--- a/src/Helpers/LoopHelper.php
+++ b/src/Helpers/LoopHelper.php
@@ -4,10 +4,37 @@ namespace Acquia\Cli\Helpers;
 
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Spinner\Spinner;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
 
 class LoopHelper {
+
+  public static function getLoopy($message, $output, $checkStatus, $message2, $logger) {
+    $loop = Loop::get();
+    $timers = [];
+    [$spinner, $spinnerTimer] = LoopHelper::addSpinnerToLoop($loop, $message, $output);
+    $timers[] = $spinnerTimer;
+    $checkIdeStatus = function () use ($loop, $spinner, &$timers, $checkStatus, $message2, $output, $logger) {
+      try {
+        if ($checkStatus) {
+          LoopHelper::finishSpinner($spinner);
+          foreach ($timers as $timer) {
+            $loop->cancelTimer($timer);
+          }
+          $timers = [];
+          $output->writeln('');
+          $output->writeln('<info>' . $message2 . '</info>');
+        }
+      }
+      catch (\Exception $e) {
+        $logger->debug($e->getMessage());
+      }
+    };
+    $timers[] = $loop->addPeriodicTimer(5, $checkIdeStatus);
+    $timers[] = LoopHelper::addTimeoutToLoop($loop, 45, $spinner, $timers);
+    return $loop;
+  }
 
   /**
    * @param \React\EventLoop\LoopInterface $loop
@@ -16,22 +43,22 @@ class LoopHelper {
    *
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    *
-   * @return \Acquia\Cli\Output\Spinner\Spinner
+   * @return array
    */
   public static function addSpinnerToLoop(
     LoopInterface $loop,
     $message,
     $output
-  ): Spinner {
+  ): array {
     $spinner = new Spinner($output, 4);
     $spinner->setMessage($message);
     $spinner->start();
-    $loop->addPeriodicTimer($spinner->interval(),
+    $timer = $loop->addPeriodicTimer($spinner->interval(),
       static function () use ($spinner) {
         $spinner->advance();
       });
 
-    return $spinner;
+    return [$spinner, $timer];
   }
 
   /**
@@ -44,11 +71,15 @@ class LoopHelper {
   public static function addTimeoutToLoop(
     LoopInterface $loop,
     float $minutes,
-    Spinner $spinner
+    Spinner $spinner,
+    array $timers
   ): TimerInterface {
-    return $loop->addTimer($minutes * 60, function () use ($loop, $minutes, $spinner) {
+    return $loop->addTimer($minutes * 60, function () use ($loop, $minutes, $spinner, &$timers) {
       self::finishSpinner($spinner);
-      $loop->stop();
+      foreach ($timers as $timer) {
+        $loop->cancelTimer($timer);
+      }
+      $timers = [];
       throw new AcquiaCliException("Timed out after $minutes minutes!");
     });
   }

--- a/src/Helpers/LoopHelper.php
+++ b/src/Helpers/LoopHelper.php
@@ -2,93 +2,50 @@
 
 namespace Acquia\Cli\Helpers;
 
-use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Spinner\Spinner;
 use React\EventLoop\Loop;
-use React\EventLoop\LoopInterface;
-use React\EventLoop\TimerInterface;
 
 class LoopHelper {
 
-  public static function getLoopy($message, $output, $checkStatus, $message2, $logger) {
-    $loop = Loop::get();
+  public static function getLoopy($output, $io, $spinnerMessage, $statusCallback, $successCallback, $timeoutCallback = NULL): void {
     $timers = [];
-    [$spinner, $spinnerTimer] = LoopHelper::addSpinnerToLoop($loop, $message, $output);
-    $timers[] = $spinnerTimer;
-    $checkIdeStatus = function () use ($loop, $spinner, &$timers, $checkStatus, $message2, $output, $logger) {
-      try {
-        if ($checkStatus) {
-          LoopHelper::finishSpinner($spinner);
-          foreach ($timers as $timer) {
-            $loop->cancelTimer($timer);
-          }
-          $timers = [];
-          $output->writeln('');
-          $output->writeln('<info>' . $message2 . '</info>');
-        }
-      }
-      catch (\Exception $e) {
-        $logger->debug($e->getMessage());
-      }
-    };
-    $timers[] = $loop->addPeriodicTimer(5, $checkIdeStatus);
-    $timers[] = LoopHelper::addTimeoutToLoop($loop, 45, $spinner, $timers);
-    return $loop;
-  }
-
-  /**
-   * @param \React\EventLoop\LoopInterface $loop
-   *
-   * @param string $message
-   *
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   *
-   * @return array
-   */
-  public static function addSpinnerToLoop(
-    LoopInterface $loop,
-    $message,
-    $output
-  ): array {
     $spinner = new Spinner($output, 4);
-    $spinner->setMessage($message);
+    $spinner->setMessage($spinnerMessage);
     $spinner->start();
-    $timer = $loop->addPeriodicTimer($spinner->interval(),
+
+    // Spinner timer.
+    $timers[] = Loop::addPeriodicTimer($spinner->interval(),
       static function () use ($spinner) {
         $spinner->advance();
       });
 
-    return [$spinner, $timer];
-  }
+    // Primary timer checking for result status.
+    $timers[] = Loop::addPeriodicTimer(5, static function () use (&$timers, $spinner, $io, $statusCallback, $successCallback) {
+      try {
+        if ($statusCallback) {
+          foreach ($timers as $timer) {
+            Loop::cancelTimer($timer);
+          }
+          $timers = [];
+          $spinner->finish();
+          $successCallback();
+        }
+      }
+      catch (\Exception $e) {
+        $io->error($e->getMessage());
+      }
+    });
 
-  /**
-   * @param \React\EventLoop\LoopInterface $loop
-   * @param float $minutes
-   * @param \Acquia\Cli\Output\Spinner\Spinner $spinner
-   *
-   * @return \React\EventLoop\TimerInterface
-   */
-  public static function addTimeoutToLoop(
-    LoopInterface $loop,
-    float $minutes,
-    Spinner $spinner,
-    array $timers
-  ): TimerInterface {
-    return $loop->addTimer($minutes * 60, function () use ($loop, $minutes, $spinner, &$timers) {
-      self::finishSpinner($spinner);
+    // Watchdog timer.
+    $timers[] = Loop::addTimer(45 * 60, static function () use ($spinner, &$timers, $timeoutCallback, $io) {
       foreach ($timers as $timer) {
-        $loop->cancelTimer($timer);
+        Loop::cancelTimer($timer);
       }
       $timers = [];
-      throw new AcquiaCliException("Timed out after $minutes minutes!");
+      $spinner->finish();
+      $io->error("Timed out after 45 minutes!");
+      $timeoutCallback();
     });
-  }
-
-  /**
-   * @param \Acquia\Cli\Output\Spinner\Spinner $spinner
-   */
-  public static function finishSpinner(Spinner $spinner): void {
-    $spinner->finish();
   }
 
 }

--- a/tests/phpunit/src/Commands/ChecklistTest.php
+++ b/tests/phpunit/src/Commands/ChecklistTest.php
@@ -56,8 +56,6 @@ class ChecklistTest extends TestBase {
     catch (AcquiaCliException $exception) {
       $this->assertEquals('Timed out after 0.01 minutes!', $exception->getMessage());
     }
-    // $loop is statically cached by Loop::get();. We don't want the 0.01 minute timer
-    // persisting into other tests so we must use Factory::create().
     $loop->cancelTimer($timer);
   }
 

--- a/tests/phpunit/src/Commands/ChecklistTest.php
+++ b/tests/phpunit/src/Commands/ChecklistTest.php
@@ -2,12 +2,8 @@
 
 namespace Acquia\Cli\Tests\Commands;
 
-use Acquia\Cli\Exception\AcquiaCliException;
-use Acquia\Cli\Helpers\LoopHelper;
 use Acquia\Cli\Output\Checklist;
 use Acquia\Cli\Tests\TestBase;
-use React\EventLoop\Loop;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 class ChecklistTest extends TestBase {
@@ -42,21 +38,6 @@ class ChecklistTest extends TestBase {
     $this->assertEquals('Testing!', $progress_bar->getMessage());
 
     putenv('PHPUNIT_RUNNING');
-  }
-
-  public function testLoopTimeout(): void {
-    $loop = Loop::get();
-    $output = new BufferedOutput();
-    $message = 'Waiting for the IDE to be ready. This can take up to 15 minutes...';
-    $spinner = LoopHelper::addSpinnerToLoop($loop, $message, $output);
-    $timer = LoopHelper::addTimeoutToLoop($loop, .01, $spinner);
-    try {
-      $loop->run();
-    }
-    catch (AcquiaCliException $exception) {
-      $this->assertEquals('Timed out after 0.01 minutes!', $exception->getMessage());
-    }
-    $loop->cancelTimer($timer);
   }
 
 }

--- a/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
@@ -42,12 +42,13 @@ class EnvCreateCommandTest extends CommandTestBase {
    * @dataProvider providerTestCreateCde
    *
    * @throws \Exception
+   * @throws \Psr\Cache\InvalidArgumentException
    */
   public function testCreateCde($application_uuid): void {
     $label = "New CDE";
     $applications_response = $this->mockApplicationsRequest();
     $application_response = $this->mockApplicationRequest();
-    $environments_response = $this->mockEnvironmentsRequest($applications_response);
+    $this->mockEnvironmentsRequest($applications_response);
 
     $response1 = $this->getMockEnvironmentsResponse();
     $response2 = $this->getMockEnvironmentsResponse();

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -27,8 +27,6 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophet;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use React\EventLoop\Factory;
-use React\EventLoop\Loop;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Cache\CacheItem;
@@ -281,14 +279,6 @@ abstract class TestBase extends TestCase {
     );
 
     return $path;
-  }
-
-  protected function tearDown(): void {
-    parent::tearDown();
-    // $loop is statically cached by Loop::get() in some tests. To prevent it
-    // persisting into other tests we must use Factory::create() to reset it.
-    // @phpstan-ignore-next-line
-    Loop::set(Factory::create());
   }
 
   public static function setEnvVars(array $env_vars): void {


### PR DESCRIPTION
**Motivation**

We (ab)use the react event loop in some ways that lead to unpredictable behavior and flaky tests. Specifically:

- Creating an event loop via `Factory::create()` is deprecated
- Creating an event loop at all (vs using the static singleton) is discouraged
- Explicitly running the event loop is discouraged
- Callbacks must not throw exceptions in event loops
- Timers added to loops must be explicitly cancelled. Simply stopping the loop isn't sufficient, as the timer will persist if the loop is restarted.

These are all [well-document bad behaviors](https://github.com/reactphp/event-loop).

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

Do things the right way. Abstract as much of the fiddly bits (cancelling timers and spinners) as possible into a single method so that we're not doing it a dozen different ways in as many places.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run commands that depend on event loops and hold onto your butts.

- `acli app:task-wait "$(acli api:environments:domain-clear-caches 32859-2ed281d4-9dec-4cc3-ac63-691c3ba002c2 pipelinesvalidation2dev.prod.acquia-sites.com)"`
- `acli env:create` is already broken, see CLI-829
- `acli ide:create` and with `-vvv`
- `acli pull:db --on-demand` and with `-vvv`
- `acli ssh-key:create-upload`

This isn't ready for testing or review yet, I'm just putting it up for reference.
