### PR TITLE
CLI-815: app:task-wait does not track failed notifications

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1789,12 +1789,14 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    */
   protected function waitForNotificationToComplete(Client $acquia_cloud_client, string $uuid, string $message, $success = NULL): void {
     $notifications_resource = new Notifications($acquia_cloud_client);
-    $checkNotificationStatus = static function () use ($notifications_resource, $uuid) {
-      return $notifications_resource->get($uuid)->progress === 100;
+    $notification = NULL;
+    $checkNotificationStatus = static function () use ($notifications_resource, &$notification, $uuid) {
+      $notification = $notifications_resource->get($uuid);
+      return $notification->status === 'completed';
     };
     if ($success === NULL) {
-      $success = function () use ($notifications_resource, $uuid) {
-        $this->writeCompletedMessage($notifications_resource->get($uuid));
+      $success = function () use (&$notification) {
+        $this->writeCompletedMessage($notification);
       };
     }
     LoopHelper::getLoopy($this->output, $this->io, $this->logger, $message, $checkNotificationStatus, $success);

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1806,7 +1806,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @param \AcquiaCloudApi\Response\NotificationResponse $notification
    * @param string $notification_uuid
    */
-  protected function writeCompletedMessage(NotificationResponse $notification): void {
+  private function writeCompletedMessage(NotificationResponse $notification): void {
     $duration = strtotime($notification->completed_at) - strtotime($notification->created_at);
     $completed_at = date("D M j G:i:s T Y", strtotime($notification->completed_at));
     $this->io->success([

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1810,7 +1810,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $duration = strtotime($notification->completed_at) - strtotime($notification->created_at);
     $completed_at = date("D M j G:i:s T Y", strtotime($notification->completed_at));
     $this->io->success([
-      "The task with notification uuid {$notification->uuid} completed with status \"{$notification->status}\"" . PHP_EOL .
+      "The task with notification uuid {$notification->uuid} completed with progress \"{$notification->progress}\"" . PHP_EOL .
       "on " . $completed_at,
       "Task type: " . $notification->label . PHP_EOL .
       "Duration: $duration seconds",

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -111,20 +111,19 @@ class IdeCreateCommand extends IdeCommandBase {
     if (!$this->getClient()) {
       $this->setClient(new Client(['base_uri' => $ide_url]));
     }
-    $checkIdeStatus = function () {
+    $checkIdeStatus = function () use (&$response) {
       $response = $this->client->request('GET', '/health');
       return $response->getStatusCode() === 200;
     };
-    $success = function () {
-      $this->output->writeln('');
-      $this->output->writeln('<info>Your IDE is ready!</info>');
-      $this->writeIdeLinksToScreen();
-    };
-    $failure = function () {
+    $doneCallback = function () use (&$response) {
+      if ($response->getStatusCode() === 200) {
+        $this->output->writeln('');
+        $this->output->writeln('<info>Your IDE is ready!</info>');
+      }
       $this->writeIdeLinksToScreen();
     };
     $spinnerMessage = 'Waiting for the IDE to be ready. This usually takes 2 - 15 minutes.';
-    LoopHelper::getLoopy($this->output, $this->io, $this->logger, $spinnerMessage, $checkIdeStatus, $success, $failure);
+    LoopHelper::getLoopy($this->output, $this->io, $this->logger, $spinnerMessage, $checkIdeStatus, $doneCallback);
 
     return 0;
   }

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -385,8 +385,11 @@ abstract class CommandTestBase extends TestBase {
     return $backup_create_response;
   }
 
-  protected function mockNotificationResponse($notification_uuid) {
+  protected function mockNotificationResponse($notification_uuid, $status = NULL) {
     $notification_response = $this->getMockResponseFromSpec('/notifications/{notificationUuid}', 'get', 200);
+    if ($status) {
+      $notification_response->status = $status;
+    }
     $this->clientProphecy->request('get', "/notifications/$notification_uuid")
       ->willReturn($notification_response)
       ->shouldBeCalled();

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -34,11 +34,14 @@ class TaskWaitCommandTest extends CommandTestBase {
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString("The task with notification uuid", $output);
+    $this->assertStringContainsString(' [OK] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 completed with progress "100"', $output);
+    $this->assertStringContainsString('      on Mon Jul 29 20:47:13 UTC 2019', $output);
+    $this->assertStringContainsString('      Task type: Application added to recents list', $output);
+    $this->assertStringContainsString('      Duration: 0 seconds', $output);
   }
 
   /**
-   * @throws \Exception
+   * @throws \Exception|\Psr\Cache\InvalidArgumentException
    */
   public function testTaskWaitCommandWithStandardInput(): void {
     $this->mockNotificationResponse('42b56cff-0b55-4bdf-a949-1fd0fca61c6c');

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -48,7 +48,6 @@ class TaskWaitCommandTest extends CommandTestBase {
 
     // Assert.
     $this->prophet->checkPredictions();
-    $output = $this->getDisplay();
   }
 
   /**
@@ -60,7 +59,6 @@ class TaskWaitCommandTest extends CommandTestBase {
 
     // Assert.
     $this->prophet->checkPredictions();
-    $output = $this->getDisplay();
   }
 
 }

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -23,10 +23,11 @@ class TaskWaitCommandTest extends CommandTestBase {
 
   /**
    * @throws \Exception
+   * @dataProvider providerTestTaskWaitCommand
    */
-  public function testTaskWaitCommand(): void {
+  public function testTaskWaitCommand(string $status, string $message): void {
     $notification_uuid = '94835c3e-b112-4660-a14d-d541906c205b';
-    $this->mockNotificationResponse($notification_uuid);
+    $this->mockNotificationResponse($notification_uuid, $status);
     $this->executeCommand([
       'notification-uuid' => $notification_uuid,
     ], []);
@@ -34,10 +35,24 @@ class TaskWaitCommandTest extends CommandTestBase {
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString(' [OK] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 completed with progress "100"', $output);
-    $this->assertStringContainsString('      on Mon Jul 29 20:47:13 UTC 2019', $output);
-    $this->assertStringContainsString('      Task type: Application added to recents list', $output);
-    $this->assertStringContainsString('      Duration: 0 seconds', $output);
+    $this->assertStringContainsString($message, $output);
+    $this->assertStringContainsString('Progress: 100', $output);
+    $this->assertStringContainsString('Completed: Mon Jul 29 20:47:13 UTC 2019', $output);
+    $this->assertStringContainsString('Task type: Application added to recents list', $output);
+    $this->assertStringContainsString('Duration: 0 seconds', $output);
+  }
+
+  public function providerTestTaskWaitCommand(): array {
+    return [
+      [
+        'completed',
+        ' [OK] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 completed'
+      ],
+      [
+        'failed',
+        ' [ERROR] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 failed'
+      ]
+    ];
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
`app:task-wait` only exits if progress reaches 100 but this won't happen if a task fails, which leads to a timeout.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Rename the 'success' callback to a 'done' callback, and make it the responsibility of that callback to determine success or failure. The LoopHelper shouldn't be involved in that.

And then of course change waitForNotificationToComplete to check for completion status ('completed' or 'failed').

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/master/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check a completed task, ensure it exits immediately as passing: `wacli app:task-wait 1c8df5c3-7d1d-45bc-b15b-46eade264985`
4. Check a failed task, ensure it exits immediately as failing: `wacli app:task-wait 4c25aeea-e103-43d4-b06a-b4d1119bf9e2`
5. Check an in progress task, ensure that it wait for the task to fail or complete: `wacli app:task-wait "$(acli api:environments:domain-clear-caches 32859-2ed281d4-9dec-4cc3-ac63-691c3ba002c2 pipelinesvalidation2dev.prod.acquia-sites.com)"`
