### PR TITLE
BUG-01: Fixes acli remote:aliases:download command.

### DIFF
--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -112,9 +112,8 @@ class AliasesDownloadCommand extends SshCommand {
       $this->drushAliasesDir = $this->input->getOption('destination-dir');
     }
     elseif (!isset($this->drushAliasesDir)) {
-      $this->drushAliasesDir = match ($version) {
-        8 => $this->localMachineHelper
-            ->getLocalFilepath('~') . '/.drush',
+      $this->drushAliasesDir = match ((int) $version) {
+        8 => $this->localMachineHelper->getLocalFilepath('~') . '/.drush',
         9 => Path::join($this->getRepoRoot(), 'drush'),
         default => throw new AcquiaCliException("Unknown Drush version"),
       };


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #1190

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
This PR adds an integer type casting the version number passed to match function.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Step 1: In local env just run acli remote:aliases:download in any acquia drupal project.


