### PR TITLE
CLI-857: Warning on missing refresh token

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,9 +58,9 @@
         "ext-iconv": "*"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-latest",
         "acquia/coding-standards": "^1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+        "mikey179/vfsstream": "^1.6",
         "overtrue/phplint": "^4.0",
         "php-coveralls/php-coveralls": "^2.2",
         "phpro/grumphp": "^1.13.0",
@@ -69,6 +69,7 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9.1",
+        "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.5",
         "twig/twig": "^3.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3e686483bbeba95348364808aaa9624",
+    "content-hash": "f57e393f2e8a262cdb378837d18e0665",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -7326,6 +7326,57 @@
                 "source": "https://github.com/laravel/serializable-closure"
             },
             "time": "2022-09-08T13:45:54+00:00"
+        },
+        {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
+                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "support": {
+                "issues": "https://github.com/bovigo/vfsStream/issues",
+                "source": "https://github.com/bovigo/vfsStream/tree/master",
+                "wiki": "https://github.com/bovigo/vfsStream/wiki"
+            },
+            "time": "2022-02-23T02:02:42+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/src/CloudApi/CloudCredentials.php
+++ b/src/CloudApi/CloudCredentials.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\CloudApi;
 
 use Acquia\Cli\ApiCredentialsInterface;
 use Acquia\Cli\DataStore\CloudDataStore;
+use Acquia\Cli\Exception\AcquiaCliException;
 
 /**
  * @package Acquia\Cli\Helpers
@@ -23,14 +24,18 @@ class CloudCredentials implements ApiCredentialsInterface {
 
   /**
    * @return string|null
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   public function getCloudAccessToken(): ?string {
-    if (getenv('ACLI_ACCESS_TOKEN')) {
-      return getenv('ACLI_ACCESS_TOKEN');
+    if ($token = getenv('ACLI_ACCESS_TOKEN')) {
+      return $token;
     }
 
-    if (getenv('ACLI_ACCESS_TOKEN_FILE')) {
-      return trim(file_get_contents(getenv('ACLI_ACCESS_TOKEN_FILE')), "\"\n");
+    if ($file = getenv('ACLI_ACCESS_TOKEN_FILE')) {
+      if (!file_exists($file)) {
+        throw new AcquiaCliException('Access token file not found at {file}', ['file' => $file]);
+      }
+      return trim(file_get_contents($file), "\"\n");
     }
 
     return NULL;
@@ -38,14 +43,18 @@ class CloudCredentials implements ApiCredentialsInterface {
 
   /**
    * @return string|null
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   public function getCloudAccessTokenExpiry(): ?string {
-    if (getenv('ACLI_ACCESS_TOKEN_EXPIRY')) {
-      return getenv('ACLI_ACCESS_TOKEN_EXPIRY');
+    if ($token = getenv('ACLI_ACCESS_TOKEN_EXPIRY')) {
+      return $token;
     }
 
-    if (getenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE')) {
-      return trim(file_get_contents(getenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE')), "\"\n");
+    if ($file = getenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE')) {
+      if (!file_exists($file)) {
+        throw new AcquiaCliException('Access token expiry file not found at {file}', ['file' => $file]);
+      }
+      return trim(file_get_contents($file), "\"\n");
     }
 
     return NULL;
@@ -55,8 +64,8 @@ class CloudCredentials implements ApiCredentialsInterface {
    * @return string|null
    */
   public function getCloudKey(): ?string {
-    if (getenv('ACLI_KEY')) {
-      return getenv('ACLI_KEY');
+    if ($key = getenv('ACLI_KEY')) {
+      return $key;
     }
 
     if ($this->datastoreCloud->get('acli_key')) {
@@ -70,8 +79,8 @@ class CloudCredentials implements ApiCredentialsInterface {
    * @return string|null
    */
   public function getCloudSecret(): ?string {
-    if (getenv('ACLI_SECRET')) {
-      return getenv('ACLI_SECRET');
+    if ($secret = getenv('ACLI_SECRET')) {
+      return $secret;
     }
 
     $acli_key = $this->getCloudKey();
@@ -89,8 +98,8 @@ class CloudCredentials implements ApiCredentialsInterface {
    * @return string|null
    */
   public function getBaseUri(): ?string {
-    if (getenv('ACLI_CLOUD_API_BASE_URI')) {
-      return getenv('ACLI_CLOUD_API_BASE_URI');
+    if ($uri = getenv('ACLI_CLOUD_API_BASE_URI')) {
+      return $uri;
     }
     return NULL;
   }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -10,6 +10,12 @@ use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\RuntimeException;
 
+/**
+ * Make exceptions warm and cuddly.
+ *
+ * Vendor libraries and APIs throw exceptions that aren't very helpful on their
+ * own. We can rewrite them to be more helpful and add support links.
+ */
 class ExceptionListener {
 
   /**
@@ -59,6 +65,10 @@ class ExceptionListener {
         case '{environmentId} must be a valid UUID or site alias.':
         case '{environmentUuid} must be a valid UUID or site alias.':
           $this->writeSiteAliasHelp();
+          break;
+        case 'Access token file not found at {file}':
+        case 'Access token expiry file not found at {file}':
+          $this->helpMessages[] = 'Get help for this error at https://docs.acquia.com/ide/known-issues/#the-automated-cloud-platform-api-authentication-might-fail';
           break;
       }
     }

--- a/src/Exception/AcquiaCliException.php
+++ b/src/Exception/AcquiaCliException.php
@@ -32,7 +32,7 @@ class AcquiaCliException extends Exception {
   public function __construct(
     string $message = NULL,
     array $replacements = [],
-           $code = 0
+    int $code = 0
     ) {
     $this->replacements = $replacements;
     $this->raw_message = $message;

--- a/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
+++ b/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
@@ -46,6 +46,9 @@ class AccessTokenConnectorTest extends TestBase {
     putenv('ACLI_ACCESS_TOKEN_EXPIRY');
   }
 
+  /**
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   */
   public function testAccessToken(): void {
     // Ensure that ACLI_ACCESS_TOKEN was used to populate the refresh token.
     self::assertEquals(self::$accessToken, $this->cloudCredentials->getCloudAccessToken());
@@ -77,6 +80,8 @@ class AccessTokenConnectorTest extends TestBase {
   /**
    * Validate that if both an access token and API key/secret pair are present,
    * the pair is used.
+   *
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   public function testConnector(): void {
     // Ensure that ACLI_ACCESS_TOKEN was used to populate the refresh token.
@@ -92,6 +97,9 @@ class AccessTokenConnectorTest extends TestBase {
     self::assertInstanceOf(Connector::class, $connector);
   }
 
+  /**
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   */
   public function testExpiredAccessToken(): void {
     self::setAccessTokenEnvVars(TRUE);
     $connector_factory = new ConnectorFactory(

--- a/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
+++ b/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
@@ -11,8 +11,10 @@ use AcquiaCloudApi\Connector\Connector;
 use AcquiaCloudApi\Connector\ConnectorInterface;
 use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Token\AccessTokenInterface;
+use org\bovigo\vfs\vfsStream;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Class AccessTokenConnectorTest.
@@ -81,10 +83,13 @@ class AccessTokenConnectorTest extends TestBase {
    */
   public function testTokenFile(): void {
     $accessTokenExpiry = time() + 300;
-    $token_file = $this->fixtureDir . '/token';
-    $expiry_file = $this->fixtureDir . '/expiry';
-    file_put_contents($token_file, self::$accessToken);
-    file_put_contents($expiry_file, $accessTokenExpiry);
+    $directory = [
+      'token' => self::$accessToken,
+      'expiry' => (string) $accessTokenExpiry
+    ];
+    $vfs = vfsStream::setup('root', NULL, $directory);
+    $token_file = Path::join($vfs->url(), 'token');
+    $expiry_file = Path::join($vfs->url(), 'expiry');
     putenv('ACLI_ACCESS_TOKEN_FILE=' . $token_file);
     putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiry_file);
     self::assertEquals(self::$accessToken, $this->cloudCredentials->getCloudAccessToken());
@@ -93,9 +98,12 @@ class AccessTokenConnectorTest extends TestBase {
 
   public function testMissingTokenFile(): void {
     $accessTokenExpiry = time() + 300;
-    $token_file = $this->fixtureDir . '/token';
-    $expiry_file = $this->fixtureDir . '/expiry';
-    file_put_contents($expiry_file, $accessTokenExpiry);
+    $directory = [
+      'expiry' => (string) $accessTokenExpiry
+    ];
+    $vfs = vfsStream::setup('root', NULL, $directory);
+    $token_file = Path::join($vfs->url(), 'token');
+    $expiry_file = Path::join($vfs->url(), 'expiry');
     putenv('ACLI_ACCESS_TOKEN_FILE=' . $token_file);
     putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiry_file);
     try {

--- a/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
+++ b/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
@@ -115,9 +115,12 @@ class AccessTokenConnectorTest extends TestBase {
   }
 
   public function testMissingExpiryFile(): void {
-    $token_file = $this->fixtureDir . '/token';
-    $expiry_file = $this->fixtureDir . '/expiry';
-    file_put_contents($token_file, self::$accessToken);
+    $directory = [
+      'token' => self::$accessToken,
+    ];
+    $vfs = vfsStream::setup('root', NULL, $directory);
+    $token_file = Path::join($vfs->url(), 'token');
+    $expiry_file = Path::join($vfs->url(), 'expiry');
     putenv('ACLI_ACCESS_TOKEN_FILE=' . $token_file);
     putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiry_file);
     try {

--- a/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
+++ b/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
@@ -5,6 +5,7 @@ namespace Acquia\Cli\Tests\CloudApi;
 use Acquia\Cli\CloudApi\AccessTokenConnector;
 use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\CloudApi\ConnectorFactory;
+use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\TestBase;
 use AcquiaCloudApi\Connector\Connector;
 use AcquiaCloudApi\Connector\ConnectorInterface;
@@ -88,6 +89,35 @@ class AccessTokenConnectorTest extends TestBase {
     putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiry_file);
     self::assertEquals(self::$accessToken, $this->cloudCredentials->getCloudAccessToken());
     self::assertEquals($accessTokenExpiry, $this->cloudCredentials->getCloudAccessTokenExpiry());
+  }
+
+  public function testMissingTokenFile(): void {
+    $accessTokenExpiry = time() + 300;
+    $token_file = $this->fixtureDir . '/token';
+    $expiry_file = $this->fixtureDir . '/expiry';
+    file_put_contents($expiry_file, $accessTokenExpiry);
+    putenv('ACLI_ACCESS_TOKEN_FILE=' . $token_file);
+    putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiry_file);
+    try {
+      $this->cloudCredentials->getCloudAccessToken();
+    }
+    catch (AcquiaCliException $exception) {
+      self::assertEquals('Access token file not found at ' . $token_file, $exception->getMessage());
+    }
+  }
+
+  public function testMissingExpiryFile(): void {
+    $token_file = $this->fixtureDir . '/token';
+    $expiry_file = $this->fixtureDir . '/expiry';
+    file_put_contents($token_file, self::$accessToken);
+    putenv('ACLI_ACCESS_TOKEN_FILE=' . $token_file);
+    putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiry_file);
+    try {
+      $this->cloudCredentials->getCloudAccessTokenExpiry();
+    }
+    catch (AcquiaCliException $exception) {
+      self::assertEquals('Access token expiry file not found at ' . $expiry_file, $exception->getMessage());
+    }
   }
 
   /**

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -25,6 +25,10 @@ class PullFilesCommandTest extends PullCommandTestBase {
     return $this->injectCommand(PullFilesCommand::class);
   }
 
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \JsonException
+   */
   public function testRefreshAcsfFiles(): void {
     $applications_response = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
@@ -33,10 +37,7 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $ssh_helper = $this->mockSshHelper();
     $this->mockGetAcsfSites($ssh_helper);
     $local_machine_helper = $this->mockLocalMachineHelper();
-    $local_machine_helper
-      ->getFilesystem()
-      ->willReturn($this->fs)
-      ->shouldBeCalled();
+    $this->mockGetFilesystem($local_machine_helper);
     $this->mockExecuteRsync($local_machine_helper, $ssh_helper, $selected_environment, '/mnt/files/profserv2.dev/sites/g/files/jxr5000596dev/files', $this->projectFixtureDir . '/docroot/sites/jxr5000596dev/');
 
     $this->command->localMachineHelper = $local_machine_helper->reveal();
@@ -65,6 +66,10 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
   }
 
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \JsonException
+   */
   public function testRefreshCloudFiles(): void {
     $applications_response = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
@@ -73,10 +78,7 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $ssh_helper = $this->mockSshHelper();
     $this->mockGetCloudSites($ssh_helper, $selected_environment);
     $local_machine_helper = $this->mockLocalMachineHelper();
-    $local_machine_helper
-      ->getFilesystem()
-      ->willReturn($this->fs)
-      ->shouldBeCalled();
+    $this->mockGetFilesystem($local_machine_helper);
     $sitegroup = CommandBase::getSiteGroupFromSshUrl($selected_environment->ssh_url);
     $this->mockExecuteRsync($local_machine_helper, $ssh_helper, $selected_environment, '/mnt/files/' . $sitegroup . '.' . $selected_environment->name . '/sites/bar/files/', $this->projectFixtureDir . '/docroot/sites/bar/files');
 

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -143,7 +143,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
    * @param $vcs_path
    * @param $vcs_urls
    */
-  protected function setUpPushArtifact($local_machine_helper, $vcs_path, $vcs_urls) {
+  protected function setUpPushArtifact($local_machine_helper, $vcs_path, $vcs_urls): void {
     $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $this->createMockGitConfigFile();
     $finder = $this->mockFinder();

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -841,7 +841,7 @@ abstract class TestBase extends TestCase {
   /**
    * @param \Prophecy\Prophecy\ObjectProphecy|LocalMachineHelper $local_machine_helper
    *
-   * @return Filesystem
+   * @return \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Filesystem\Filesystem
    */
   protected function mockGetFilesystem(ObjectProphecy|LocalMachineHelper $local_machine_helper): ObjectProphecy|Filesystem {
     $local_machine_helper->getFilesystem()->willReturn($this->fs)->shouldBeCalled();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #1177

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Catch this condition and rethrow as an exception so we can track via Amplitude and provide the customer with assistance

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Set ACLI_ACCESS_TOKEN_FILE or ACLI_ACCESS_TOKEN_EXPIRY_FILE to an invalid value and observe that an exception is thrown instead of a warning.
