### PR TITLE
CLI-838: SSH key upload timeouts

### DIFF
--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -110,6 +110,10 @@ class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
 
     // Wait for the key to register on the Cloud Platform.
     if ($key_was_uploaded) {
+      if ($this->input->isInteractive() && !$this->promptWaitForSsh($this->io)) {
+        $this->io->success('Your SSH key has been successfully uploaded to Cloud Platform.');
+        return 0;
+      }
       $this->pollAcquiaCloudUntilSshSuccess($output);
     }
 

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -111,7 +111,7 @@ class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
     // Wait for the key to register on the Cloud Platform.
     if ($key_was_uploaded) {
       if ($this->input->isInteractive() && !$this->promptWaitForSsh($this->io)) {
-        $this->io->success('Your SSH key has been successfully uploaded to Cloud Platform.');
+        $this->io->success('Your SSH key has been successfully uploaded to the Cloud Platform.');
         return 0;
       }
       $this->pollAcquiaCloudUntilSshSuccess($output);

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -500,7 +500,7 @@ EOT
     // Wait for the key to register on the Cloud Platform.
     if ($this->input->hasOption('no-wait') && $this->input->getOption('no-wait') === FALSE) {
       if ($this->input->isInteractive() && !$this->promptWaitForSsh($this->io)) {
-        $this->io->success('Your SSH key has been successfully uploaded to Cloud Platform.');
+        $this->io->success('Your SSH key has been successfully uploaded to the Cloud Platform.');
         return;
       }
 

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -27,28 +27,18 @@ abstract class SshKeyCommandBase extends CommandBase {
 
   use SshCommandTrait;
 
-  /** @var string */
-  protected $passphraseFilepath;
+  protected string $passphraseFilepath;
 
-  /**
-   * @var string
-   */
-  protected $privateSshKeyFilename;
+  protected string $privateSshKeyFilename;
 
-  /**
-   * @var string
-   */
-  protected $privateSshKeyFilepath;
+  protected string $privateSshKeyFilepath;
 
-  /**
-   * @var string
-   */
-  protected $publicSshKeyFilepath;
+  protected string $publicSshKeyFilepath;
 
   /**
    * @param string $private_ssh_key_filename
    */
-  protected function setSshKeyFilepath(string $private_ssh_key_filename) {
+  protected function setSshKeyFilepath(string $private_ssh_key_filename): void {
     $this->privateSshKeyFilename = $private_ssh_key_filename;
     $this->privateSshKeyFilepath = $this->sshDir . '/' . $this->privateSshKeyFilename;
     $this->publicSshKeyFilepath = $this->privateSshKeyFilepath . '.pub';
@@ -493,7 +483,7 @@ EOT
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  protected function uploadSshKey(string $label, string $chosen_local_key, string $public_key) {
+  protected function uploadSshKey(string $label, string $chosen_local_key, string $public_key): void {
     $options = [
       'form_params' => [
         'label' => $label,
@@ -509,13 +499,9 @@ EOT
 
     // Wait for the key to register on the Cloud Platform.
     if ($this->input->hasOption('no-wait') && $this->input->getOption('no-wait') === FALSE) {
-      if ($this->input->isInteractive()) {
-        $this->io->note("It may take some time before the SSH key is installed on all of your application's web servers.");
-        $answer = $this->io->confirm("Would you like to wait until Cloud Platform is ready?");
-        if (!$answer) {
-          $this->io->success('Your SSH key has been successfully uploaded to Cloud Platform.');
-          return;
-        }
+      if ($this->input->isInteractive() && !$this->promptWaitForSsh($this->io)) {
+        $this->io->success('Your SSH key has been successfully uploaded to Cloud Platform.');
+        return;
       }
 
       if ($this->keyHasUploaded($this->cloudApiClientService->getClient(), $public_key)) {

--- a/src/Command/Ssh/SshKeyUploadCommand.php
+++ b/src/Command/Ssh/SshKeyUploadCommand.php
@@ -16,20 +16,11 @@ class SshKeyUploadCommand extends SshKeyCommandBase {
   /**
    * {inheritdoc}.
    */
-  protected function configure() {
+  protected function configure(): void {
     $this->setDescription('Upload a local SSH key to the Cloud Platform')
       ->addOption('filepath', NULL, InputOption::VALUE_REQUIRED, 'The filepath of the public SSH key to upload')
       ->addOption('label', NULL, InputOption::VALUE_REQUIRED, 'The SSH key label to be used with the Cloud Platform')
       ->addOption('no-wait', NULL, InputOption::VALUE_NONE, "Don't wait for the SSH key to be uploaded to the Cloud Platform");
-  }
-
-  /**
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   *
-   * @return bool
-   */
-  protected function commandRequiresAuthentication(InputInterface $input): bool {
-    return TRUE;
   }
 
   /**
@@ -40,7 +31,7 @@ class SshKeyUploadCommand extends SshKeyCommandBase {
    * @throws \Acquia\Cli\Exception\AcquiaCliException
    * @throws \Exception
    */
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output): int {
     [$chosen_local_key, $public_key] = $this->determinePublicSshKey();
     $label = $this->determineSshKeyLabel($input, $output);
     $this->uploadSshKey($label, $chosen_local_key, $public_key);

--- a/src/Helpers/SshCommandTrait.php
+++ b/src/Helpers/SshCommandTrait.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Helpers;
 
 use Acquia\Cli\Exception\AcquiaCliException;
+use AcquiaCloudApi\Connector\Client;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 trait SshCommandTrait {
@@ -47,7 +48,7 @@ trait SshCommandTrait {
    *
    * @return array|object|null
    */
-  private function determineCloudKey($acquia_cloud_client) {
+  private function determineCloudKey(Client $acquia_cloud_client): object|array|null {
     $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
     return $this->promptChooseFromObjectsOrArrays(
       $cloud_keys,
@@ -73,7 +74,7 @@ trait SshCommandTrait {
    * @return bool
    */
   protected function promptWaitForSsh(SymfonyStyle $io): bool {
-    $io->note("It may take an hour or more before the SSH key is installed on all of your application's servers. Create a Support ticket if this process takes too long.");
+    $io->note("It may take an hour or more before the SSH key is installed on all of your application's servers. Create a Support ticket for further assistance.");
     return $io->confirm("Would you like to wait until your key is installed on all of your application's servers?");
   }
 

--- a/src/Helpers/SshCommandTrait.php
+++ b/src/Helpers/SshCommandTrait.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Helpers;
 
 use Acquia\Cli\Exception\AcquiaCliException;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 trait SshCommandTrait {
 
@@ -64,6 +65,16 @@ trait SshCommandTrait {
     $finder = $this->localMachineHelper->getFinder();
     $finder->files()->in($this->sshDir)->name('*.pub')->ignoreUnreadableDirs();
     return iterator_to_array($finder);
+  }
+
+  /**
+   * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+   *
+   * @return bool
+   */
+  protected function promptWaitForSsh(SymfonyStyle $io): bool {
+    $io->note("It may take an hour or more before the SSH key is installed on all of your application's servers. Create a Support ticket if this process takes too long.");
+    return $io->confirm("Would you like to wait until your key is installed on all of your application's servers?");
   }
 
 }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -111,7 +111,7 @@ class SshKeyUploadCommandTest extends CommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
     $this->assertStringContainsString("Uploaded $file_name to the Cloud Platform with label " . $this->sshKeysRequestBody['label'], $output);
-    $this->assertStringContainsString('Would you like to wait until Cloud Platform is ready?', $output);
+    $this->assertStringContainsString('Would you like to wait until your key is installed on all of your application\'s servers?', $output);
     $this->assertStringContainsString('Your SSH key is ready for use!', $output);
   }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-838

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
- Modify ssh key upload warning message to mention specific times (>1 hour)
- Tell customers to contact support if it takes too long (workarounds would be to re-use an existing key or delete the key and try again, and support should channel this into a PF)
- Add this prompt to SSH key uploads in IDEs for consistency

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
