### PR TITLE
CLI-837: Broken SSL certs cause pull:db to fail

### DIFF
--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -141,3 +141,6 @@ services:
 
   # Amplitude service.
   Zumba\Amplitude\Amplitude: ~
+
+  # Guzzle service.
+  GuzzleHttp\Client: ~

--- a/src/Command/Acsf/AcsfCommandFactory.php
+++ b/src/Command/Acsf/AcsfCommandFactory.php
@@ -11,6 +11,7 @@ use Acquia\Cli\Helpers\LocalMachineHelper;
 use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Helpers\TelemetryHelper;
 use AcquiaLogstream\LogstreamManager;
+use GuzzleHttp\Client;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -73,6 +74,8 @@ class AcsfCommandFactory implements CommandFactoryInterface {
    */
   private $logger;
 
+  private Client $httpClient;
+
   /**
    * @param \Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
    * @param \Acquia\Cli\DataStore\CloudDataStore $datastoreCloud
@@ -97,7 +100,8 @@ class AcsfCommandFactory implements CommandFactoryInterface {
     LogstreamManager $logstreamManager,
     SshHelper $sshHelper,
     string $sshDir,
-    LoggerInterface $logger
+    LoggerInterface $logger,
+    Client $httpClient
   ) {
     $this->localMachineHelper = $localMachineHelper;
     $this->datastoreCloud = $datastoreCloud;
@@ -110,6 +114,7 @@ class AcsfCommandFactory implements CommandFactoryInterface {
     $this->sshHelper = $sshHelper;
     $this->sshDir = $sshDir;
     $this->logger = $logger;
+    $this->httpClient = $httpClient;
   }
 
   /**
@@ -127,7 +132,8 @@ class AcsfCommandFactory implements CommandFactoryInterface {
       $this->logstreamManager,
       $this->sshHelper,
       $this->sshDir,
-      $this->logger
+      $this->logger,
+      $this->httpClient
     );
   }
 
@@ -146,7 +152,8 @@ class AcsfCommandFactory implements CommandFactoryInterface {
       $this->logstreamManager,
       $this->sshHelper,
       $this->sshDir,
-      $this->logger
+      $this->logger,
+      $this->httpClient
     );
   }
 

--- a/src/Command/Api/ApiCommandFactory.php
+++ b/src/Command/Api/ApiCommandFactory.php
@@ -11,6 +11,7 @@ use Acquia\Cli\Helpers\LocalMachineHelper;
 use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Helpers\TelemetryHelper;
 use AcquiaLogstream\LogstreamManager;
+use GuzzleHttp\Client;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -73,6 +74,8 @@ class ApiCommandFactory implements CommandFactoryInterface {
    */
   private $logger;
 
+  private Client $httpClient;
+
   /**
    * @param \Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
    * @param \Acquia\Cli\DataStore\CloudDataStore $datastoreCloud
@@ -97,7 +100,8 @@ class ApiCommandFactory implements CommandFactoryInterface {
     LogstreamManager $logstreamManager,
     SshHelper $sshHelper,
     string $sshDir,
-    LoggerInterface $logger
+    LoggerInterface $logger,
+    Client $httpClient
   ) {
     $this->localMachineHelper = $localMachineHelper;
     $this->datastoreCloud = $datastoreCloud;
@@ -110,6 +114,7 @@ class ApiCommandFactory implements CommandFactoryInterface {
     $this->sshHelper = $sshHelper;
     $this->sshDir = $sshDir;
     $this->logger = $logger;
+    $this->httpClient = $httpClient;
   }
 
   /**
@@ -127,7 +132,8 @@ class ApiCommandFactory implements CommandFactoryInterface {
       $this->logstreamManager,
       $this->sshHelper,
       $this->sshDir,
-      $this->logger
+      $this->logger,
+      $this->httpClient
     );
   }
 
@@ -146,7 +152,8 @@ class ApiCommandFactory implements CommandFactoryInterface {
       $this->logstreamManager,
       $this->sshHelper,
       $this->sshDir,
-      $this->logger
+      $this->logger,
+      $this->httpClient
     );
   }
 

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -163,6 +163,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    */
   protected $updateClient;
 
+  protected \GuzzleHttp\Client $httpClient;
+
   /**
    * CommandBase constructor.
    *
@@ -189,7 +191,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     LogstreamManager $logstreamManager,
     SshHelper $sshHelper,
     string $sshDir,
-    LoggerInterface $logger
+    LoggerInterface $logger,
+    \GuzzleHttp\Client $httpClient
   ) {
     $this->localMachineHelper = $localMachineHelper;
     $this->datastoreCloud = $datastoreCloud;
@@ -202,6 +205,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->sshHelper = $sshHelper;
     $this->sshDir = $sshDir;
     $this->logger = $logger;
+    $this->httpClient = $httpClient;
     parent::__construct();
   }
 

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -18,7 +18,7 @@ class PullCodeCommand extends PullCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Copy code from a Cloud Platform environment')
       ->acceptEnvironmentId()
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
@@ -34,7 +34,7 @@ class PullCodeCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->pullCode($input, $output);
     $this->checkEnvironmentPhpVersions($this->sourceEnvironment);
     $this->matchIdePhpVersion($output, $this->sourceEnvironment);

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -18,7 +18,7 @@ class PullCommand extends PullCommandBase {
   /**
    * {inheritdoc}
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setAliases(['refresh', 'pull'])
       ->setDescription('Copy code, database, and files from a Cloud Platform environment')
       ->acceptEnvironmentId()
@@ -43,7 +43,7 @@ class PullCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     parent::execute($input, $output);
 
     if (!$input->getOption('no-code')) {

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -17,7 +17,7 @@ class PullDatabaseCommand extends PullCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Import database backup from a Cloud Platform environment')
       ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. If no backup exists, one will be created.')
       ->setAliases(['pull:db'])

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -16,7 +16,7 @@ class PullFilesCommand extends PullCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Copy files from a Cloud Platform environment')
       ->acceptEnvironmentId()
       ->acceptSite()
@@ -30,7 +30,7 @@ class PullFilesCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     parent::execute($input, $output);
     $this->pullFiles($input, $output);
 

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -17,7 +17,7 @@ class PullScriptsCommand extends PullCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Execute post pull scripts')
       ->acceptEnvironmentId()
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
@@ -40,7 +40,7 @@ class PullScriptsCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->executeAllScripts($input, $this->getOutputCallback($output, $this->checklist));
 
     return 0;

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -20,43 +20,27 @@ class PushArtifactCommand extends PullCommandBase {
   protected static $defaultName = 'push:artifact';
 
   /**
-   * @var array
-   *
    * Composer vendor directories.
    */
-  protected $vendorDirs;
+  protected array $vendorDirs;
 
   /**
-   * @var array
-   *
    * Composer scaffold files.
    */
-  protected $scaffoldFiles;
+  protected array $scaffoldFiles;
 
-  /**
-   * @var string
-   */
-  private $composerJsonPath;
+  private string $composerJsonPath;
 
   /**
    * @var string
    */
   private $drupalCorePath;
 
-  /**
-   * @var string
-   */
-  private $docrootPath;
+  private string $docrootPath;
 
-  /**
-   * @var \AcquiaCloudApi\Response\EnvironmentResponse
-   */
-  private $environment;
+  private \AcquiaCloudApi\Response\EnvironmentResponse $environment;
 
-  /**
-   * @var string
-   */
-  private $destinationGitRef;
+  private string $destinationGitRef;
 
   /**
    * {inheritdoc}.

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -17,7 +17,7 @@ class PushCodeCommand extends PullCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Push code from your IDE to a Cloud Platform environment')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
@@ -29,7 +29,7 @@ class PushCodeCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $output->writeln("Please use <options=bold>git</> to push code changes upstream.");
 
     return 0;

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -19,7 +19,7 @@ class PushDatabaseCommand extends PullCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Push a database from your IDE to a Cloud Platform environment')
       ->setAliases(['push:db'])
       ->acceptEnvironmentId()
@@ -34,7 +34,7 @@ class PushDatabaseCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $destination_environment = $this->determineEnvironment($input, $output, FALSE);
     $acquia_cloud_client = $this->cloudApiClientService->getClient();
     $databases = $this->determineCloudDatabases($acquia_cloud_client, $destination_environment, $input->getArgument('site'), FALSE);

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -19,7 +19,7 @@ class PushFilesCommand extends PullCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Push Drupal files from your IDE to a Cloud Platform environment')
       ->acceptEnvironmentId()
       ->acceptSite()
@@ -33,7 +33,7 @@ class PushFilesCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->setDirAndRequireProjectCwd($input);
     $destination_environment = $this->determineEnvironment($input, $output, FALSE);
     $chosen_site = $input->getArgument('site');

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -526,7 +526,8 @@ abstract class CommandTestBase extends TestBase {
       $this->logStreamManagerProphecy->reveal(),
       $this->sshHelper,
       $this->sshDir,
-      $this->logger
+      $this->logger,
+      $this->httpClientProphecy->reveal()
     );
   }
 

--- a/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
@@ -146,7 +146,8 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
       $this->logStreamManagerProphecy->reveal(),
       $this->sshHelper,
       $this->sshDir,
-      $this->logger
+      $this->logger,
+      $this->httpClientProphecy->reveal()
     );
   }
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -109,6 +109,8 @@ abstract class TestBase extends TestCase {
 
   protected string $passphraseFilepath = '~/.passphrase';
 
+  protected \GuzzleHttp\Client|ObjectProphecy $httpClientProphecy;
+
   /**
    * Filter an applications response in order to simulate query filters.
    *
@@ -167,6 +169,7 @@ abstract class TestBase extends TestCase {
     $this->cloudCredentials = new CloudCredentials($this->datastoreCloud);
     $this->telemetryHelper = new TelemetryHelper($input, $output, $this->clientServiceProphecy->reveal(), $this->datastoreAcli, $this->datastoreCloud);
     $this->logStreamManagerProphecy = $this->prophet->prophesize(LogstreamManager::class);
+    $this->httpClientProphecy = $this->prophet->prophesize(\GuzzleHttp\Client::class);
     ClearCacheCommand::clearCaches();
 
     parent::setUp();
@@ -318,7 +321,8 @@ abstract class TestBase extends TestCase {
       $this->logStreamManagerProphecy->reveal(),
       $this->sshHelper,
       $this->sshDir,
-      $this->logger
+      $this->logger,
+      $this->httpClientProphecy->reveal()
     );
   }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-837

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Use a plain Guzzle Client request since we're not actually calling the Cloud API the second time but the customer domain directly. This might break some minor features that were dependent on the Cloud client, such as progress reporting, but this seems like a small price to pay to support SSL fallback. Ultimately this is all a problem with Cloud API redirecting download requests instead of streaming them directly (which is what caused the SSL issue in the first place).

Shockingly, it seems we don't make raw Guzzle requests anywhere else in a way that requires mocking, so this requires adding a new service via DI.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Keep abusing the Acquia Cloud Client for the subsequent request like before. Doesn't seem smart.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `acli pull:db c[SNIP]b.prod --no-import`
4. Try to `gunzip` the downloaded file. This would be invalid before, but should pass now.
