### PR TITLE
IDE-2489: Restore default db import behavior

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -1057,20 +1057,25 @@ abstract class PullCommandBase extends CommandBase {
    */
   private function importRemoteDatabase(stdClass $database, string $local_filepath, callable $output_callback = NULL): void {
     if ($database->flags->default) {
+      // Easy case, import the default db into the default db.
       $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);
     }
-    elseif (AcquiaDrupalEnvironmentDetector::isAhIdeEnv() || AcquiaDrupalEnvironmentDetector::isLandoEnv()) {
-      $this->io->note("Acquia CLI assumes that the database name for the {$database->name} database is also {$database->name}");
-      $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), 'root', $database->name, '', $local_filepath, $output_callback);
-    }
-    elseif (AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !getenv('IDE_ENABLE_MULTISITE')) {
-      // Cloud IDE only has 2 available databases for importing, so we only allow importing into the default database.
+    else if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !getenv('IDE_ENABLE_MULTISITE')) {
+      // Import non-default db into default db. Needed on legacy IDE without multiple dbs.
+      // @todo remove this case once all IDEs support multiple dbs.
       $this->io->note("Cloud IDE only supports importing into the default Drupal database. Acquia CLI will import the NON-DEFAULT database {$database->name} into the DEFAULT database {$this->getDefaultLocalDbName()}");
       $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);
     }
     else {
-      $this->io->note("Acquia CLI assumes that the local database name for the {$database->name} database is also {$database->name}");
-      $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $database->name, $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);
+      // Import non-default db into non-default db.
+      $this->io->note("Acquia CLI assumes that the local name for the {$database->name} database is also {$database->name}");
+      if (AcquiaDrupalEnvironmentDetector::isLandoEnv() || AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
+        $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), 'root', $database->name, '', $local_filepath, $output_callback);
+      }
+      else {
+        $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $database->name, $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);
+
+      }
     }
   }
 

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -89,7 +89,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     ], $inputs);
     LandoInfoHelper::unsetLandoInfo();
     $output = $this->getDisplay();
-    self::assertStringContainsString('Acquia CLI assumes that the database name', $output);
+    self::assertStringContainsString('Acquia CLI assumes that the local name', $output);
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #1152 

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Always import to default db in IDEs and refactor the logic to make regressions less likely.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `pull:db` in an IDE against a multisite application, ensure that it's imported to the default db.
