### PR TITLE
IDE-2272: Refresh tokens should not expire during ACLI calls

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
         convertDeprecationsToExceptions="true"
+        bootstrap="tests/phpunit/bootstrap.php"
 >
   <coverage processUncoveredFiles="true">
     <include>

--- a/src/AcsfApi/AcsfClientService.php
+++ b/src/AcsfApi/AcsfClientService.php
@@ -32,7 +32,7 @@ class AcsfClientService extends ClientService {
   /**
    * @return bool
    */
-  public function checkAuthentication(): bool {
+  protected function checkAuthentication(): bool {
     return ($this->credentials->getCloudKey() && $this->credentials->getCloudSecret());
   }
 

--- a/src/AcsfApi/AcsfClientService.php
+++ b/src/AcsfApi/AcsfClientService.php
@@ -30,22 +30,10 @@ class AcsfClientService extends ClientService {
   }
 
   /**
-   * @param CloudDataStore $cloud_datastore
-   *
-   * @return bool|null
+   * @return bool
    */
-  public function isMachineAuthenticated(): ?bool {
-    if ($this->machineIsAuthenticated) {
-      return $this->machineIsAuthenticated;
-    }
-
-    if ($this->credentials->getCloudKey() && $this->credentials->getCloudSecret()) {
-      $this->machineIsAuthenticated = TRUE;
-      return $this->machineIsAuthenticated;
-    }
-
-    $this->machineIsAuthenticated = FALSE;
-    return $this->machineIsAuthenticated;
+  public function checkAuthentication(): bool {
+    return ($this->credentials->getCloudKey() && $this->credentials->getCloudSecret());
   }
 
 }

--- a/src/AcsfApi/AcsfClientService.php
+++ b/src/AcsfApi/AcsfClientService.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\AcsfApi;
 
 use Acquia\Cli\Application;
 use Acquia\Cli\CloudApi\ClientService;
+use Acquia\Cli\CloudApi\CloudCredentials;
 use Acquia\Cli\DataStore\CloudDataStore;
 
 /**
@@ -15,8 +16,8 @@ class AcsfClientService extends ClientService {
    * @param \Acquia\Cli\AcsfApi\AcsfConnectorFactory $connector_factory
    * @param \Acquia\Cli\Application $application
    */
-  public function __construct(AcsfConnectorFactory $connector_factory, Application $application) {
-    parent::__construct($connector_factory, $application);
+  public function __construct(AcsfConnectorFactory $connector_factory, Application $application, CloudCredentials $cloudCredentials) {
+    parent::__construct($connector_factory, $application, $cloudCredentials);
   }
 
   /**

--- a/src/AcsfApi/AcsfClientService.php
+++ b/src/AcsfApi/AcsfClientService.php
@@ -4,8 +4,6 @@ namespace Acquia\Cli\AcsfApi;
 
 use Acquia\Cli\Application;
 use Acquia\Cli\CloudApi\ClientService;
-use Acquia\Cli\CloudApi\CloudCredentials;
-use Acquia\Cli\DataStore\CloudDataStore;
 
 /**
  * AcsfClientService class.
@@ -15,13 +13,14 @@ class AcsfClientService extends ClientService {
   /**
    * @param \Acquia\Cli\AcsfApi\AcsfConnectorFactory $connector_factory
    * @param \Acquia\Cli\Application $application
+   * @param \Acquia\Cli\AcsfApi\AcsfCredentials $cloudCredentials
    */
-  public function __construct(AcsfConnectorFactory $connector_factory, Application $application, CloudCredentials $cloudCredentials) {
+  public function __construct(AcsfConnectorFactory $connector_factory, Application $application, AcsfCredentials $cloudCredentials) {
     parent::__construct($connector_factory, $application, $cloudCredentials);
   }
 
   /**
-   * @return \AcquiaCloudApi\Connector\Client
+   * @return \Acquia\Cli\AcsfApi\AcsfClient
    */
   public function getClient(): AcsfClient {
     $client = AcsfClient::factory($this->connector);
@@ -33,21 +32,14 @@ class AcsfClientService extends ClientService {
   /**
    * @param CloudDataStore $cloud_datastore
    *
-   * @return bool
+   * @return bool|null
    */
-  public function isMachineAuthenticated(CloudDataStore $cloud_datastore): ?bool {
+  public function isMachineAuthenticated(): ?bool {
     if ($this->machineIsAuthenticated) {
       return $this->machineIsAuthenticated;
     }
 
-    if (getenv('ACSF_USERNAME') && getenv('ACSF_KEY') ) {
-      $this->machineIsAuthenticated = TRUE;
-      return $this->machineIsAuthenticated;
-    }
-
-    $factory = $cloud_datastore->get('acsf_active_factory');
-    $keys = $cloud_datastore->get('acsf_factories');
-    if ($factory && $keys && array_key_exists($factory, $keys)) {
+    if ($this->credentials->getCloudKey() && $this->credentials->getCloudSecret()) {
       $this->machineIsAuthenticated = TRUE;
       return $this->machineIsAuthenticated;
     }

--- a/src/AcsfApi/AcsfCredentials.php
+++ b/src/AcsfApi/AcsfCredentials.php
@@ -10,10 +10,7 @@ use Acquia\Cli\DataStore\CloudDataStore;
  */
 class AcsfCredentials implements ApiCredentialsInterface {
 
-  /**
-   * @var \Acquia\Cli\DataStore\CloudDataStore
-   */
-  private $datastoreCloud;
+  private CloudDataStore $datastoreCloud;
 
   /**
    * CloudCredentials constructor.
@@ -46,7 +43,7 @@ class AcsfCredentials implements ApiCredentialsInterface {
    *
    * @return mixed|null
    */
-  public function getFactoryActiveUser(array $factory) {
+  public function getFactoryActiveUser(array $factory): mixed {
     if (array_key_exists('active_user', $factory)) {
       $active_user = $factory['active_user'];
       if (array_key_exists($active_user, $factory['users'])) {

--- a/src/ApiCredentialsInterface.php
+++ b/src/ApiCredentialsInterface.php
@@ -6,4 +6,8 @@ interface ApiCredentialsInterface {
 
   public function getBaseUri(): ?string;
 
+  public function getCloudKey(): ?string;
+
+  public function getCloudSecret(): ?string;
+
 }

--- a/src/CloudApi/ClientService.php
+++ b/src/CloudApi/ClientService.php
@@ -2,10 +2,10 @@
 
 namespace Acquia\Cli\CloudApi;
 
+use Acquia\Cli\ApiCredentialsInterface;
 use Acquia\Cli\Application;
 use Acquia\Cli\ClientServiceInterface;
 use Acquia\Cli\ConnectorFactoryInterface;
-use Acquia\Cli\DataStore\CloudDataStore;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Connector\ConnectorInterface;
 
@@ -24,18 +24,18 @@ class ClientService implements ClientServiceInterface {
   protected ConnectorFactoryInterface|ConnectorFactory $connectorFactory;
   protected Application $application;
   protected ?bool $machineIsAuthenticated = NULL;
-  protected CloudCredentials $cloudCredentials;
+  protected ApiCredentialsInterface $credentials;
 
   /**
    * @param \Acquia\Cli\CloudApi\ConnectorFactory $connector_factory
    * @param \Acquia\Cli\Application $application
-   * @param \Acquia\Cli\CloudApi\CloudCredentials $cloudCredentials
+   * @param \Acquia\Cli\ApiCredentialsInterface $credentials
    */
-  public function __construct(ConnectorFactoryInterface $connector_factory, Application $application, CloudCredentials $cloudCredentials) {
+  public function __construct(ConnectorFactoryInterface $connector_factory, Application $application, ApiCredentialsInterface $credentials) {
     $this->connectorFactory = $connector_factory;
     $this->setConnector($connector_factory->createConnector());
     $this->setApplication($application);
-    $this->cloudCredentials = $cloudCredentials;
+    $this->credentials = $credentials;
   }
 
   /**
@@ -77,17 +77,17 @@ class ClientService implements ClientServiceInterface {
    *
    * @return bool|null
    */
-  public function isMachineAuthenticated(CloudDataStore $cloud_datastore): ?bool {
+  public function isMachineAuthenticated(): ?bool {
     if ($this->machineIsAuthenticated) {
       return $this->machineIsAuthenticated;
     }
 
-    if ($this->cloudCredentials->getCloudAccessToken()) {
+    if ($this->credentials->getCloudAccessToken()) {
       $this->machineIsAuthenticated = TRUE;
       return $this->machineIsAuthenticated;
     }
 
-    if ($this->cloudCredentials->getCloudKey() && $this->cloudCredentials->getCloudSecret()) {
+    if ($this->credentials->getCloudKey() && $this->credentials->getCloudSecret()) {
       $this->machineIsAuthenticated = TRUE;
       return $this->machineIsAuthenticated;
     }

--- a/src/CloudApi/ClientService.php
+++ b/src/CloudApi/ClientService.php
@@ -73,27 +73,21 @@ class ClientService implements ClientServiceInterface {
   }
 
   /**
-   * @param CloudDataStore $cloud_datastore
-   *
-   * @return bool|null
+   * @return bool
    */
-  public function isMachineAuthenticated(): ?bool {
-    if ($this->machineIsAuthenticated) {
+  public function isMachineAuthenticated(): bool {
+    if ($this->machineIsAuthenticated !== NULL) {
       return $this->machineIsAuthenticated;
     }
-
-    if ($this->credentials->getCloudAccessToken()) {
-      $this->machineIsAuthenticated = TRUE;
-      return $this->machineIsAuthenticated;
-    }
-
-    if ($this->credentials->getCloudKey() && $this->credentials->getCloudSecret()) {
-      $this->machineIsAuthenticated = TRUE;
-      return $this->machineIsAuthenticated;
-    }
-
-    $this->machineIsAuthenticated = FALSE;
+    $this->machineIsAuthenticated = $this->checkAuthentication();
     return $this->machineIsAuthenticated;
+  }
+
+  protected function checkAuthentication(): bool {
+    return (
+      $this->credentials->getCloudAccessToken() ||
+      ($this->credentials->getCloudKey() && $this->credentials->getCloudSecret())
+    );
   }
 
 }

--- a/src/CloudApi/CloudCredentials.php
+++ b/src/CloudApi/CloudCredentials.php
@@ -10,10 +10,7 @@ use Acquia\Cli\DataStore\CloudDataStore;
  */
 class CloudCredentials implements ApiCredentialsInterface {
 
-  /**
-   * @var \Acquia\Cli\DataStore\CloudDataStore
-   */
-  private $datastoreCloud;
+  private CloudDataStore $datastoreCloud;
 
   /**
    * CloudCredentials constructor.
@@ -32,6 +29,10 @@ class CloudCredentials implements ApiCredentialsInterface {
       return getenv('ACLI_ACCESS_TOKEN');
     }
 
+    if (getenv('ACLI_ACCESS_TOKEN_FILE')) {
+      return file_get_contents(getenv('ACLI_ACCESS_TOKEN_FILE'));
+    }
+
     return NULL;
   }
 
@@ -41,6 +42,10 @@ class CloudCredentials implements ApiCredentialsInterface {
   public function getCloudAccessTokenExpiry(): ?string {
     if (getenv('ACLI_ACCESS_TOKEN_EXPIRY')) {
       return getenv('ACLI_ACCESS_TOKEN_EXPIRY');
+    }
+
+    if (getenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE')) {
+      return file_get_contents(getenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE'));
     }
 
     return NULL;

--- a/src/Command/Acsf/AcsfApiAuthLogoutCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLogoutCommand.php
@@ -36,7 +36,7 @@ class AcsfApiAuthLogoutCommand extends AcsfCommandBase {
    * @throws \Exception
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    if (!$this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
+    if (!$this->cloudApiClientService->isMachineAuthenticated()) {
       $this->io->error(['You are not logged into any factories.']);
       return 1;
     }

--- a/src/Command/Acsf/AcsfApiBaseCommand.php
+++ b/src/Command/Acsf/AcsfApiBaseCommand.php
@@ -17,7 +17,7 @@ class AcsfApiBaseCommand extends ApiBaseCommand {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   protected function checkAuthentication(): void {
-    if ($this->commandRequiresAuthentication($this->input) && !$this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
+    if ($this->commandRequiresAuthentication($this->input) && !$this->cloudApiClientService->isMachineAuthenticated()) {
       throw new AcquiaCliException('This machine is not yet authenticated with the Acquia Cloud Site Factory. Please run `acli auth:acsf-login`');
     }
   }

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -42,7 +42,7 @@ class AuthLoginCommand extends CommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     /** @var \Acquia\Cli\DataStore\CloudDataStore $cloud_datastore */
-    if ($this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
+    if ($this->cloudApiClientService->isMachineAuthenticated()) {
       $answer = $this->io->confirm('Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?');
       if (!$answer) {
         return 0;

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -39,7 +39,7 @@ class AuthLogoutCommand extends CommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     /** @var \Acquia\Cli\DataStore\CloudDataStore $cloud_datastore */
-    if ($this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
+    if ($this->cloudApiClientService->isMachineAuthenticated()) {
       $answer = $this->io->confirm('Are you sure you\'d like to unset the Acquia Cloud API key for Acquia CLI?');
       if (!$answer) {
         return 0;

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1773,7 +1773,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   protected function checkAuthentication(): void {
-    if ($this->commandRequiresAuthentication($this->input) && !$this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
+    if ($this->commandRequiresAuthentication($this->input) && !$this->cloudApiClientService->isMachineAuthenticated()) {
       throw new AcquiaCliException('This machine is not yet authenticated with the Cloud Platform. Please run `acli auth:login`');
     }
   }

--- a/src/Command/Self/ClearCacheCommand.php
+++ b/src/Command/Self/ClearCacheCommand.php
@@ -18,7 +18,7 @@ class ClearCacheCommand extends CommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Clears local Acquia CLI caches')
       ->setAliases(['cc', 'cr']);
   }
@@ -29,7 +29,7 @@ class ClearCacheCommand extends CommandBase {
    *
    * @return int
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     self::clearCaches();
     $output->writeln('Acquia CLI caches were cleared.');
 

--- a/src/Command/WizardCommandBase.php
+++ b/src/Command/WizardCommandBase.php
@@ -24,7 +24,7 @@ abstract class WizardCommandBase extends SshKeyCommandBase {
    * @throws \Symfony\Component\Console\Exception\ExceptionInterface
    */
   protected function initialize(InputInterface $input, OutputInterface $output) {
-    if ($this->commandRequiresAuthentication($input) && !$this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
+    if ($this->commandRequiresAuthentication($input) && !$this->cloudApiClientService->isMachineAuthenticated()) {
       $command_name = 'auth:login';
       $command = $this->getApplication()->find($command_name);
       $arguments = ['command' => $command_name];

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -144,7 +144,7 @@ class TelemetryHelper {
    */
   private function getUserData(): ?array {
     $user = $this->datastoreCloud->get(DataStoreContract::USER);
-    if (!$user && $this->cloudApiClientService->isMachineAuthenticated($this->datastoreCloud)) {
+    if (!$user && $this->cloudApiClientService->isMachineAuthenticated()) {
       $this->setDefaultUserData();
       $user = $this->datastoreCloud->get(DataStoreContract::USER);
     }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+use Symfony\Component\Filesystem\Filesystem;
+
+// ensure a fresh cache when debug mode is disabled
+(new Filesystem())->remove(__DIR__ . '/../../var/cache/dev');

--- a/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
+++ b/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
@@ -4,14 +4,21 @@ namespace Acquia\Cli\Tests\AcsfApi;
 
 use Acquia\Cli\AcsfApi\AcsfClientService;
 use Acquia\Cli\AcsfApi\AcsfConnectorFactory;
+use Acquia\Cli\AcsfApi\AcsfCredentials;
 use Acquia\Cli\Application;
-use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Tests\TestBase;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class CloudServiceTest.
  */
 class AcsfServiceTest extends TestBase {
+
+  protected function setUp(OutputInterface $output = NULL): void {
+    parent::setUp($output);
+    $this->cloudCredentials = new AcsfCredentials($this->datastoreCloud);
+
+  }
 
   /**
    * @return array[]
@@ -42,11 +49,10 @@ class AcsfServiceTest extends TestBase {
    * @param array $env_vars
    * @param bool $is_authenticated
    */
-  public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated) {
+  public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated): void {
     self::setEnvVars($env_vars);
     $client_service = new AcsfClientService(new AcsfConnectorFactory(['key' => NULL, 'secret' => NULL]), $this->prophet->prophesize(Application::class)->reveal(), $this->cloudCredentials);
-    $cloud_datastore = $this->prophet->prophesize(CloudDataStore::class);
-    $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated($cloud_datastore->reveal()));
+    $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated());
     self::unsetEnvVars($env_vars);
   }
 

--- a/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
+++ b/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
@@ -44,7 +44,7 @@ class AcsfServiceTest extends TestBase {
    */
   public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated) {
     self::setEnvVars($env_vars);
-    $client_service = new AcsfClientService(new AcsfConnectorFactory(['key' => NULL, 'secret' => NULL]), $this->prophet->prophesize(Application::class)->reveal());
+    $client_service = new AcsfClientService(new AcsfConnectorFactory(['key' => NULL, 'secret' => NULL]), $this->prophet->prophesize(Application::class)->reveal(), $this->cloudCredentials);
     $cloud_datastore = $this->prophet->prophesize(CloudDataStore::class);
     $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated($cloud_datastore->reveal()));
     self::unsetEnvVars($env_vars);

--- a/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
+++ b/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
@@ -44,12 +44,12 @@ class AccessTokenConnectorTest extends TestBase {
     putenv('ACLI_ACCESS_TOKEN_EXPIRY=' . $accessTokenExpiry);
   }
 
-  public static function unsetAccessTokenEnvVars() {
+  public static function unsetAccessTokenEnvVars(): void {
     putenv('ACLI_ACCESS_TOKEN');
     putenv('ACLI_ACCESS_TOKEN_EXPIRY');
   }
 
-  public function testAccessToken() {
+  public function testAccessToken(): void {
     // Ensure that ACLI_ACCESS_TOKEN was used to populate the refresh token.
     self::assertEquals(self::$accessToken, $this->cloudCredentials->getCloudAccessToken());
     $connector_factory = new ConnectorFactory(
@@ -81,7 +81,7 @@ class AccessTokenConnectorTest extends TestBase {
    * Validate that if both an access token and API key/secret pair are present,
    * the pair is used.
    */
-  public function testConnector() {
+  public function testConnector(): void {
     // Ensure that ACLI_ACCESS_TOKEN was used to populate the refresh token.
     self::assertEquals(self::$accessToken, $this->cloudCredentials->getCloudAccessToken());
     $connector_factory = new ConnectorFactory(
@@ -95,7 +95,7 @@ class AccessTokenConnectorTest extends TestBase {
     self::assertInstanceOf(Connector::class, $connector);
   }
 
-  public function testExpiredAccessToken() {
+  public function testExpiredAccessToken(): void {
     self::setAccessTokenEnvVars(TRUE);
     $connector_factory = new ConnectorFactory(
       [
@@ -108,14 +108,14 @@ class AccessTokenConnectorTest extends TestBase {
     self::assertInstanceOf(Connector::class, $connector);
   }
 
-  public function testConnectorConfig() {
+  public function testConnectorConfig(): void {
     $connector_factory = new ConnectorFactory(
       [
         'key' => $this->cloudCredentials->getCloudKey(),
         'secret' => $this->cloudCredentials->getCloudSecret(),
         'accessToken' => NULL,
       ]);
-    $clientService = new ClientService($connector_factory, $this->application);
+    $clientService = new ClientService($connector_factory, $this->application, $this->cloudCredentials);
     $client = $clientService->getClient();
     $options = $client->getOptions();
     $this->assertArrayHasKey('headers', $options);

--- a/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
+++ b/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
@@ -18,10 +18,7 @@ use Psr\Http\Message\RequestInterface;
  */
 class AccessTokenConnectorTest extends TestBase {
 
-  /**
-   * @var string
-   */
-  private static $accessToken = 'testaccesstoken';
+  private static string $accessToken = 'testaccesstoken';
 
   public function setUp($output = NULL): void {
     parent::setUp();
@@ -33,7 +30,7 @@ class AccessTokenConnectorTest extends TestBase {
     self::unsetAccessTokenEnvVars();
   }
 
-  public static function setAccessTokenEnvVars($expired = FALSE) {
+  public static function setAccessTokenEnvVars($expired = FALSE): void {
     if ($expired) {
       $accessTokenExpiry = time() - 300;
     }

--- a/tests/phpunit/src/CloudApi/CloudServiceTest.php
+++ b/tests/phpunit/src/CloudApi/CloudServiceTest.php
@@ -31,6 +31,10 @@ class CloudServiceTest extends TestBase {
         ['ACLI_ACCESS_TOKEN' => NULL, 'ACLI_KEY' => NULL, 'ACLI_SECRET' => NULL],
         FALSE,
       ],
+      [
+        ['ACLI_ACCESS_TOKEN' => NULL, 'ACLI_KEY' => 'key', 'ACLI_SECRET' => NULL],
+        FALSE,
+      ]
     ];
   }
 

--- a/tests/phpunit/src/CloudApi/CloudServiceTest.php
+++ b/tests/phpunit/src/CloudApi/CloudServiceTest.php
@@ -43,7 +43,7 @@ class CloudServiceTest extends TestBase {
     self::setEnvVars($env_vars);
     $cloud_datastore = $this->prophet->prophesize(CloudDataStore::class);
     $client_service = new ClientService(new ConnectorFactory(['key' => NULL, 'secret' => NULL, 'accessToken' => NULL]), $this->prophet->prophesize(Application::class)->reveal(), new CloudCredentials($cloud_datastore->reveal()));
-    $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated($cloud_datastore->reveal()));
+    $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated());
     self::unsetEnvVars($env_vars);
   }
 

--- a/tests/phpunit/src/CloudApi/CloudServiceTest.php
+++ b/tests/phpunit/src/CloudApi/CloudServiceTest.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\Tests\CloudApi;
 
 use Acquia\Cli\Application;
 use Acquia\Cli\CloudApi\ClientService;
+use Acquia\Cli\CloudApi\CloudCredentials;
 use Acquia\Cli\CloudApi\ConnectorFactory;
 use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Tests\TestBase;
@@ -38,10 +39,10 @@ class CloudServiceTest extends TestBase {
    * @param array $env_vars
    * @param bool $is_authenticated
    */
-  public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated) {
+  public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated): void {
     self::setEnvVars($env_vars);
-    $client_service = new ClientService(new ConnectorFactory(['key' => NULL, 'secret' => NULL, 'accessToken' => NULL]), $this->prophet->prophesize(Application::class)->reveal());
     $cloud_datastore = $this->prophet->prophesize(CloudDataStore::class);
+    $client_service = new ClientService(new ConnectorFactory(['key' => NULL, 'secret' => NULL, 'accessToken' => NULL]), $this->prophet->prophesize(Application::class)->reveal(), new CloudCredentials($cloud_datastore->reveal()));
     $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated($cloud_datastore->reveal()));
     self::unsetEnvVars($env_vars);
   }

--- a/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
@@ -9,7 +9,6 @@ use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\Command\Acsf\AcsfApiBaseCommand;
 use Acquia\Cli\Command\Acsf\AcsfCommandFactory;
 use Acquia\Cli\CommandFactoryInterface;
-use Acquia\Cli\DataStore\CloudDataStore;
 use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,6 +32,7 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
 
   /**
    * {@inheritdoc}
+   * @throws \JsonException
    */
   protected function createCommand(): Command {
     $this->createMockCloudConfigFile($this->getAcsfCredentialsFileContents());
@@ -130,7 +130,7 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
     $this->clientServiceProphecy = $this->prophet->prophesize($client_service_class);
     $this->clientServiceProphecy->getClient()
       ->willReturn($this->clientProphecy->reveal());
-    $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))
+    $this->clientServiceProphecy->isMachineAuthenticated()
       ->willReturn(TRUE);
   }
 

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
@@ -6,7 +6,6 @@ use Acquia\Cli\AcsfApi\AcsfCredentials;
 use Acquia\Cli\Command\Acsf\AcsfApiAuthLoginCommand;
 use Acquia\Cli\Config\CloudDataConfig;
 use Acquia\Cli\DataStore\CloudDataStore;
-use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Validator\Exception\ValidatorException;
 
@@ -105,7 +104,7 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
    */
   public function testAcsfAuthLoginCommand($machine_is_authenticated, $inputs, $args, $output_to_assert, $config = []): void {
     if (!$machine_is_authenticated) {
-      $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
+      $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
     }
     else {
@@ -152,7 +151,7 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
    * @throws \Exception
    */
   public function testAcsfAuthLoginInvalidInputCommand($inputs, $args): void {
-    $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
+    $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
     $this->removeMockCloudConfigFile();
     $this->createDataStores();
     $this->command = $this->createCommand();

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
@@ -6,7 +6,6 @@ use Acquia\Cli\AcsfApi\AcsfCredentials;
 use Acquia\Cli\Command\Acsf\AcsfApiAuthLogoutCommand;
 use Acquia\Cli\Config\CloudDataConfig;
 use Acquia\Cli\DataStore\CloudDataStore;
-use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -65,7 +64,7 @@ class AcsfAuthLogoutCommandTest extends AcsfCommandTestBase {
    */
   public function testAcsfAuthLogoutCommand(bool $machine_is_authenticated, array $inputs, array $config = []): void {
     if (!$machine_is_authenticated) {
-      $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
+      $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
     }
     else {

--- a/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
@@ -6,7 +6,6 @@ use Acquia\Cli\Command\Auth\AuthLoginCommand;
 use Acquia\Cli\Config\CloudDataConfig;
 use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Tests\CommandTestBase;
-use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Validator\Exception\ValidatorException;
 
@@ -116,7 +115,7 @@ class AuthLoginCommandTest extends CommandTestBase {
   public function testAuthLoginCommand($machine_is_authenticated, $assert_cloud_prompts, $inputs, $args, $output_to_assert): void {
     $mock_body = $this->mockTokenRequest();
     if (!$machine_is_authenticated) {
-      $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
+      $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
       $this->createDataStores();
       $this->command = $this->createCommand();
@@ -159,7 +158,7 @@ class AuthLoginCommandTest extends CommandTestBase {
    * @throws \Exception
    */
   public function testAuthLoginInvalidInputCommand($inputs, $args): void {
-    $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
+    $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
     $this->removeMockCloudConfigFile();
     $this->createDataStores();
     $this->command = $this->createCommand();

--- a/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
@@ -6,7 +6,6 @@ use Acquia\Cli\Command\Auth\AuthLogoutCommand;
 use Acquia\Cli\Config\CloudDataConfig;
 use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Tests\CommandTestBase;
-use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -47,7 +46,7 @@ class AuthLogoutCommandTest extends CommandTestBase {
    */
   public function testAuthLogoutCommand($machine_is_authenticated, $inputs): void {
     if (!$machine_is_authenticated) {
-      $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
+      $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
     }
 

--- a/tests/phpunit/src/Commands/CommandBaseTest.php
+++ b/tests/phpunit/src/Commands/CommandBaseTest.php
@@ -5,10 +5,8 @@ namespace Acquia\Cli\Tests\Commands;
 use Acquia\Cli\Command\App\LinkCommand;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ide\IdeListCommand;
-use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Tests\CommandTestBase;
 use Exception;
-use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Validator\Exception\ValidatorException;
 
@@ -26,7 +24,7 @@ class CommandBaseTest extends CommandTestBase {
   }
 
   public function testUnauthenticatedFailure(): void {
-    $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))->willReturn(FALSE);
+    $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
     $this->removeMockConfigFiles();
 
     $inputs = [

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -890,7 +890,7 @@ abstract class TestBase extends TestCase {
     $this->clientServiceProphecy = $this->prophet->prophesize($client_service_class);
     $this->clientServiceProphecy->getClient()
       ->willReturn($this->clientProphecy->reveal());
-    $this->clientServiceProphecy->isMachineAuthenticated(Argument::type(CloudDataStore::class))
+    $this->clientServiceProphecy->isMachineAuthenticated()
       ->willReturn(TRUE);
   }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Access tokens are currently set via the ACLI_ACCESS_TOKEN env var prior to ACLI calls. This is problematic for long-running processes where the token may expire during the process.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Read ACLI_ACCESS_TOKEN_FILE if it is set so that it can be refreshed mid-process if necessary.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
