### PR TITLE
CLI-834: Reduce method visibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,7 @@
             "php build/box.phar compile"
         ],
         "infection-install": [
-            "curl -f -L https://github.com/infection/infection/releases/download/0.26.0/infection.phar -o build/infection.phar"
+            "curl -f -L https://github.com/infection/infection/releases/download/0.26.13/infection.phar -o build/infection.phar"
         ],
         "infection": [
             "php -d pcov.enabled=1 build/infection.phar --threads=8"

--- a/infection.json
+++ b/infection.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/infection/infection/0.26.0/resources/schema.json",
+    "$schema": "https://raw.githubusercontent.com/infection/infection/0.26.13/resources/schema.json",
     "source": {
         "directories": [
             "src"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,7 +20,10 @@
 
   <rule ref="AcquiaPHP" />
 
+  <rule ref="Drupal.Classes.ClassDeclaration" />
   <rule ref="Drupal.Classes.UnusedUseStatement" />
   <rule ref="Drupal.ControlStructures.ControlSignature" />
+  <rule ref="Drupal.Functions.FunctionDeclaration" />
+  <rule ref="PSR12.Functions.ReturnTypeDeclaration" />
 
 </ruleset>

--- a/src/AcsfApi/AcsfCredentials.php
+++ b/src/AcsfApi/AcsfCredentials.php
@@ -60,7 +60,7 @@ class AcsfCredentials implements ApiCredentialsInterface {
   /**
    * @return mixed|null
    */
-  public function getCurrentFactory() {
+  protected function getCurrentFactory() {
     if ($factory = $this->datastoreCloud->get('acsf_active_factory')) {
       if ($acsf_factories = $this->datastoreCloud->get('acsf_factories')) {
         if (array_key_exists($factory, $acsf_factories)) {

--- a/src/Application.php
+++ b/src/Application.php
@@ -18,7 +18,7 @@ class Application extends \Symfony\Component\Console\Application {
   /**
    * @return mixed
    */
-  public function getHelpMessages(): array {
+  private function getHelpMessages(): array {
     return $this->helpMessages;
   }
 

--- a/src/CloudApi/ClientService.php
+++ b/src/CloudApi/ClientService.php
@@ -49,7 +49,7 @@ class ClientService implements ClientServiceInterface {
   /**
    * @param \Acquia\Cli\Application $application
    */
-  public function setApplication(Application $application): void {
+  protected function setApplication(Application $application): void {
     $this->application = $application;
   }
 

--- a/src/Command/Acsf/AcsfApiAuthLoginCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLoginCommand.php
@@ -101,7 +101,7 @@ class AcsfApiAuthLoginCommand extends AcsfCommandBase {
    * @param string $key
    *
    */
-  protected function writeAcsfCredentialsToDisk($factory_url, string $username, string $key): void {
+  private function writeAcsfCredentialsToDisk($factory_url, string $username, string $key): void {
     $keys = $this->datastoreCloud->get('acsf_factories');
     $keys[$factory_url]['users'][$username] = [
       'username' => $username,
@@ -120,7 +120,7 @@ class AcsfApiAuthLoginCommand extends AcsfCommandBase {
    *
    * @return mixed|null
    */
-  protected function askForOptionValue(InputInterface $input, string $option_name, bool $hidden = FALSE) {
+  private function askForOptionValue(InputInterface $input, string $option_name, bool $hidden = FALSE) {
     if (!$input->getOption($option_name)) {
       $option = $this->getDefinition()->getOption($option_name);
       $this->io->note([

--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -81,7 +81,7 @@ class ApiBaseCommand extends CommandBase {
    * @param \Symfony\Component\Console\Input\InputInterface $input
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    */
-  public function interact(InputInterface $input, OutputInterface $output) {
+  protected function interact(InputInterface $input, OutputInterface $output) {
     $params = array_merge($this->queryParams, $this->postParams, $this->pathParams);
     foreach ($this->getDefinition()->getArguments() as $argument) {
       if ($argument->isRequired() && !$input->getArgument($argument->getName())) {
@@ -256,7 +256,7 @@ class ApiBaseCommand extends CommandBase {
    *
    * @return bool|int|string|array
    */
-  protected function castParamType(array $param_spec, $value) {
+  private function castParamType(array $param_spec, $value) {
     $one_of = $this->getParamTypeOneOf($param_spec);
     if (isset($one_of)) {
       $types = [];
@@ -294,7 +294,7 @@ class ApiBaseCommand extends CommandBase {
    *
    * @return array|bool|int|string
    */
-  protected function doCastParamType($type, $value) {
+  private function doCastParamType($type, $value) {
     return match ($type) {
       'int', 'integer' => (int) $value,
       'bool', 'boolean' => $this->castBool($value),
@@ -318,7 +318,7 @@ class ApiBaseCommand extends CommandBase {
    *
    * @return null|string
    */
-  protected function getParamType(array $param_spec): ?string {
+  private function getParamType(array $param_spec): ?string {
     // @todo File a CXAPI ticket regarding the inconsistent nesting of the 'type' property.
     if (array_key_exists('type', $param_spec)) {
       return $param_spec['type'];
@@ -335,7 +335,7 @@ class ApiBaseCommand extends CommandBase {
    *
    * @return callable|null
    */
-  protected function createCallableValidator(InputArgument $argument, array $params): ?callable {
+  private function createCallableValidator(InputArgument $argument, array $params): ?callable {
     $validator = NULL;
     if (array_key_exists($argument->getName(), $params)) {
       $param_spec = $params[$argument->getName()];
@@ -370,7 +370,7 @@ class ApiBaseCommand extends CommandBase {
    *
    * @return array
    */
-  protected function createLengthConstraint($schema, array $constraints): array {
+  private function createLengthConstraint($schema, array $constraints): array {
     if (array_key_exists('minLength', $schema) || array_key_exists('maxLength', $schema)) {
       $length_options = [];
       if (array_key_exists('minLength', $schema)) {
@@ -462,7 +462,7 @@ class ApiBaseCommand extends CommandBase {
   * @param mixed $param_value
   * @param \AcquiaCloudApi\Connector\Client $acquia_cloud_client
   */
-  protected function addPostParamToClient(string $param_name, $param_spec, $param_value, Client $acquia_cloud_client) {
+  private function addPostParamToClient(string $param_name, $param_spec, $param_value, Client $acquia_cloud_client) {
     $param_name = ApiCommandHelper::restoreRenamedParameter($param_name);
     if ($param_spec) {
       $param_value = $this->castParamType($param_spec, $param_value);
@@ -486,7 +486,7 @@ class ApiBaseCommand extends CommandBase {
    *
    * @return mixed
    */
-  protected function askFreeFormQuestion(InputArgument $argument, array $params) {
+  private function askFreeFormQuestion(InputArgument $argument, array $params) {
     $question = new Question("Please enter a value for {$argument->getName()}", $argument->getDefault());
     switch ($argument->getName()) {
       case 'applicationUuid':
@@ -536,7 +536,7 @@ class ApiBaseCommand extends CommandBase {
    *
    * @return array|bool|int|string
    */
-  protected function castParamToArray(mixed $param_spec, array|string $original_value): string|array|bool|int {
+  private function castParamToArray(mixed $param_spec, array|string $original_value): string|array|bool|int {
     if (array_key_exists('items', $param_spec) && array_key_exists('type', $param_spec['items'])) {
       if (!is_array($original_value)) {
         $original_value = $this->doCastParamType('array', $original_value);

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -65,7 +65,7 @@ class ApiCommandHelper {
   /**
    *
    */
-  public function useCloudApiSpecCache(): bool {
+  protected function useCloudApiSpecCache(): bool {
     return !(getenv('ACQUIA_CLI_USE_CLOUD_API_SPEC_CACHE') === '0');
   }
 
@@ -97,7 +97,7 @@ class ApiCommandHelper {
    *
    * @return string
    */
-  protected function addOptionExampleToUsageForGetEndpoint($param_definition, string $usage): string {
+  private function addOptionExampleToUsageForGetEndpoint($param_definition, string $usage): string {
     if (array_key_exists('example', $param_definition)) {
       $usage .= '--' . $param_definition['name'] . '="' . $param_definition['example'] . '" ';
     }
@@ -110,7 +110,7 @@ class ApiCommandHelper {
    * @param array $acquia_cloud_spec
    * @param CommandBase $command
    */
-  protected function addApiCommandParameters($schema, $acquia_cloud_spec, CommandBase $command): void {
+  private function addApiCommandParameters($schema, $acquia_cloud_spec, CommandBase $command): void {
     $input_definition = [];
     $usage = '';
 
@@ -161,7 +161,7 @@ class ApiCommandHelper {
    *
    * @return array
    */
-  protected function addApiCommandParametersForRequestBody($schema, $acquia_cloud_spec): array {
+  private function addApiCommandParametersForRequestBody($schema, $acquia_cloud_spec): array {
     $usage = '';
     $input_definition = [];
     $request_body_schema = $this->getRequestBodyFromParameterSchema($schema, $acquia_cloud_spec);
@@ -219,7 +219,7 @@ class ApiCommandHelper {
    *
    * @return string
    */
-  protected function addPostArgumentUsageToExample($request_body, $prop_key, $param_definition, $type, $usage): string {
+  private function addPostArgumentUsageToExample($request_body, $prop_key, $param_definition, $type, $usage): string {
     $request_body_schema = [];
     if (array_key_exists('application/x-www-form-urlencoded', $request_body['content'])) {
       $request_body_schema = $request_body['content']['application/x-www-form-urlencoded'];
@@ -279,7 +279,7 @@ class ApiCommandHelper {
    *
    * @return array
    */
-  protected function addApiCommandParametersForPathAndQuery(array $schema, array $acquia_cloud_spec): array {
+  private function addApiCommandParametersForPathAndQuery(array $schema, array $acquia_cloud_spec): array {
     $usage = '';
     $input_definition = [];
     if (!array_key_exists('parameters', $schema)) {
@@ -325,7 +325,7 @@ class ApiCommandHelper {
    *
    * @return mixed
    */
-  protected function getParameterDefinitionFromSpec($param_key, $acquia_cloud_spec, $schema) {
+  private function getParameterDefinitionFromSpec($param_key, $acquia_cloud_spec, $schema) {
     $uppercase_key = ucfirst($param_key);
     if (array_key_exists('parameters', $acquia_cloud_spec['components'])
       && array_key_exists($uppercase_key, $acquia_cloud_spec['components']['parameters'])) {
@@ -345,7 +345,7 @@ class ApiCommandHelper {
    *
    * @return mixed
    */
-  protected function getParameterSchemaFromSpec(string $param_key, array $acquia_cloud_spec) {
+  private function getParameterSchemaFromSpec(string $param_key, array $acquia_cloud_spec) {
     return $acquia_cloud_spec['components']['schemas'][$param_key];
   }
 
@@ -357,7 +357,7 @@ class ApiCommandHelper {
    * @return bool
    * @throws \Psr\Cache\InvalidArgumentException
    */
-  protected function isApiSpecChecksumCacheValid($cache_item, string $acquia_cloud_spec_file_checksum): bool {
+  private function isApiSpecChecksumCacheValid($cache_item, string $acquia_cloud_spec_file_checksum): bool {
     // If the spec file doesn't exist, assume cache is valid.
     if ($cache_item->isHit() && !$acquia_cloud_spec_file_checksum) {
       return TRUE;
@@ -376,7 +376,7 @@ class ApiCommandHelper {
    * @return array
    * @throws \Psr\Cache\InvalidArgumentException
    */
-  protected function getCloudApiSpec(string $spec_file_path): array {
+  private function getCloudApiSpec(string $spec_file_path): array {
     $cache_key = basename($spec_file_path);
     $cache = new PhpArrayAdapter(__DIR__ . '/../../../var/cache/' . $cache_key . '.cache', new NullAdapter());
     $cache_item_checksum = $cache->getItem($cache_key . '.checksum');
@@ -418,7 +418,7 @@ class ApiCommandHelper {
    *
    * @return ApiBaseCommand[]
    */
-  protected function generateApiCommandsFromSpec(array $acquia_cloud_spec, string $command_prefix, CommandFactoryInterface $command_factory): array {
+  private function generateApiCommandsFromSpec(array $acquia_cloud_spec, string $command_prefix, CommandFactoryInterface $command_factory): array {
     $api_commands = [];
     foreach ($acquia_cloud_spec['paths'] as $path => $endpoint) {
       // Skip internal endpoints. These shouldn't actually be in the spec.
@@ -486,7 +486,7 @@ class ApiCommandHelper {
    * @param array $input_definition
    * @param string $usage
    */
-  protected function addAliasUsageExamples(ApiBaseCommand $command, array $input_definition, string $usage): void {
+  private function addAliasUsageExamples(ApiBaseCommand $command, array $input_definition, string $usage): void {
     foreach ($input_definition as $key => $parameter) {
       if ($parameter->getName() === 'applicationUuid') {
         $usage_parts = explode(' ', $usage);
@@ -549,7 +549,7 @@ class ApiCommandHelper {
    *
    * @return mixed
    */
-  protected function getPropertySpecFromRequestBodyParam(array $request_body_schema, $parameter_definition) {
+  private function getPropertySpecFromRequestBodyParam(array $request_body_schema, $parameter_definition) {
     if (array_key_exists($parameter_definition->getName(), $request_body_schema['properties'])) {
       return $request_body_schema['properties'][$parameter_definition->getName()];
     }
@@ -603,7 +603,7 @@ class ApiCommandHelper {
    *
    * @return ApiListCommandBase[]
    */
-  protected function generateApiListCommands(array $api_commands, $command_prefix, CommandFactoryInterface $command_factory): array {
+  private function generateApiListCommands(array $api_commands, $command_prefix, CommandFactoryInterface $command_factory): array {
     $api_list_commands = [];
     foreach ($api_commands as $api_command) {
       $command_name_parts = explode(':', $api_command->getName());

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -82,7 +82,7 @@ class NewCommand extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function createProject($project, string $dir): void {
+  private function createProject($project, string $dir): void {
     $process = $this->localMachineHelper->execute([
       'composer',
       'create-project',
@@ -100,7 +100,7 @@ class NewCommand extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function initializeGitRepository(string $dir): void {
+  private function initializeGitRepository(string $dir): void {
     if ($this->localMachineHelper->getFilesystem()->exists(Path::join($dir, '.git'))) {
       $this->logger->debug('.git directory detected, skipping Git repo initialization');
       return;

--- a/src/Command/Archive/ArchiveExportCommand.php
+++ b/src/Command/Archive/ArchiveExportCommand.php
@@ -56,7 +56,7 @@ class ArchiveExportCommand extends CommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Psr\Cache\InvalidArgumentException
    */
-  public function initialize(InputInterface $input, OutputInterface $output) {
+  protected function initialize(InputInterface $input, OutputInterface $output) {
     parent::initialize($input, $output);
     $this->fs = $this->localMachineHelper->getFilesystem();
     $this->checklist = new Checklist($output);
@@ -115,7 +115,7 @@ class ArchiveExportCommand extends CommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function determineDestinationDir(InputInterface $input): void {
+  private function determineDestinationDir(InputInterface $input): void {
     $this->destinationDir = $input->getArgument('destination-dir');
     if (!$this->fs->exists($this->destinationDir)) {
       throw new AcquiaCliException("The destination directory {$this->destinationDir} does not exist!");
@@ -128,7 +128,7 @@ class ArchiveExportCommand extends CommandBase {
    * @param \Closure $output_callback
    * @param string $artifact_dir
    */
-  protected function createArchiveDirectory(Closure $output_callback, string $artifact_dir): void {
+  private function createArchiveDirectory(Closure $output_callback, string $artifact_dir): void {
     $this->checklist->updateProgressBar("Mirroring source files from {$this->dir} to {$artifact_dir}");
     $originFinder = $this->localMachineHelper->getFinder();
     $originFinder->files()->in($this->dir)
@@ -152,7 +152,7 @@ class ArchiveExportCommand extends CommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  protected function exportDatabaseToArchiveDir(
+  private function exportDatabaseToArchiveDir(
     Closure $output_callback,
     string $archive_temp_dir
   ): void {
@@ -178,7 +178,7 @@ class ArchiveExportCommand extends CommandBase {
    * @return string
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function compressArchiveDirectory($archive_dir, $destination_dir, $output_callback = NULL): string {
+  private function compressArchiveDirectory($archive_dir, $destination_dir, $output_callback = NULL): string {
     $destination_filename = basename($archive_dir) . '.tar.gz';
     $destination_filepath = Path::join($destination_dir, $destination_filename);
     $this->localMachineHelper->checkRequiredBinariesExist(['tar']);

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -83,7 +83,7 @@ class AuthLoginCommand extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function writeApiCredentialsToDisk(string $api_key, string $api_secret): void {
+  private function writeApiCredentialsToDisk(string $api_key, string $api_secret): void {
     $token_info = $this->cloudApiClientService->getClient()->request('get', "/account/tokens/{$api_key}");
     $keys = $this->datastoreCloud->get('keys');
     $keys[$api_key] = [

--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -44,7 +44,7 @@ trait CodeStudioCommandTrait {
    * @return string
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function getGitLabToken(string $gitlab_host): string {
+  private function getGitLabToken(string $gitlab_host): string {
     if ($this->input->getOption('gitlab-token')) {
       return $this->input->getOption('gitlab-token');
     }
@@ -77,7 +77,7 @@ trait CodeStudioCommandTrait {
    * @return string
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function getGitLabHost(): string {
+  private function getGitLabHost(): string {
     // If hostname is available as argument, use that.
     if ($this->input->hasOption('gitlab-host-name')
      && $this->input->getOption('gitlab-host-name')) {
@@ -106,7 +106,7 @@ trait CodeStudioCommandTrait {
   /**
    * @return \Gitlab\Client
    */
-  protected function getGitLabClient(): Client {
+  private function getGitLabClient(): Client {
     if (!isset($this->gitLabClient)) {
       $gitlab_client = new Client(new Builder(new \GuzzleHttp\Client()));
       $gitlab_client->setUrl('https://' . $this->gitLabHost);
@@ -126,7 +126,7 @@ trait CodeStudioCommandTrait {
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
    */
-  protected function writeApiTokenMessage(InputInterface $input): void {
+  private function writeApiTokenMessage(InputInterface $input): void {
     // Get Cloud access tokens.
     if (!$input->getOption('key') || !$input->getOption('secret')) {
       $token_url = 'https://cloud.acquia.com/a/profile/tokens';
@@ -158,7 +158,7 @@ trait CodeStudioCommandTrait {
   /**
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function authenticateWithGitLab(): void {
+  private function authenticateWithGitLab(): void {
     $this->validateEnvironment();
     $this->gitLabHost = $this->getGitLabHost();
     $this->gitLabToken = $this->getGitLabToken($this->gitLabHost);
@@ -183,7 +183,7 @@ trait CodeStudioCommandTrait {
    *
    * @return array
    */
-  protected function determineGitLabProject(ApplicationResponse $cloud_application): array {
+  private function determineGitLabProject(ApplicationResponse $cloud_application): array {
     // Use command option.
     if ($this->input->getOption('gitlab-project-id')) {
       $id = $this->input->getOption('gitlab-project-id');
@@ -234,7 +234,7 @@ trait CodeStudioCommandTrait {
    *
    * @return array
    */
-  protected function createGitLabProject(ApplicationResponse $cloud_application): array {
+  private function createGitLabProject(ApplicationResponse $cloud_application): array {
     $user_groups = $this->gitLabClient->groups()->all([
       'all_available' => TRUE,
       'min_access_level' => 40,
@@ -258,14 +258,14 @@ trait CodeStudioCommandTrait {
   /**
    *
    */
-  protected function setGitLabProjectDescription($cloud_application_uuid): void {
+  private function setGitLabProjectDescription($cloud_application_uuid): void {
     $this->gitLabProjectDescription = "Source repository for Acquia Cloud Platform application <comment>$cloud_application_uuid</comment>";
   }
 
   /**
    * @return array
    */
-  protected function getGitLabProjectDefaults(): array {
+  private function getGitLabProjectDefaults(): array {
     return [
       'description' => $this->gitLabProjectDescription,
       'topics' => 'Acquia Cloud Application',

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -99,7 +99,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    * @param array $project
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function checkGitLabCiCdVariables(array $project) {
+  private function checkGitLabCiCdVariables(array $project) {
     $gitlab_cicd_variables = CodeStudioCiCdVariables::getList();
     $gitlab_cicd_existing_variables = $this->gitLabClient->projects()->variables($project['id']);
     $existing_keys = array_column($gitlab_cicd_existing_variables, 'key');
@@ -118,7 +118,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    * @return array
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function getAcquiaPipelinesFileContents(array $project): array {
+  private function getAcquiaPipelinesFileContents(array $project): array {
     $pipelines_filepath_yml = Path::join($this->repoRoot, 'acquia-pipelines.yml');
     $pipelines_filepath_yaml = Path::join($this->repoRoot, 'acquia-pipelines.yaml');
     if ($this->localMachineHelper->getFilesystem()->exists($pipelines_filepath_yml) ||
@@ -142,7 +142,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    *
    * @return array
    */
-  protected function getGitLabCiFileTemplate(): array {
+  private function getGitLabCiFileTemplate(): array {
     return [
         'include' => ['project' => 'acquia/standard-template', 'file' => '/gitlab-ci/Auto-DevOps.acquia.gitlab-ci.yml'],
     ];
@@ -151,7 +151,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
   /**
    * Migrating `variables` section to .gitlab-ci.yml file.
    */
-  protected function migrateVariablesSection($acquia_pipelines_file_contents, &$gitlab_ci_file_contents) {
+  private function migrateVariablesSection($acquia_pipelines_file_contents, &$gitlab_ci_file_contents) {
     if (array_key_exists('variables', $acquia_pipelines_file_contents)) {
       $variables_dump = Yaml::dump(['variables' => $acquia_pipelines_file_contents['variables']]);
       $remove_global = preg_replace('/global:/', '', $variables_dump);
@@ -174,7 +174,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    *
    * @return null
    */
-  protected function getPipelinesSection(array $acquia_pipelines_file_contents, string $event_name) {
+  private function getPipelinesSection(array $acquia_pipelines_file_contents, string $event_name) {
     if (!array_key_exists('events', $acquia_pipelines_file_contents)) {
       return NULL;
     }
@@ -194,7 +194,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    * @param array $acquia_pipelines_file_contents
    * @param array $gitlab_ci_file_contents
    */
-  protected function migrateEventsSection(array $acquia_pipelines_file_contents, array &$gitlab_ci_file_contents) {
+  private function migrateEventsSection(array $acquia_pipelines_file_contents, array &$gitlab_ci_file_contents) {
     $events_map = [
       'build' => [
         'skip' => [
@@ -318,7 +318,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    *
    * Removing empty script.
    */
-  protected function removeEmptyScript(array &$gitlab_ci_file_contents) {
+  private function removeEmptyScript(array &$gitlab_ci_file_contents) {
     foreach ($gitlab_ci_file_contents as $key => $value) {
       if (array_key_exists('script', $value) && empty($value['script'])) {
         unset($gitlab_ci_file_contents[$key]);
@@ -329,7 +329,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
   /**
    * Creating .gitlab-ci.yml file.
    */
-  protected function createGitLabCiFile(array $contents,$acquia_pipelines_file_name) {
+  private function createGitLabCiFile(array $contents,$acquia_pipelines_file_name) {
     $gitlab_ci_filepath = Path::join($this->repoRoot, '.gitlab-ci.yml');
     $this->localMachineHelper->getFilesystem()->dumpFile($gitlab_ci_filepath, Yaml::dump($contents, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
     $this->localMachineHelper->getFilesystem()->remove($acquia_pipelines_file_name);
@@ -341,7 +341,7 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    *
    * @return string|null
    */
-  protected function assignStageFromKeywords(array $keywords, string $haystack): ?string {
+  private function assignStageFromKeywords(array $keywords, string $haystack): ?string {
     foreach ($keywords as $needle => $stage) {
       if (str_contains($haystack, $needle)) {
         return $stage;

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -141,7 +141,7 @@ class CodeStudioWizardCommand extends WizardCommandBase {
    *
    * @return array|null
    */
-  protected function getGitLabScheduleByDescription(array $project, string $scheduled_pipeline_description): ?array {
+  private function getGitLabScheduleByDescription(array $project, string $scheduled_pipeline_description): ?array {
     $existing_schedules = $this->gitLabClient->schedules()->showAll($project['id']);
     foreach ($existing_schedules as $schedule) {
       if ($schedule['description'] == $scheduled_pipeline_description) {
@@ -157,7 +157,7 @@ class CodeStudioWizardCommand extends WizardCommandBase {
    *
    * @return array|null ?
    */
-  protected function getGitLabProjectAccessTokenByName(array $project, string $name): ?array {
+  private function getGitLabProjectAccessTokenByName(array $project, string $name): ?array {
     $existing_project_access_tokens = $this->gitLabClient->projects()->projectAccessTokens($project['id']);
     foreach ($existing_project_access_tokens as $key => $token) {
       if ($token['name'] == $name) {
@@ -173,7 +173,7 @@ class CodeStudioWizardCommand extends WizardCommandBase {
    *
    * @return string
    */
-  protected function createProjectAccessToken(array $project, string $project_access_token_name): string {
+  private function createProjectAccessToken(array $project, string $project_access_token_name): string {
     $this->io->writeln("Creating project access token...");
 
     if ($existing_token = $this->getGitLabProjectAccessTokenByName($project, $project_access_token_name)) {
@@ -200,7 +200,7 @@ class CodeStudioWizardCommand extends WizardCommandBase {
    * @param string $project_access_token_name
    * @param string $project_access_token
    */
-  protected function setGitLabCiCdVariables(array $project, string $cloud_application_uuid, string $cloud_key, string $cloud_secret, string $project_access_token_name, string $project_access_token): void {
+  private function setGitLabCiCdVariables(array $project, string $cloud_application_uuid, string $cloud_key, string $cloud_secret, string $project_access_token_name, string $project_access_token): void {
     $this->io->writeln("Setting GitLab CI/CD variables for {$project['path_with_namespace']}..");
     $gitlab_cicd_variables = CodeStudioCiCdVariables::getDefaults($cloud_application_uuid, $cloud_key, $cloud_secret, $project_access_token_name, $project_access_token);
     $gitlab_cicd_existing_variables = $this->gitLabClient->projects()
@@ -228,7 +228,7 @@ class CodeStudioWizardCommand extends WizardCommandBase {
   /**
    * @param array $project
    */
-  protected function createScheduledPipeline(array $project): void {
+  private function createScheduledPipeline(array $project): void {
     $this->io->writeln("Creating scheduled pipeline");
     $scheduled_pipeline_description = "Code Studio Automatic Updates";
 
@@ -258,7 +258,7 @@ class CodeStudioWizardCommand extends WizardCommandBase {
   /**
    * @param array $project
    */
-  protected function updateGitLabProject(array $project): void {
+  private function updateGitLabProject(array $project): void {
     // Setting the description to match the known pattern will allow us to automatically find the project next time.
     if ($project['description'] != $this->gitLabProjectDescription) {
       $this->gitLabClient->projects()->update($project['id'], $this->getGitLabProjectDefaults());

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -229,7 +229,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return $this->repoRoot;
   }
 
-  protected function setLocalDbUser(): void {
+  private function setLocalDbUser(): void {
     $this->localDbUser = 'drupal';
     if ($lando_info = self::getLandoInfo()) {
       $this->localDbUser = $lando_info->database->creds->user;
@@ -247,7 +247,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return $this->localDbUser;
   }
 
-  protected function setLocalDbPassword(): void {
+  private function setLocalDbPassword(): void {
     $this->localDbPassword = 'drupal';
     if ($lando_info = self::getLandoInfo()) {
       $this->localDbPassword = $lando_info->database->creds->password;
@@ -268,7 +268,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return $this->localDbPassword;
   }
 
-  protected function setLocalDbName(): void {
+  private function setLocalDbName(): void {
     $this->localDbName = 'drupal';
     if ($lando_info = self::getLandoInfo()) {
       $this->localDbName = $lando_info->database->creds->database;
@@ -289,7 +289,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return $this->localDbName;
   }
 
-  protected function setLocalDbHost(): void {
+  private function setLocalDbHost(): void {
     $this->localDbHost = 'localhost';
     if ($lando_info = self::getLandoInfo()) {
       $this->localDbHost = $lando_info->database->hostnames[0];
@@ -464,7 +464,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @return null|object|array
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function promptChooseSubscription(
+  private function promptChooseSubscription(
     Client $acquia_cloud_client
   ) {
     $subscriptions_resource = new Subscriptions($acquia_cloud_client);
@@ -515,7 +515,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    *
    * @return null|object|array
    */
-  protected function promptChooseEnvironment(
+  private function promptChooseEnvironment(
     Client $acquia_cloud_client,
     string $application_uuid
   ) {
@@ -624,7 +624,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    *
    * @return array|null
    */
-  protected function getGitConfig(): ?array {
+  private function getGitConfig(): ?array {
     $file_path = $this->repoRoot . '/.git/config';
     if (file_exists($file_path)) {
       return parse_ini_file($file_path, TRUE);
@@ -641,7 +641,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @return array
    *   A flat array of git remote urls.
    */
-  protected function getGitRemotes(array $git_config): array {
+  private function getGitRemotes(array $git_config): array {
     $local_vcs_remotes = [];
     foreach ($git_config as $section_name => $section) {
       if ((strpos($section_name, 'remote ') !== FALSE) &&
@@ -660,7 +660,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    *
    * @return ApplicationResponse|null
    */
-  protected function findCloudApplicationByGitUrl(
+  private function findCloudApplicationByGitUrl(
         Client $acquia_cloud_client,
         array $local_git_remotes
     ): ?ApplicationResponse {
@@ -724,7 +724,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    *
    * @return ApplicationResponse|null
    */
-  protected function searchApplicationEnvironmentsForGitUrl(
+  private function searchApplicationEnvironmentsForGitUrl(
         $application,
         $application_environments,
         $local_git_remotes
@@ -930,7 +930,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @return bool
    * @throws \Exception
    */
-  protected function saveCloudUuidToDatastore(ApplicationResponse $application): bool {
+  private function saveCloudUuidToDatastore(ApplicationResponse $application): bool {
     $this->datastoreAcli->set('cloud_app_uuid', $application->uuid);
     $this->io->success("The Cloud application {$application->name} has been linked to this repository by writing to .acquia-cli.yml in the repository root.");
 
@@ -1066,7 +1066,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @return EnvironmentResponse
    * @throws \Psr\Cache\InvalidArgumentException
    */
-  protected function getEnvFromAlias($alias): EnvironmentResponse {
+  private function getEnvFromAlias($alias): EnvironmentResponse {
     return self::getAliasCache()->get($alias, function () use ($alias) {
       return $this->doGetEnvFromAlias($alias);
     });
@@ -1164,7 +1164,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * @throws AcquiaCliException
    */
-  public function requireCloudIdeEnvironment(): void {
+  protected function requireCloudIdeEnvironment(): void {
     if (!self::isAcquiaCloudIde() || !self::getThisCloudIdeUuid()) {
       throw new AcquiaCliException('This command can only be run inside of an Acquia Cloud IDE');
     }
@@ -1382,7 +1382,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @return array
    * @throws AcquiaCliException
    */
-  protected function getCloudSites($cloud_environment): array {
+  private function getCloudSites($cloud_environment): array {
     $sitegroup = self::getSiteGroupFromSshUrl($cloud_environment->sshUrl);
     $command = ['ls', $this->getCloudSitesPath($cloud_environment, $sitegroup)];
     $process = $this->sshHelper->executeCommand($cloud_environment, $command, FALSE);
@@ -1468,7 +1468,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     ]), $base_uri);
   }
 
-  protected function warnMultisite(): void {
+  private function warnMultisite(): void {
     $this->io->note("This is a multisite application. Drupal will load the default site unless you've configured sites.php for this environment: https://docs.acquia.com/cloud-platform/develop/drupal/multisite/");
   }
 
@@ -1628,7 +1628,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    *
    * @return string
    */
-  protected function validateApiKey($key): string {
+  private function validateApiKey($key): string {
     $violations = Validation::createValidator()->validate($key, [
       new Length(['min' => 10]),
       new NotBlank(),
@@ -1671,7 +1671,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @return \AcquiaCloudApi\Response\EnvironmentResponse|null
    * @throws \Exception
    */
-  protected function getAnyAhEnvironment(string $cloud_app_uuid, callable $filter): ?EnvironmentResponse {
+  private function getAnyAhEnvironment(string $cloud_app_uuid, callable $filter): ?EnvironmentResponse {
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $environment_resource = new Environments($acquia_cloud_client);
     /** @var EnvironmentResponse[] $application_environments */

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -116,7 +116,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    * @param array $records
    *
    */
-  protected function generateZoneFile($base_domain, $records) {
+  private function generateZoneFile($base_domain, $records) {
 
     $zone = new Zone($base_domain . '.');
 
@@ -151,7 +151,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    *
    * @return array
    */
-  protected function determineApplications(Client $client, SubscriptionResponse $subscription) {
+  private function determineApplications(Client $client, SubscriptionResponse $subscription) {
     $applications_resource = new Applications($client);
     $applications = $applications_resource->getAll();
     $subscription_applications = [];
@@ -183,7 +183,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    *
    * @return bool
    */
-  protected function domainAlreadyAssociated($application, $exception) {
+  private function domainAlreadyAssociated($application, $exception) {
     if (strpos($exception, 'is already associated with this application') === FALSE) {
       $this->io->error($exception->getMessage());
       return FALSE;
@@ -204,7 +204,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    *
    * @return bool
    */
-  protected function environmentAlreadyEnabled($environment, $exception) {
+  private function environmentAlreadyEnabled($environment, $exception) {
     if (strpos($exception, 'is already enabled on this environment') === FALSE) {
       $this->io->error($exception->getMessage());
       return FALSE;
@@ -227,7 +227,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function addDomainToSubscriptionApplications(Client $client, SubscriptionResponse $subscription, string $base_domain, string $domain_uuid) {
+  private function addDomainToSubscriptionApplications(Client $client, SubscriptionResponse $subscription, string $base_domain, string $domain_uuid) {
     $applications = $this->determineApplications($client, $subscription);
 
     $environments_resource = new Environments($client);
@@ -299,7 +299,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    * @return mixed
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function fetchDomainUuid(Client $client, $subscription, $base_domain) {
+  private function fetchDomainUuid(Client $client, $subscription, $base_domain) {
     $domains_response = $client->request('get', "/subscriptions/{$subscription->uuid}/domains");
     foreach ($domains_response as $domain) {
       if ($domain->domain_name === $base_domain) {
@@ -321,7 +321,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function createDnsText(Client $client, $subscription, $base_domain, $domain_uuid, $file_format): void {
+  private function createDnsText(Client $client, $subscription, $base_domain, $domain_uuid, $file_format): void {
     $domain_registration_response = $client->request('get', "/subscriptions/{$subscription->uuid}/domains/{$domain_uuid}");
     if (!isset($domain_registration_response->dns_records)) {
       throw new AcquiaCliException('Could not retrieve DNS records for this domain. Please try again by rerunning this script with the domain that you just registered.');
@@ -363,7 +363,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    *
    * @return bool
    */
-  protected function checkIfDomainVerified(
+  private function checkIfDomainVerified(
     SubscriptionResponse $subscription,
     string $domain_uuid,
     OutputInterface $output
@@ -402,7 +402,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    *
    * @return string
    */
-  protected function determineDomain() {
+  private function determineDomain() {
     $domain = $this->io->ask("What's the domain name you'd like to register?", '', \Closure::fromCallable([
       $this,
       'validateUrl'

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -81,7 +81,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    * @return void
    * @throws \League\Csv\CannotInsertRecord
    */
-  protected function writeDomainsToTables(OutputInterface $output, SubscriptionResponse $subscription, array $domain_list) {
+  private function writeDomainsToTables(OutputInterface $output, SubscriptionResponse $subscription, array $domain_list) {
 
     // initialize tables to be displayed in console
     $all_domains_table = $this->createTotalDomainTable($output, "Subscription {$subscription->name} - All Domains");
@@ -176,7 +176,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    *
    * @return void
    */
-  protected function renderDomainInfoTables(array $tables) {
+  private function renderDomainInfoTables(array $tables) {
     foreach ($tables as $table) {
       $table->render();
       $this->io->newLine();
@@ -192,7 +192,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    * @return array|null
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function validateSubscriptionApplicationCount(Client $client, SubscriptionResponse $subscription) {
+  private function validateSubscriptionApplicationCount(Client $client, SubscriptionResponse $subscription) {
     $applications_resource = new Applications($client);
     $applications = $applications_resource->getAll();
     $subscription_applications = [];
@@ -227,7 +227,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    * @return void
    * @throws \League\Csv\CannotInsertRecord
    */
-  protected function renderApplicationAssociations(OutputInterface $output, Client $client, $subscription, $subscription_applications) {
+  private function renderApplicationAssociations(OutputInterface $output, Client $client, $subscription, $subscription_applications) {
     $apps_domains_table = $this->createApplicationDomainsTable($output, 'Domain Association Status');
     $writer_apps_domains = Writer::createFromPath("./subscription-{$subscription->uuid}-domains/apps-domain-associations.csv", 'w+');
 
@@ -272,7 +272,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    *
    * @return \Symfony\Component\Console\Helper\Table
    */
-  protected function createTotalDomainTable(OutputInterface $output, string $title): Table {
+  private function createTotalDomainTable(OutputInterface $output, string $title): Table {
     $headers = ['Domain Name', 'Domain UUID', 'Verification Status'];
     $widths = [.2, .2, .1];
     return $this->createTable($output, $title, $headers, $widths);
@@ -286,7 +286,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    *
    * @return \Symfony\Component\Console\Helper\Table
    */
-  protected function createDomainStatusTable(OutputInterface $output, string $title): Table {
+  private function createDomainStatusTable(OutputInterface $output, string $title): Table {
     $headers = ['Domain Name', 'Summary'];
     $widths = [.2, .2];
     return $this->createTable($output, $title, $headers, $widths);
@@ -301,7 +301,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    *
    * @return \Symfony\Component\Console\Helper\Table
    */
-  protected function createApplicationDomainsTable(OutputInterface $output, string $title): Table {
+  private function createApplicationDomainsTable(OutputInterface $output, string $title): Table {
     $headers = ['Domain Name', 'Associated?'];
     $widths = [.2, .1];
     return $this->createTable($output, $title, $headers, $widths);
@@ -315,7 +315,7 @@ class EmailInfoForSubscriptionCommand extends CommandBase {
    *
    * @return string
    */
-  protected function showHumanReadableStatus(string $code): string {
+  private function showHumanReadableStatus(string $code): string {
     switch ($code) {
       case '200':
           return "Succeeded";

--- a/src/Command/Env/EnvDeleteCommand.php
+++ b/src/Command/Env/EnvDeleteCommand.php
@@ -53,7 +53,7 @@ class EnvDeleteCommand extends CommandBase {
    * @return \AcquiaCloudApi\Response\EnvironmentResponse
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function determineEnvironment(Environments $environments_resource, string $cloud_app_uuid): EnvironmentResponse {
+  private function determineEnvironment(Environments $environments_resource, string $cloud_app_uuid): EnvironmentResponse {
     if ($this->input->getArgument('environmentId')) {
       // @todo Validate.
       $environment_id = $this->input->getArgument('environmentId');

--- a/src/Command/Env/EnvMirrorCommand.php
+++ b/src/Command/Env/EnvMirrorCommand.php
@@ -115,7 +115,7 @@ class EnvMirrorCommand extends CommandBase {
    *
    * @return object|null
    */
-  protected function getDefaultDatabase(array $databases): ?object {
+  private function getDefaultDatabase(array $databases): ?object {
     foreach ($databases as $database) {
       if ($database->flags->default) {
         return $database;
@@ -132,7 +132,7 @@ class EnvMirrorCommand extends CommandBase {
    *
    * @return \AcquiaCloudApi\Response\OperationResponse
    */
-  protected function mirrorDatabase(Client $acquia_cloud_client, mixed $source_environment_uuid, mixed $destination_environment_uuid, callable $output_callback): OperationResponse {
+  private function mirrorDatabase(Client $acquia_cloud_client, mixed $source_environment_uuid, mixed $destination_environment_uuid, callable $output_callback): OperationResponse {
     $this->checklist->addItem("Initiating database copy");
     $output_callback('out', "Getting a list of databases");
     $databases_resource = new Databases($acquia_cloud_client);
@@ -154,7 +154,7 @@ class EnvMirrorCommand extends CommandBase {
    *
    * @return mixed
    */
-  protected function mirrorCode(Client $acquia_cloud_client, mixed $destination_environment_uuid, EnvironmentResponse $source_environment, callable $output_callback): mixed {
+  private function mirrorCode(Client $acquia_cloud_client, mixed $destination_environment_uuid, EnvironmentResponse $source_environment, callable $output_callback): mixed {
     $this->checklist->addItem("Initiating code switch");
     $output_callback('out', "Switching to {$source_environment->vcs->path}");
     $code_copy_response = $acquia_cloud_client->request('post', "/environments/$destination_environment_uuid/code/actions/switch", [
@@ -175,7 +175,7 @@ class EnvMirrorCommand extends CommandBase {
    *
    * @return \AcquiaCloudApi\Response\OperationResponse
    */
-  protected function mirrorFiles(Environments $environments_resource, mixed $source_environment_uuid, mixed $destination_environment_uuid, callable $output_callback): OperationResponse {
+  private function mirrorFiles(Environments $environments_resource, mixed $source_environment_uuid, mixed $destination_environment_uuid, callable $output_callback): OperationResponse {
     $this->checklist->addItem("Initiating files copy");
     $files_copy_response = $environments_resource->copyFiles($source_environment_uuid, $destination_environment_uuid);
     $this->checklist->completePreviousItem();
@@ -191,7 +191,7 @@ class EnvMirrorCommand extends CommandBase {
    *
    * @return \AcquiaCloudApi\Response\OperationResponse
    */
-  protected function mirrorConfig(EnvironmentResponse $source_environment, EnvironmentResponse $destination_environment, Environments $environments_resource, mixed $destination_environment_uuid, callable $output_callback): OperationResponse {
+  private function mirrorConfig(EnvironmentResponse $source_environment, EnvironmentResponse $destination_environment, Environments $environments_resource, mixed $destination_environment_uuid, callable $output_callback): OperationResponse {
     $this->checklist->addItem("Initiating config copy");
     $output_callback('out', "Copying PHP version, acpu memory limit, etc.");
     $config = (array) $source_environment->configuration->php;

--- a/src/Command/Ide/IdeCommandBase.php
+++ b/src/Command/Ide/IdeCommandBase.php
@@ -116,7 +116,7 @@ abstract class IdeCommandBase extends CommandBase {
    *
    * @return string
    */
-  public function getXdebugIniFilePath(): string {
+  protected function getXdebugIniFilePath(): string {
     if (!isset($this->xdebugIniFilepath)) {
       $this->xdebugIniFilepath = self::DEFAULT_XDEBUG_INI_FILEPATH;
     }

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -91,7 +91,7 @@ class IdeCreateCommand extends IdeCommandBase {
    *
    * @return string
    */
-  protected function validateIdeLabel(string $label): string {
+  private function validateIdeLabel(string $label): string {
     $violations = Validation::createValidator()->validate($label, [
       new Regex(['pattern' => '/^[\w\' ]+$/', 'message' => 'Please use only letters, numbers, and spaces']),
     ]);
@@ -131,7 +131,7 @@ class IdeCreateCommand extends IdeCommandBase {
   /**
    * Writes the IDE links to screen.
    */
-  public function writeIdeLinksToScreen(): void {
+  private function writeIdeLinksToScreen(): void {
     $this->output->writeln('');
     $this->output->writeln("<comment>Your IDE URL:</comment> <href={$this->ide->links->ide->href}>{$this->ide->links->ide->href}</>");
     $this->output->writeln("<comment>Your Drupal Site URL:</comment> <href={$this->ide->links->web->href}>{$this->ide->links->web->href}</>");
@@ -141,7 +141,7 @@ class IdeCreateCommand extends IdeCommandBase {
   /**
    * @return \GuzzleHttp\Client|null
    */
-  public function getClient(): ?Client {
+  private function getClient(): ?Client {
     return $this->client;
   }
 
@@ -158,7 +158,7 @@ class IdeCreateCommand extends IdeCommandBase {
    *
    * @return \AcquiaCloudApi\Response\IdeResponse
    */
-  protected function getIdeFromResponse(
+  private function getIdeFromResponse(
     OperationResponse $response,
     \AcquiaCloudApi\Connector\Client $acquia_cloud_client
   ): IdeResponse {

--- a/src/Command/Ide/IdePhpVersionCommand.php
+++ b/src/Command/Ide/IdePhpVersionCommand.php
@@ -64,7 +64,7 @@ class IdePhpVersionCommand extends IdeCommandBase {
   /**
    * @return string
    */
-  public function getIdePhpFilePathPrefix(): string {
+  private function getIdePhpFilePathPrefix(): string {
     if (!isset($this->idePhpFilePathPrefix)) {
       $this->idePhpFilePathPrefix = '/usr/local/php';
     }
@@ -84,7 +84,7 @@ class IdePhpVersionCommand extends IdeCommandBase {
    * @return string
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function validatePhpVersion(string $version): string {
+  private function validatePhpVersion(string $version): string {
     $violations = Validation::createValidator()->validate($version, [
       new Length(['min' => 3]),
       new NotBlank(),

--- a/src/Command/Ide/IdeServiceRestartCommand.php
+++ b/src/Command/Ide/IdeServiceRestartCommand.php
@@ -71,7 +71,7 @@ class IdeServiceRestartCommand extends IdeCommandBase {
    *
    * @return string
    */
-  protected function validateService($service) {
+  private function validateService($service) {
     $violations = Validation::createValidator()->validate($service, [
       new Choice([
         'choices' => ['php', 'php-fpm', 'apache', 'apache2', 'mysql', 'mysqld'],

--- a/src/Command/Ide/IdeServiceStartCommand.php
+++ b/src/Command/Ide/IdeServiceStartCommand.php
@@ -71,7 +71,7 @@ class IdeServiceStartCommand extends IdeCommandBase {
    *
    * @return string
    */
-  protected function validateService($service) {
+  private function validateService($service) {
     $violations = Validation::createValidator()->validate($service, [
       new Choice([
         'choices' => ['php', 'php-fpm', 'apache', 'apache2', 'mysql', 'mysqld'],

--- a/src/Command/Ide/IdeServiceStopCommand.php
+++ b/src/Command/Ide/IdeServiceStopCommand.php
@@ -71,7 +71,7 @@ class IdeServiceStopCommand extends IdeCommandBase {
    *
    * @return string
    */
-  protected function validateService($service) {
+  private function validateService($service) {
     $violations = Validation::createValidator()->validate($service, [
       new Choice([
         'choices' => ['php', 'php-fpm', 'apache', 'apache2', 'mysql', 'mysqld'],

--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -75,7 +75,7 @@ class IdeShareCommand extends CommandBase {
   /**
    * @return array
    */
-  public function getShareCodeFilepaths(): array {
+  private function getShareCodeFilepaths(): array {
     if (!isset($this->shareCodeFilepaths)) {
       $this->shareCodeFilepaths = [
         '/usr/local/share/ide/.sharecode',
@@ -88,7 +88,7 @@ class IdeShareCommand extends CommandBase {
   /**
    * @throws \Exception
    */
-  public function regenerateShareCode(): void {
+  private function regenerateShareCode(): void {
     $new_share_code = Uuid::uuid4();
     foreach ($this->getShareCodeFilepaths() as $path) {
       $this->localMachineHelper->writeFile($path, $new_share_code);

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -70,7 +70,7 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    * @param string $contents
    *   The contents of php.ini.
    */
-  protected function setXDebugStatus($contents): void {
+  private function setXDebugStatus($contents): void {
     if (strpos($contents, ';zend_extension=xdebug.so') !== FALSE) {
       $this->xDebugEnabled = FALSE;
     }
@@ -88,7 +88,7 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    * @return bool|null
    *   $this->xDebugEnabled.
    */
-  protected function getXDebugStatus() {
+  private function getXDebugStatus() {
     return $this->xDebugEnabled;
   }
 
@@ -99,7 +99,7 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    * @param string $contents
    *   The contents of php.ini.
    */
-  protected function enableXDebug($destination_file, $contents): void {
+  private function enableXDebug($destination_file, $contents): void {
     $this->logger->notice("Enabling Xdebug PHP extension in $destination_file...");
 
     // Note that this replaces 1 or more ";" characters.
@@ -116,7 +116,7 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    * @param string $contents
    *   The contents of php.ini.
    */
-  protected function disableXDebug($destination_file, $contents) {
+  private function disableXDebug($destination_file, $contents) {
     $this->logger->notice("Disabling Xdebug PHP extension in $destination_file...");
     $new_contents = preg_replace('/(;)*(zend_extension=xdebug\.so)/', ';$2', $contents);
     file_put_contents($destination_file, $new_contents);

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -77,7 +77,7 @@ abstract class PullCommandBase extends CommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Psr\Cache\InvalidArgumentException
    */
-  public function initialize(InputInterface $input, OutputInterface $output) {
+  protected function initialize(InputInterface $input, OutputInterface $output) {
     parent::initialize($input, $output);
     $this->checklist = new Checklist($output);
   }
@@ -187,7 +187,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function pullCodeFromCloud(EnvironmentResponse $chosen_environment, $output_callback = NULL): void {
+  private function pullCodeFromCloud(EnvironmentResponse $chosen_environment, $output_callback = NULL): void {
     $is_dirty = $this->isLocalGitRepoDirty();
     if ($is_dirty) {
       throw new AcquiaCliException('Pulling code from your Cloud Platform environment was aborted because your local Git repository has uncommitted changes. Please either commit, reset, or stash your changes via git.');
@@ -209,7 +209,7 @@ abstract class PullCommandBase extends CommandBase {
    * @param null $output_callback
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function checkoutBranchFromEnv(EnvironmentResponse $environment, $output_callback = NULL): void {
+  private function checkoutBranchFromEnv(EnvironmentResponse $environment, $output_callback = NULL): void {
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
     $this->localMachineHelper->execute([
       'git',
@@ -228,7 +228,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function doImportRemoteDatabase(
+  private function doImportRemoteDatabase(
     string $database_host,
     string $database_user,
     string $database_name,
@@ -251,7 +251,7 @@ abstract class PullCommandBase extends CommandBase {
    * @return string
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function downloadDatabaseBackup(
+  private function downloadDatabaseBackup(
     $environment,
     $database,
     BackupResponse $backup_response,
@@ -321,7 +321,7 @@ abstract class PullCommandBase extends CommandBase {
   /**
    * @return \Psr\Http\Message\UriInterface|null
    */
-  public function getBackupDownloadUrl(): ?UriInterface {
+  protected function getBackupDownloadUrl(): ?UriInterface {
     if (isset($this->backupDownloadUrl)) {
       return $this->backupDownloadUrl;
     }
@@ -362,7 +362,7 @@ abstract class PullCommandBase extends CommandBase {
    * @param \stdClass $database
    * @param $acquia_cloud_client
    */
-  protected function createBackup(EnvironmentResponse $environment, stdClass $database, $acquia_cloud_client): void {
+  private function createBackup(EnvironmentResponse $environment, stdClass $database, $acquia_cloud_client): void {
     $backups = new DatabaseBackups($acquia_cloud_client);
     $response = $backups->create($environment->uuid, $database->name);
     $url_parts = explode('/', $response->links->notification->href);
@@ -397,7 +397,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function connectToLocalDatabase($db_host, $db_user, $db_name, $db_password, $output_callback = NULL): void {
+  private function connectToLocalDatabase($db_host, $db_user, $db_name, $db_password, $output_callback = NULL): void {
     if ($output_callback) {
       $output_callback('out', "Connecting to database $db_name");
     }
@@ -431,7 +431,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function dropLocalDatabase($db_host, $db_user, $db_name, $db_password, $output_callback = NULL): void {
+  private function dropLocalDatabase($db_host, $db_user, $db_name, $db_password, $output_callback = NULL): void {
     if ($output_callback) {
       $output_callback('out', "Dropping database $db_name");
     }
@@ -460,7 +460,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function createLocalDatabase($db_host, $db_user, $db_name, $db_password, $output_callback = NULL): void {
+  private function createLocalDatabase($db_host, $db_user, $db_name, $db_password, $output_callback = NULL): void {
     if ($output_callback) {
       $output_callback('out', "Creating new empty database $db_name");
     }
@@ -490,7 +490,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function importDatabaseDump(string $local_dump_filepath, string $db_host, string $db_user, string $db_name, string $db_password, $output_callback = NULL): void {
+  private function importDatabaseDump(string $local_dump_filepath, string $db_host, string $db_user, string $db_name, string $db_password, $output_callback = NULL): void {
     if ($output_callback) {
       $output_callback('out', "Importing downloaded file to database $db_name");
     }
@@ -574,7 +574,7 @@ abstract class PullCommandBase extends CommandBase {
    * @return array
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function promptChooseDatabases(
+  private function promptChooseDatabases(
     $cloud_environment,
     $environment_databases,
     $multiple_dbs
@@ -655,7 +655,7 @@ abstract class PullCommandBase extends CommandBase {
    * @return mixed|string
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function determineSite($environment, InputInterface $input) {
+  private function determineSite($environment, InputInterface $input) {
     if (isset($this->site)) {
       return $this->site;
     }
@@ -681,7 +681,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function rsyncFilesFromCloud($chosen_environment, Closure $output_callback = NULL, string $site): void {
+  private function rsyncFilesFromCloud($chosen_environment, Closure $output_callback = NULL, string $site): void {
     $sitegroup = self::getSiteGroupFromSshUrl($chosen_environment->sshUrl);
     if ($this->isAcsfEnv($chosen_environment)) {
       $source_dir = '/mnt/files/' . $sitegroup . '.' . $chosen_environment->name . '/sites/g/files/' . $site . '/files';
@@ -758,7 +758,7 @@ abstract class PullCommandBase extends CommandBase {
    * @return bool
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function determineCloneProject(OutputInterface $output): bool {
+  private function determineCloneProject(OutputInterface $output): bool {
     $finder = $this->localMachineHelper->getFinder()->files()->in($this->dir)->ignoreDotFiles(FALSE);
 
     // If we are in an IDE, assume we should pull into /home/ide/project.
@@ -793,7 +793,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function cloneFromCloud(EnvironmentResponse $chosen_environment, Closure $output_callback): void {
+  private function cloneFromCloud(EnvironmentResponse $chosen_environment, Closure $output_callback): void {
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
     $command = [
       'git',
@@ -873,7 +873,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @return bool
    */
-  protected function environmentPhpVersionMatches($environment): bool {
+  private function environmentPhpVersionMatches($environment): bool {
     $current_php_version = $this->getIdePhpVersion();
     return $environment->configuration->php->version === $current_php_version;
   }
@@ -950,7 +950,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function composerInstall($output_callback): void {
+  private function composerInstall($output_callback): void {
     $process = $this->localMachineHelper->execute([
       'composer',
       'install',
@@ -1005,7 +1005,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @return false|mixed
    */
-  protected function getDatabaseBackup(
+  private function getDatabaseBackup(
     Client $acquia_cloud_client,
     $environment,
     $database
@@ -1030,7 +1030,7 @@ abstract class PullCommandBase extends CommandBase {
    * @param BackupResponse $backup_response
    * @param \AcquiaCloudApi\Response\EnvironmentResponse $source_environment
    */
-  protected function printDatabaseBackupInfo(
+  private function printDatabaseBackupInfo(
     BackupResponse $backup_response,
     EnvironmentResponse $source_environment
   ): void {
@@ -1058,7 +1058,7 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @throws \Exception
    */
-  protected function importRemoteDatabase(stdClass $database, string $local_filepath, callable $output_callback = NULL): void {
+  private function importRemoteDatabase(stdClass $database, string $local_filepath, callable $output_callback = NULL): void {
     if ($database->flags->default) {
       $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);
     }

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -161,7 +161,7 @@ class PushArtifactCommand extends PullCommandBase {
    * @return false|mixed|null
    * @throws \Exception
    */
-  protected function determineDestinationGitUrls($application_uuid) {
+  private function determineDestinationGitUrls($application_uuid) {
     if ($this->input->getOption('destination-git-urls')) {
       return $this->input->getOption('destination-git-urls');
     }
@@ -185,7 +185,7 @@ class PushArtifactCommand extends PullCommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function cloneSourceBranch(Closure $output_callback, string $artifact_dir, string $vcs_url, string $vcs_path): void {
+  private function cloneSourceBranch(Closure $output_callback, string $artifact_dir, string $vcs_url, string $vcs_path): void {
     $fs = $this->localMachineHelper->getFilesystem();
 
     $output_callback('out', "Removing $artifact_dir if it exists");
@@ -229,7 +229,7 @@ class PushArtifactCommand extends PullCommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function buildArtifact(Closure $output_callback, string $artifact_dir): void {
+  private function buildArtifact(Closure $output_callback, string $artifact_dir): void {
     // @todo generate a deploy identifier
     // @see https://git.drupalcode.org/project/drupal/-/blob/9.1.x/sites/default/default.settings.php#L295
     $output_callback('out', "Mirroring source files from {$this->dir} to $artifact_dir");
@@ -257,7 +257,7 @@ class PushArtifactCommand extends PullCommandBase {
    * @param \Closure $output_callback
    * @param string $artifact_dir
    */
-  protected function sanitizeArtifact(Closure $output_callback, string $artifact_dir):void {
+  private function sanitizeArtifact(Closure $output_callback, string $artifact_dir): void {
     $output_callback('out', 'Finding Drupal core text files');
     $sanitizeFinder = $this->localMachineHelper->getFinder()
       ->files()
@@ -324,7 +324,7 @@ class PushArtifactCommand extends PullCommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function commit(Closure $output_callback, string $artifact_dir, string $commit_hash):void {
+  private function commit(Closure $output_callback, string $artifact_dir, string $commit_hash): void {
     $output_callback('out', 'Adding and committing changed files');
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
     $process = $this->localMachineHelper->execute(['git', 'add', '-A'], $output_callback, $artifact_dir, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
@@ -351,7 +351,7 @@ class PushArtifactCommand extends PullCommandBase {
    *
    * @return array|false|string
    */
-  public function generateCommitMessage(string $commit_hash) {
+  private function generateCommitMessage(string $commit_hash) {
     if ($env_var = getenv('ACLI_PUSH_ARTIFACT_COMMIT_MSG')) {
       return $env_var;
     }
@@ -369,7 +369,7 @@ class PushArtifactCommand extends PullCommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function pushArtifact(Closure $output_callback, string $artifact_dir, array $vcs_urls, string $dest_git_branch):void {
+  private function pushArtifact(Closure $output_callback, string $artifact_dir, array $vcs_urls, string $dest_git_branch): void {
     foreach ($vcs_urls as $vcs_url) {
       $output_callback('out', "Pushing changes to Acquia Git ($vcs_url)");
       $this->localMachineHelper->checkRequiredBinariesExist(['git']);
@@ -393,7 +393,7 @@ class PushArtifactCommand extends PullCommandBase {
    *
    * @return array|string[]
    */
-  protected function vendorDirs(string $artifact_dir): array {
+  private function vendorDirs(string $artifact_dir): array {
     if (!empty($this->vendorDirs)) {
       return $this->vendorDirs;
     }
@@ -419,7 +419,7 @@ class PushArtifactCommand extends PullCommandBase {
    *
    * @return array
    */
-  protected function scaffoldFiles(string $artifact_dir): array {
+  private function scaffoldFiles(string $artifact_dir): array {
     if (!empty($this->scaffoldFiles)) {
       return $this->scaffoldFiles;
     }
@@ -439,7 +439,7 @@ class PushArtifactCommand extends PullCommandBase {
   /**
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function validateSourceCode(): void {
+  private function validateSourceCode(): void {
     $required_paths = [
       $this->composerJsonPath,
       $this->docrootPath
@@ -456,7 +456,7 @@ class PushArtifactCommand extends PullCommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  protected function determineSourceGitRef() {
+  private function determineSourceGitRef() {
     if ($this->input->getOption('source-git-tag')) {
       return $this->input->getOption('source-git-tag');
     }
@@ -476,7 +476,7 @@ class PushArtifactCommand extends PullCommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  protected function determineDestinationGitRef() {
+  private function determineDestinationGitRef() {
     if ($this->input->getOption('destination-git-tag')) {
       $this->destinationGitRef = $this->input->getOption('destination-git-tag');
       return $this->destinationGitRef;
@@ -511,7 +511,7 @@ class PushArtifactCommand extends PullCommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function createTag($tag_name, Closure $output_callback, string $artifact_dir): void {
+  private function createTag($tag_name, Closure $output_callback, string $artifact_dir): void {
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
     $process = $this->localMachineHelper->execute([
       'git',

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -72,7 +72,7 @@ class PushDatabaseCommand extends PullCommandBase {
    * @return string
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function uploadDatabaseDump(
+  private function uploadDatabaseDump(
     $environment,
     $database,
     string $local_filepath,
@@ -105,7 +105,7 @@ class PushDatabaseCommand extends PullCommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function importDatabaseDumpOnRemote($environment, $remote_dump_filepath, $database): void {
+  private function importDatabaseDumpOnRemote($environment, $remote_dump_filepath, $database): void {
     $this->logger->debug("Importing $remote_dump_filepath to MySQL on remote machine");
     $command = "pv $remote_dump_filepath --bytes --rate | gunzip | MYSQL_PWD={$database->password} mysql --host={$this->getHostFromDatabaseResponse($environment, $database)} --user={$database->user_name} {$this->getNameFromDatabaseResponse($database)}";
     $process = $this->sshHelper->executeCommand($environment, [$command], ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL), NULL);
@@ -119,7 +119,7 @@ class PushDatabaseCommand extends PullCommandBase {
    *
    * @return string
    */
-  protected function getNameFromDatabaseResponse($database): string {
+  private function getNameFromDatabaseResponse($database): string {
     $db_url_parts = explode('/', $database->url);
     $db_name = end($db_url_parts);
 

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -65,7 +65,7 @@ class PushFilesCommand extends PullCommandBase {
    *
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function rsyncFilesToCloud($chosen_environment, $output_callback = NULL, $site = NULL): void {
+  private function rsyncFilesToCloud($chosen_environment, $output_callback = NULL, $site = NULL): void {
     $source = $this->dir . '/docroot/sites/default/files/';
     $sitegroup = self::getSiteGroupFromSshUrl($chosen_environment->sshUrl);
 

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -202,7 +202,7 @@ EOT
     $loop->run();
   }
 
-  protected function checkPermissions(array $perms, string $cloud_app_uuid, OutputInterface $output): array {
+  private function checkPermissions(array $perms, string $cloud_app_uuid, OutputInterface $output): array {
     $mappings = [];
     $needed_perms = ['add ssh key to git', 'add ssh key to non-prod', 'add ssh key to prod'];
     foreach ($needed_perms as $index => $perm) {
@@ -254,7 +254,7 @@ EOT
    * @return string
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
-  protected function doCreateSshKey($filename, $password): string {
+  private function doCreateSshKey($filename, $password): string {
     $filepath = $this->sshDir . '/' . $filename;
     if (file_exists($filepath)) {
       throw new AcquiaCliException('An SSH key with the filename {filepath} already exists. Please delete it and retry', ['filepath' => $filename]);
@@ -308,7 +308,7 @@ EOT
    *
    * @return mixed
    */
-  protected function validateFilename($filename) {
+  private function validateFilename($filename) {
     $violations = Validation::createValidator()->validate($filename, [
       new Length(['min' => 5]),
       new NotBlank(),
@@ -352,7 +352,7 @@ EOT
    *
    * @return string
    */
-  protected function validatePassword($password) {
+  private function validatePassword($password) {
     $violations = Validation::createValidator()->validate($password, [
       new Length(['min' => 5]),
       new NotBlank(),
@@ -370,7 +370,7 @@ EOT
    *
    * @return bool
    */
-  protected function keyHasUploaded($acquia_cloud_client, $public_key): bool {
+  private function keyHasUploaded($acquia_cloud_client, $public_key): bool {
     $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
     foreach ($cloud_keys as $cloud_key) {
       if (trim($cloud_key->public_key) === trim($public_key)) {
@@ -420,7 +420,7 @@ EOT
    *
    * @return string
    */
-  protected function promptChooseLocalSshKey($local_keys): string {
+  private function promptChooseLocalSshKey($local_keys): string {
     $labels = [];
     foreach ($local_keys as $local_key) {
       $labels[] = $local_key->getFilename();
@@ -459,7 +459,7 @@ EOT
    *
    * @return mixed
    */
-  protected function validateSshKeyLabel($label) {
+  private function validateSshKeyLabel($label) {
     if (trim($label) === '') {
       throw new RuntimeException('The label cannot be empty');
     }
@@ -474,7 +474,7 @@ EOT
    * @return string
    * @throws \Exception
    */
-  protected function getLocalSshKeyContents(array $local_keys, string $chosen_local_key): string {
+  private function getLocalSshKeyContents(array $local_keys, string $chosen_local_key): string {
     $filepath = '';
     foreach ($local_keys as $local_key) {
       if ($local_key->getFilename() === $chosen_local_key) {

--- a/src/Command/Ssh/SshKeyInfoCommand.php
+++ b/src/Command/Ssh/SshKeyInfoCommand.php
@@ -57,7 +57,7 @@ class SshKeyInfoCommand extends SshKeyCommandBase {
   /**
    * @throws \violuke\RsaSshKeyFingerprint\InvalidInputException
    */
-  protected function determineSshKey($acquia_cloud_client): array {
+  private function determineSshKey($acquia_cloud_client): array {
     $cloudKeysResponse = new SshKeys($acquia_cloud_client);
     $cloudKeys = (array) $cloudKeysResponse->getAll();
     $localKeys = $this->findLocalSshKeys();

--- a/src/Command/WizardCommandBase.php
+++ b/src/Command/WizardCommandBase.php
@@ -21,6 +21,7 @@ abstract class WizardCommandBase extends SshKeyCommandBase {
    *
    * @return void
    * @throws \Acquia\Cli\Exception\AcquiaCliException|\Psr\Cache\InvalidArgumentException
+   * @throws \Symfony\Component\Console\Exception\ExceptionInterface
    */
   protected function initialize(InputInterface $input, OutputInterface $output) {
     if ($this->commandRequiresAuthentication($input) && !$this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
@@ -54,7 +55,7 @@ abstract class WizardCommandBase extends SshKeyCommandBase {
    *
    * @return bool|int
    */
-  protected function savePassPhraseToFile(string $passphrase) {
+  protected function savePassPhraseToFile(string $passphrase): bool|int {
     return file_put_contents($this->passphraseFilepath, $passphrase);
   }
 

--- a/src/Descriptor/ReStructuredTextDescriptor.php
+++ b/src/Descriptor/ReStructuredTextDescriptor.php
@@ -23,8 +23,7 @@ use Symfony\Component\Console\Input\InputOption;
 /**
  * ReStructuredTextDescriptor descriptor.
  */
-class ReStructuredTextDescriptor extends MarkdownDescriptor
-{
+class ReStructuredTextDescriptor extends MarkdownDescriptor {
 
   // <h1>
   private $partChar = '#';
@@ -184,7 +183,7 @@ class ReStructuredTextDescriptor extends MarkdownDescriptor
    * @param $application
    * @param array $options
    */
-  protected function describeCommands(ApplicationDescription $description, $application, array $options): void {
+  private function describeCommands(ApplicationDescription $description, $application, array $options): void {
     $title = "Commands";
     $this->write("\n\n$title\n" . str_repeat($this->chapterChar, Helper::width($title)) . "\n\n");
     foreach ($this->visibleNamespaces as $namespace) {
@@ -211,7 +210,7 @@ class ReStructuredTextDescriptor extends MarkdownDescriptor
    * @param \Symfony\Component\Console\Descriptor\ApplicationDescription $description
    * @param \Symfony\Component\Console\Application $application
    */
-  protected function createTableOfContents(ApplicationDescription $description, Application $application): void {
+  private function createTableOfContents(ApplicationDescription $description, Application $application): void {
     $this->setVisibleNamespaces($description);
     $chapter_title = "Table of Contents";
     $this->write("\n\n$chapter_title\n" . str_repeat($this->chapterChar, Helper::width($chapter_title)) . "\n\n");
@@ -237,7 +236,7 @@ class ReStructuredTextDescriptor extends MarkdownDescriptor
    * @param \Symfony\Component\Console\Input\InputDefinition $definition
    * @return array
    */
-  protected function getNonDefaultOptions(InputDefinition $definition): array {
+  private function getNonDefaultOptions(InputDefinition $definition): array {
     $global_options = [
       'help',
       'quiet',
@@ -260,7 +259,7 @@ class ReStructuredTextDescriptor extends MarkdownDescriptor
   /**
   * @param \Symfony\Component\Console\Descriptor\ApplicationDescription $description
   */
-  protected function setVisibleNamespaces(ApplicationDescription $description) {
+  private function setVisibleNamespaces(ApplicationDescription $description) {
     $commands = $description->getCommands();
     foreach ($description->getNamespaces() as $namespace) {
       try {
@@ -292,7 +291,7 @@ class ReStructuredTextDescriptor extends MarkdownDescriptor
    *
    * @return array
    */
-  protected function removeAliasesAndHiddenCommands(array $commands): array {
+  private function removeAliasesAndHiddenCommands(array $commands): array {
     // Remove aliases.
     foreach ($commands as $key => $command) {
       if (in_array($key, $command->getAliases()) || $command->isHidden()) {

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -101,7 +101,7 @@ class ExceptionListener {
   /**
    *
    */
-  protected function writeApplicationAliasHelp(): void {
+  private function writeApplicationAliasHelp(): void {
     $this->helpMessages[] = "The <bg={$this->messagesBgColor};options=bold>applicationUuid</> argument must be a valid UUID or unique application alias accessible to your Cloud Platform user." . PHP_EOL . PHP_EOL
       . "An alias consists of an application name optionally prefixed with a hosting realm, e.g. <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>myapp</> or <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>prod.myapp</>." . PHP_EOL . PHP_EOL
       . "Run <bg={$this->messagesBgColor};options=bold>acli remote:aliases:list</> to see a list of all available aliases.";
@@ -110,7 +110,7 @@ class ExceptionListener {
   /**
    *
    */
-  protected function writeSiteAliasHelp(): void {
+  private function writeSiteAliasHelp(): void {
     $this->helpMessages[] = "<bg={$this->messagesBgColor};options=bold>environmentId</> can also be a site alias. E.g. <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>myapp.dev</>." . PHP_EOL
     . "Run <bg={$this->messagesBgColor};options=bold>acli remote:aliases:list</> to see a list of all available aliases.";
   }
@@ -118,7 +118,7 @@ class ExceptionListener {
   /**
    * @param \Symfony\Component\Console\Event\ConsoleErrorEvent $event
    */
-  protected function writeSupportTicketHelp(ConsoleErrorEvent $event): void {
+  private function writeSupportTicketHelp(ConsoleErrorEvent $event): void {
     $message = "You can submit a support ticket at https://support-acquia.force.com/s/contactsupport";
     if (!$event->getOutput()->isVeryVerbose()) {
       $message .= PHP_EOL . "Please re-run the command with the <bg={$this->messagesBgColor};fg={$this->messagesFgColor};options=bold>-vvv</> flag and include the full command output in your support ticket.";
@@ -129,7 +129,7 @@ class ExceptionListener {
   /**
    * @param \Symfony\Component\Console\Event\ConsoleErrorEvent $event
    */
-  protected function writeUpdateHelp(ConsoleErrorEvent $event): void {
+  private function writeUpdateHelp(ConsoleErrorEvent $event): void {
     try {
       $command = $event->getCommand();
       if ($command

--- a/src/Helpers/DataStoreContract.php
+++ b/src/Helpers/DataStoreContract.php
@@ -5,4 +5,5 @@ namespace Acquia\Cli\Helpers;
 class DataStoreContract {
   const SEND_TELEMETRY = 'send_telemetry';
   const USER = 'user';
+
 }

--- a/src/Helpers/IdeCommandTrait.php
+++ b/src/Helpers/IdeCommandTrait.php
@@ -12,7 +12,7 @@ trait IdeCommandTrait {
   /**
    * @return string
    */
-  protected function getIdePhpVersion(): string {
+  private function getIdePhpVersion(): string {
     return trim($this->localMachineHelper->readFile($this->getIdePhpVersionFilePath()));
   }
 
@@ -26,7 +26,7 @@ trait IdeCommandTrait {
   /**
    * @return string
    */
-  public function getIdePhpVersionFilePath(): string {
+  protected function getIdePhpVersionFilePath(): string {
     if (!isset($this->phpVersionFilePath)) {
       $this->phpVersionFilePath = '/home/ide/configs/php/.version';
     }

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -160,7 +160,7 @@ class LocalMachineHelper {
    *
    * @return \Symfony\Component\Process\Process
    */
-  protected function executeProcess(Process $process, callable $callback = NULL, ?bool $print_output = TRUE): Process {
+  private function executeProcess(Process $process, callable $callback = NULL, ?bool $print_output = TRUE): Process {
     if ($callback === NULL && $print_output !== FALSE) {
       $callback = function ($type, $buffer) {
         $this->output->write($buffer);

--- a/src/Helpers/SshCommandTrait.php
+++ b/src/Helpers/SshCommandTrait.php
@@ -10,7 +10,7 @@ trait SshCommandTrait {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  public function deleteSshKeyFromCloud($output, $cloud_key = NULL): int {
+  private function deleteSshKeyFromCloud($output, $cloud_key = NULL): int {
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     if (!$cloud_key) {
       $cloud_key = $this->determineCloudKey($acquia_cloud_client);
@@ -46,7 +46,7 @@ trait SshCommandTrait {
    *
    * @return array|object|null
    */
-  protected function determineCloudKey($acquia_cloud_client) {
+  private function determineCloudKey($acquia_cloud_client) {
     $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
     return $this->promptChooseFromObjectsOrArrays(
       $cloud_keys,

--- a/src/Helpers/SshHelper.php
+++ b/src/Helpers/SshHelper.php
@@ -78,7 +78,7 @@ class SshHelper implements LoggerAwareInterface {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  protected function sendCommand($url, $command, $print_output, $timeout = NULL): Process {
+  private function sendCommand($url, $command, $print_output, $timeout = NULL): Process {
     $command = array_values($this->getSshCommand($url, $command));
     $this->localMachineHelper->checkRequiredBinariesExist(['ssh']);
 
@@ -156,7 +156,7 @@ class SshHelper implements LoggerAwareInterface {
    *
    * @return array
    */
-  protected function getSshCommand(string $url, $command): array {
+  private function getSshCommand(string $url, $command): array {
     return array_merge($this->getConnectionArgs($url), $command);
   }
 

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -97,7 +97,7 @@ class TelemetryHelper {
    *   Telemetry user data.
    * @throws \Exception
    */
-  protected function getTelemetryUserData(): array {
+  private function getTelemetryUserData(): array {
     $data = [
       'ah_env' => AcquiaDrupalEnvironmentDetector::getAhEnv(),
       'ah_group' => AcquiaDrupalEnvironmentDetector::getAhGroup(),
@@ -126,7 +126,7 @@ class TelemetryHelper {
    *   User UUID from Cloud.
    * @throws \Exception
    */
-  public function getUserId(): ?string {
+  private function getUserId(): ?string {
     $user = $this->getUserData();
     if ($user && isset($user['uuid'])) {
       return $user['uuid'];
@@ -142,7 +142,7 @@ class TelemetryHelper {
    *   User account data from Cloud.
    * @throws \Exception
    */
-  protected function getUserData(): ?array {
+  private function getUserData(): ?array {
     $user = $this->datastoreCloud->get(DataStoreContract::USER);
     if (!$user && $this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
       $this->setDefaultUserData();
@@ -155,7 +155,7 @@ class TelemetryHelper {
   /**
    * This requires the machine to be authenticated.
    */
-  protected function setDefaultUserData(): void {
+  private function setDefaultUserData(): void {
     $user = $this->getDefaultUserData();
     $this->datastoreCloud->set(DataStoreContract::USER, $user);
   }
@@ -165,7 +165,7 @@ class TelemetryHelper {
    *
    * @return array
    */
-  protected function getDefaultUserData(): array {
+  private function getDefaultUserData(): array {
     // @todo Cache this!
     $account = new Account($this->cloudApiClientService->getClient());
     return [

--- a/src/Output/Checklist.php
+++ b/src/Output/Checklist.php
@@ -63,7 +63,7 @@ class Checklist {
   /**
    *
    */
-  protected function getLastItem() {
+  private function getLastItem() {
     return end($this->items);
   }
 

--- a/src/Output/Spinner/Spinner.php
+++ b/src/Output/Spinner/Spinner.php
@@ -169,7 +169,7 @@ class Spinner {
   /**
    *
    */
-  protected function getSpinnerCharacter(): ?string {
+  private function getSpinnerCharacter(): ?string {
     if ($this->currentColorIdx === $this->colorCount) {
       $this->currentColorIdx = 0;
     }

--- a/tests/phpunit/src/ApplicationTestBase.php
+++ b/tests/phpunit/src/ApplicationTestBase.php
@@ -23,7 +23,7 @@ class ApplicationTestBase extends TestBase {
    */
   protected Kernel $kernel;
 
-  public function setUp($output = NULL):void {
+  public function setUp($output = NULL): void {
     parent::setUp($output);
     $this->kernel = new Kernel('dev', 0);
     $this->kernel->boot();

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardTestBase.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardTestBase.php
@@ -10,4 +10,5 @@ use Acquia\Cli\Tests\Commands\WizardTestBase;
  */
 abstract class IdeWizardTestBase extends WizardTestBase {
   use IdeRequiredTestTrait;
+
 }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
@@ -12,8 +12,7 @@ use Symfony\Component\Console\Command\Command;
  * @property SshKeyDeleteCommand $command
  * @package Acquia\Cli\Tests\Ssh
  */
-class SshKeyDeleteCommandTest extends CommandTestBase
-{
+class SshKeyDeleteCommandTest extends CommandTestBase {
 
   /**
    * {@inheritdoc}

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -11,8 +11,7 @@ use Symfony\Component\Console\Command\Command;
  * @property SshKeyListCommand $command
  * @package Acquia\Cli\Tests\Ssh
  */
-class SshKeyListCommandTest extends CommandTestBase
-{
+class SshKeyListCommandTest extends CommandTestBase {
 
   /**
    * {@inheritdoc}

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -15,8 +15,7 @@ use Symfony\Component\Filesystem\Path;
  * @property SshKeyUploadCommand $command
  * @package Acquia\Cli\Tests\Ssh
  */
-class SshKeyUploadCommandTest extends CommandTestBase
-{
+class SshKeyUploadCommandTest extends CommandTestBase {
 
   /**
    * @var array


### PR DESCRIPTION
This should kill a whole bunch of escaped mutants related to method visibility.

For posterity, here's the script I threw together to fix these in bulk.

Maybe this should be a standalone package...

```
<?php

$json = file_get_contents('infection-report.json');
$decoded = json_decode($json, FALSE);
foreach ($decoded->escaped as $mutant) {
  $mutator = $mutant->mutator;
  $file = file($mutator->originalFilePath);
  $index = $mutator->originalStartLine - 1;
  if ($mutator->mutatorName === 'PublicVisibility') {
    $search = 'public function';
    $replace = 'protected function';
  }
  else if ($mutator->mutatorName === 'ProtectedVisibility') {
    $search = 'protected function';
    $replace = 'private function';
  }
  $file[$index] = str_replace($search, $replace, $file[$index]);
  file_put_contents($mutant->mutator->originalFilePath, $file);
}
```