### PR TITLE
CLI-842: Restore single-db imports for IDE

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -1063,6 +1063,11 @@ abstract class PullCommandBase extends CommandBase {
       $this->io->note("Acquia CLI assumes that the database name for the {$database->name} database is also {$database->name}");
       $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), 'root', $database->name, '', $local_filepath, $output_callback);
     }
+    elseif (AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !getenv('IDE_ENABLE_MULTISITE')) {
+      // Cloud IDE only has 2 available databases for importing, so we only allow importing into the default database.
+      $this->io->note("Cloud IDE only supports importing into the default Drupal database. Acquia CLI will import the NON-DEFAULT database {$database->name} into the DEFAULT database {$this->getDefaultLocalDbName()}");
+      $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);
+    }
     else {
       $this->io->note("Acquia CLI assumes that the local database name for the {$database->name} database is also {$database->name}");
       $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $database->name, $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);


### PR DESCRIPTION
@anavarre I haven't had time to give this much thought or test it, but it seems to me that this should be coupled to the IDE multisite work. If the customer has enabled multisite, ACLI should use multiple DBs, otherwise it should use a single DB.

This doesn't fix the permissions issue but it at least stops the bleeding. Let me know if you think it's an acceptable hotfix.