### PR TITLE
CLI-864 | Unhide cs:wizard from list of ACLI commands

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3625,16 +3625,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.0.11",
+            "version": "v6.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "8c98079892d254b4e5806bedf694bddab8fe92b4"
+                "reference": "908edffec894ef7c60d6a66869ecb826d76a491f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/8c98079892d254b4e5806bedf694bddab8fe92b4",
-                "reference": "8c98079892d254b4e5806bedf694bddab8fe92b4",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/908edffec894ef7c60d6a66869ecb826d76a491f",
+                "reference": "908edffec894ef7c60d6a66869ecb826d76a491f",
                 "shasum": ""
             },
             "require": {
@@ -3691,14 +3691,14 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Provides an extended PSR-6, PSR-16 (and tags) implementation",
+            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
             "homepage": "https://symfony.com",
             "keywords": [
                 "caching",
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.0.11"
+                "source": "https://github.com/symfony/cache/tree/v6.0.13"
             },
             "funding": [
                 {
@@ -3714,7 +3714,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-29T07:39:48+00:00"
+            "time": "2022-09-08T09:32:44+00:00"
         },
         {
             "name": "symfony/cache-contracts",

--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -48,6 +48,9 @@ trait CodeStudioCommandTrait {
     if ($this->input->getOption('gitlab-token')) {
       return $this->input->getOption('gitlab-token');
     }
+    if (!$this->localMachineHelper->commandExists('glab')) {
+      throw new AcquiaCliException("Please install glab to continue: https://gitlab.com/gitlab-org/cli#installation");
+    }
     $process = $this->localMachineHelper->execute([
       'glab',
       'config',
@@ -83,7 +86,9 @@ trait CodeStudioCommandTrait {
      && $this->input->getOption('gitlab-host-name')) {
       return $this->input->getOption('gitlab-host-name');
     }
-
+    if (!$this->localMachineHelper->commandExists('glab')) {
+      throw new AcquiaCliException("Please install glab to continue: https://gitlab.com/gitlab-org/cli#installation");
+    }
     $process = $this->localMachineHelper->execute([
       'glab',
       'config',

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -5,7 +5,6 @@ namespace Acquia\Cli\Command\CodeStudio;
 use Acquia\Cli\Command\WizardCommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Endpoints\Account;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -37,7 +36,6 @@ class CodeStudioWizardCommand extends WizardCommandBase {
       ->addOption('gitlab-host-name', NULL, InputOption::VALUE_REQUIRED, 'The GitLab hostname.')
       ->setAliases(['cs:wizard']);
     $this->acceptApplicationUuid();
-    $this->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
   }
 
   /**

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -423,6 +423,18 @@ abstract class CommandTestBase extends TestBase {
   }
 
   /**
+   * @param ObjectProphecy $local_machine_helper
+   */
+  protected function mockExecuteGlabExists(
+    ObjectProphecy $local_machine_helper
+  ): void {
+    $local_machine_helper
+      ->commandExists('glab')
+      ->willReturn(TRUE)
+      ->shouldBeCalled();
+  }
+
+  /**
    * Mock guzzle requests for update checks so we don't actually hit Github.
    *
    * @param int $status_code

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -90,6 +90,7 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase {
    */
   public function testCommand($mocked_gitlab_projects, $inputs, $args): void {
     $local_machine_helper = $this->mockLocalMachineHelper();
+    $this->mockExecuteGlabExists($local_machine_helper);
     $this->mockGitlabGetHost($local_machine_helper, $this->gitLabHost);
     $this->mockGitlabGetToken($local_machine_helper, $this->gitLabToken, $this->gitLabHost);
     $gitlab_client = $this->prophet->prophesize(Client::class);

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -189,6 +189,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
 
     $local_machine_helper = $this->mockLocalMachineHelper();
     $local_machine_helper->checkRequiredBinariesExist(['git']);
+    $this->mockExecuteGlabExists($local_machine_helper);
     $process = $this->mockProcess();
     $local_machine_helper->execute(Argument::containing('remote'), Argument::type('callable'), '/home/ide/project', FALSE)->willReturn($process->reveal());
     $local_machine_helper->execute(Argument::containing('push'), Argument::type('callable'), '/home/ide/project', FALSE)->willReturn($process->reveal());
@@ -211,6 +212,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
 
   public function testInvalidGitLabCredentials() {
     $local_machine_helper = $this->mockLocalMachineHelper();
+    $this->mockExecuteGlabExists($local_machine_helper);
     $gitlab_client = $this->mockGitLabAuthenticate($local_machine_helper, $this->gitLabHost, $this->gitLabToken);
     $this->command->setGitLabClient($gitlab_client->reveal());
     $this->command->localMachineHelper = $local_machine_helper->reveal();
@@ -227,6 +229,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
 
   public function testMissingGitLabCredentials() {
     $local_machine_helper = $this->mockLocalMachineHelper();
+    $this->mockExecuteGlabExists($local_machine_helper);
     $this->mockGitlabGetHost($local_machine_helper, $this->gitLabHost);
     $this->mockGitlabGetToken($local_machine_helper, $this->gitLabToken, $this->gitLabHost, FALSE);
     $this->command->localMachineHelper = $local_machine_helper->reveal();


### PR DESCRIPTION
**Motivation**
Fixes #1192 

**Proposed changes**
Shows cs:wizard in the acli command list.


**Testing steps**

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `./bin/acli` and see `codestudio:wizard` in the list of available commands.
