### PR TITLE
CLI-829: env:create error

### DIFF
--- a/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
@@ -3,7 +3,9 @@
 namespace Acquia\Cli\Tests\Commands\Env;
 
 use Acquia\Cli\Command\Env\EnvCreateCommand;
+use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\CommandTestBase;
+use Exception;
 use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 
@@ -15,37 +17,15 @@ use Symfony\Component\Console\Command\Command;
  */
 class EnvCreateCommandTest extends CommandTestBase {
 
-  /**
-   * {@inheritdoc}
-   */
-  protected function createCommand(): Command {
-    return $this->injectCommand(EnvCreateCommand::class);
-  }
+  private static string $validLabel = 'New CDE';
 
   /**
-   * @return array
+   * @param string $label
+   *
+   * @return string
    * @throws \Psr\Cache\InvalidArgumentException
    */
-  public function providerTestCreateCde(): array {
-    $applications_response = $this->getMockResponseFromSpec('/applications',
-      'get', '200');
-    $application_response = $applications_response->{'_embedded'}->items[0];
-    return [
-      [$application_response->uuid],
-      [NULL],
-    ];
-  }
-
-  /**
-   * Tests the 'app:environment:create' command.
-   *
-   * @dataProvider providerTestCreateCde
-   *
-   * @throws \Exception
-   * @throws \Psr\Cache\InvalidArgumentException
-   */
-  public function testCreateCde($application_uuid): void {
-    $label = "New CDE";
+  private function setupCdeTest(string $label): string {
     $applications_response = $this->mockApplicationsRequest();
     $application_response = $this->mockApplicationRequest();
     $this->mockEnvironmentsRequest($applications_response);
@@ -62,45 +42,140 @@ class EnvCreateCommandTest extends CommandTestBase {
 
     $code_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
     $this->clientProphecy->request('get',
-      "/applications/{$application_response->uuid}/code")
+      "/applications/$application_response->uuid/code")
       ->willReturn($code_response->_embedded->items)
       ->shouldBeCalled();
 
     $databases_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/databases", 'get', '200');
     $this->clientProphecy->request('get',
-      "/applications/{$application_response->uuid}/databases")
+      "/applications/$application_response->uuid/databases")
       ->willReturn($databases_response->_embedded->items)
       ->shouldBeCalled();
 
     $environments_response = $this->getMockResponseFromSpec('/applications/{applicationUuid}/environments',
       'post', 202);
-    $this->clientProphecy->request('post', "/applications/{$application_response->uuid}/environments", Argument::type('array'))
+    $this->clientProphecy->request('post', "/applications/$application_response->uuid/environments", Argument::type('array'))
       ->willReturn($environments_response->{'Adding environment'}->value)
       ->shouldBeCalled();
 
-    $notifications_response = $this->getMockResponseFromSpec( "/notifications/{notificationUuid}", 'get', '200');
+    $notifications_response = $this->getMockResponseFromSpec("/notifications/{notificationUuid}", 'get', '200');
     $this->clientProphecy->request('get', Argument::containingString("/notifications/"))
       ->willReturn($notifications_response)
       ->shouldBeCalled();
+    return $response2->_embedded->items[3]->domains[0];
+  }
+
+  /**
+   * @return string
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  private function getBranch(): string {
+    $code_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
+    return $code_response->_embedded->items[0]->name;
+  }
+
+  /**
+   * @return string
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  private function getApplication(): string {
+    $applications_response = $this->getMockResponseFromSpec('/applications',
+      'get', '200');
+    return $applications_response->{'_embedded'}->items[0]->uuid;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function createCommand(): Command {
+    return $this->injectCommand(EnvCreateCommand::class);
+  }
+
+  /**
+   * @return array
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function providerTestCreateCde(): array {
+    $application = $this->getApplication();
+    $branch = $this->getBranch();
+    return [
+      // No args, only interactive input.
+      [[NULL, NULL], ['n', 0, 0]],
+      // Branch as arg.
+      [[$branch, NULL], ['n', 0]],
+      // Branch and app id as args.
+      [[$branch, $application], []],
+    ];
+  }
+
+  /**
+   * Tests the 'app:environment:create' command.
+   *
+   * @dataProvider providerTestCreateCde
+   *
+   * @throws \Exception
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function testCreateCde($args, $input): void {
+    $domain = $this->setupCdeTest(self::$validLabel);
 
     $this->executeCommand(
       [
-        'label' => $label,
-        'branch' => $code_response->_embedded->items[0]->name,
-        'applicationUuid' => $application_uuid,
+        'label' => self::$validLabel,
+        'branch' => $args[0],
+        'applicationUuid' => $args[1],
       ],
-      [
-        // Would you like Acquia CLI to search for a Cloud application that matches your local git config?'
-        'n',
-        // Please select a Cloud Platform application: [Sample application 1]:
-        0,
-      ]
+      $input
     );
 
     $output = $this->getDisplay();
     $this->assertEquals(0, $this->getStatusCode());
-    $this->assertStringContainsString("Your CDE URL: {$response2->_embedded->items[3]->domains[0]}", $output);
+    $this->assertStringContainsString("Your CDE URL: $domain", $output);
+  }
 
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \Exception
+   */
+  public function testCreateCdeNonUniqueLabel(): void {
+    $label = 'Dev';
+    $this->setupCdeTest($label);
+
+    try {
+      $this->executeCommand(
+        [
+          'label' => $label,
+          'branch' => $this->getBranch(),
+          'applicationUuid' => $this->getApplication(),
+        ]
+      );
+    }
+    catch (Exception $e) {
+      $this->assertInstanceOf(AcquiaCliException::class, $e);
+      $this->assertEquals('An environment named Dev already exists.', $e->getMessage());
+    }
+  }
+
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \Exception
+   */
+  public function testCreateCdeInvalidTag(): void {
+    $this->setupCdeTest(self::$validLabel);
+
+    try {
+      $this->executeCommand(
+        [
+          'label' => self::$validLabel,
+          'branch' => 'bogus',
+          'applicationUuid' => $this->getApplication(),
+        ]
+      );
+    }
+    catch (Exception $e) {
+      $this->assertInstanceOf(AcquiaCliException::class, $e);
+      $this->assertEquals('There is no branch or tag with the name bogus on the remote VCS.', $e->getMessage());
+    }
   }
 
 }


### PR DESCRIPTION
**Motivation**

Running `env:create` with interactive branch name selection throws an error
