### PR TITLE
CLI-861: Use virtual fs for tests

### DIFF
--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -124,12 +124,17 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
       $this->localMachineHelper->getFilesystem()->exists($pipelines_filepath_yaml)
     ) {
       $this->gitLabClient->projects()->update($project['id'], ['ci_config_path' => '']);
-      $filename = implode('', glob("acquia-pipelines.*"));
-      $file_contents = file_get_contents($filename);
-      return [
-        'file_contents' => Yaml::parse($file_contents, Yaml::PARSE_OBJECT),
-         'filename' =>  $filename
-        ];
+      $pipelines_filenames = ['acquia-pipelines.yml', 'acquia-pipelines.yaml'];
+      foreach ($pipelines_filenames as $pipelines_filename) {
+        $pipelines_filepath = Path::join($this->repoRoot, $pipelines_filename);
+        if (file_exists($pipelines_filepath)) {
+          $file_contents = file_get_contents($pipelines_filepath);
+          return [
+            'file_contents' => Yaml::parse($file_contents, Yaml::PARSE_OBJECT),
+            'filename' =>  $pipelines_filename
+          ];
+        }
+      }
     }
 
     throw new AcquiaCliException("Missing 'acquia-pipelines.yml' file which is required to migrate the project to Code Studio.");

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -87,7 +87,6 @@ abstract class CommandTestBase extends TestBase {
    */
   protected function executeCommand(array $args = [], array $inputs = []): void {
     $cwd = $this->projectFixtureDir;
-    chdir($cwd);
     $tester = $this->getCommandTester();
     $tester->setInputs($inputs);
     $command_name = $this->command->getName();

--- a/tests/phpunit/src/Commands/App/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/App/NewCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acquia\Cli\Tests\Commands;
+namespace Acquia\Cli\Tests\Commands\App;
 
 use Acquia\Cli\Command\App\NewCommand;
 use Acquia\Cli\Tests\CommandTestBase;
@@ -17,7 +17,15 @@ use Symfony\Component\Process\Process;
  */
 class NewCommandTest extends CommandTestBase {
 
-  protected $newProjectDir;
+  protected string $newProjectDir;
+
+  /**
+   * @throws \JsonException
+   */
+  public function setUp($output = NULL): void {
+    parent::setUp($output);
+    $this->setupFsFixture();
+  }
 
   /**
    * {@inheritdoc}

--- a/tests/phpunit/src/Commands/Pull/PullCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTest.php
@@ -15,12 +15,23 @@ use Symfony\Component\Console\Command\Command;
 class PullCommandTest extends PullCommandTestBase {
 
   /**
+   * @throws \JsonException
+   */
+  public function setUp($output = NULL): void {
+    parent::setUp($output);
+    $this->setupFsFixture();
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected function createCommand(): Command {
     return $this->injectCommand(PullCommand::class);
   }
 
+  /**
+   * @throws \Exception
+   */
   public function testMissingLocalRepo(): void {
     // Unset repo root. Mimics failing to find local git repo. Command must be re-created
     // to re-inject the parameter into the command.

--- a/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
@@ -26,6 +26,15 @@ class AliasesDownloadCommandTest extends CommandTestBase {
   }
 
   /**
+   * @throws \JsonException
+   */
+  public function setUp($output = NULL): void {
+    parent::setUp($output);
+    $this->setupFsFixture();
+    $this->command = $this->createCommand();
+  }
+
+  /**
    * Test all Drush alias versions.
    */
   public function providerTestRemoteAliasesDownloadCommand(): array {
@@ -53,7 +62,6 @@ class AliasesDownloadCommandTest extends CommandTestBase {
    */
   public function testRemoteAliasesDownloadCommand(array $inputs, array $args, string $destination_dir = NULL, bool $all = FALSE): void {
     $alias_version = $inputs[0];
-    chdir(sys_get_temp_dir());
 
     $drush_aliases_fixture = Path::canonicalize(__DIR__ . '/../../../../fixtures/drush-aliases');
     $drush_aliases_tarball_fixture_filepath = tempnam(sys_get_temp_dir(), 'AcquiaDrushAliases');

--- a/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
@@ -47,6 +47,7 @@ class AliasesDownloadCommandTest extends CommandTestBase {
    */
   public function testRemoteAliasesDownloadCommand($inputs, $args, $destination_dir = NULL, $all = FALSE): void {
     $alias_version = $inputs[0];
+    chdir(sys_get_temp_dir());
 
     $drush_aliases_fixture = Path::canonicalize(__DIR__ . '/../../../../fixtures/drush-aliases');
     $drush_aliases_tarball_fixture_filepath = tempnam(sys_get_temp_dir(), 'AcquiaDrushAliases');

--- a/tests/phpunit/src/Commands/Ssh/SshKeyInfoCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyInfoCommandTest.php
@@ -16,6 +16,15 @@ class SshKeyInfoCommandTest extends CommandTestBase {
     return $this->injectCommand(SshKeyInfoCommand::class);
   }
 
+  /**
+   * @throws \JsonException
+   */
+  public function setUp($output = NULL): void {
+    parent::setUp($output);
+    $this->setupFsFixture();
+    $this->command = $this->createCommand();
+  }
+
   public function testInfo(): void {
     $this->mockListSshKeysRequest();
 

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -21,6 +21,15 @@ class SshKeyListCommandTest extends CommandTestBase {
   }
 
   /**
+   * @throws \JsonException
+   */
+  public function setUp($output = NULL): void {
+    parent::setUp($output);
+    $this->setupFsFixture();
+    $this->command = $this->createCommand();
+  }
+
+  /**
    * Tests the 'ssh-key:upload' command.
    * @throws \Psr\Cache\InvalidArgumentException
    * @throws \Exception

--- a/tests/phpunit/src/Misc/LocalMachineHelperTest.php
+++ b/tests/phpunit/src/Misc/LocalMachineHelperTest.php
@@ -52,7 +52,11 @@ class LocalMachineHelperTest extends TestBase {
     }
   }
 
+  /**
+   * @throws \JsonException
+   */
   public function testExecuteWithCwd(): void {
+    $this->setupFsFixture();
     $local_machine_helper = $this->localMachineHelper;
     $process = $local_machine_helper->execute(['ls', '-lash'], NULL, $this->projectFixtureDir, FALSE);
     $this->assertTrue($process->isSuccessful());

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -193,17 +193,15 @@ abstract class TestBase extends TestCase {
    */
   protected function setUp(OutputInterface $output = NULL): void {
     putenv('COLUMNS=85');
-    if (!$output) {
-      $output = new BufferedOutput();
-    }
-    $input = new ArrayInput([]);
+    $this->output = $output ?: new BufferedOutput();
+    $this->input = new ArrayInput([]);
 
     $this->application = new Application();
     $this->fs = new Filesystem();
     $this->prophet = new Prophet();
     $this->consoleOutput = new ConsoleOutput();
     $this->setClientProphecies();
-    $this->setIo($input, $output);
+    $this->setIo();
 
     $this->setupVfsFixture();
     $this->logStreamManagerProphecy = $this->prophet->prophesize(LogstreamManager::class);
@@ -266,14 +264,12 @@ abstract class TestBase extends TestCase {
     }
   }
 
-  protected function setIo($input, $output): void {
-    $this->input = $input;
-    $this->output = $output;
-    $this->logger = new ConsoleLogger($output);
-    $this->localMachineHelper = new LocalMachineHelper($input, $output, $this->logger);
+  private function setIo(): void {
+    $this->logger = new ConsoleLogger($this->output);
+    $this->localMachineHelper = new LocalMachineHelper($this->input, $this->output, $this->logger);
     // TTY should never be used for tests.
     $this->localMachineHelper->setIsTty(FALSE);
-    $this->sshHelper = new SshHelper($output, $this->localMachineHelper, $this->logger);
+    $this->sshHelper = new SshHelper($this->output, $this->localMachineHelper, $this->logger);
   }
 
   /**


### PR DESCRIPTION
Cuts number of tmp directories on every test run from 600 to 10, I'll take it. Could still fix the rest of the tests to use VFS ideally. And really, stop mirroring the whole fixture for every test, only mock the files we need.

Also need to fix email subscription command to stop creating weird csv directory.

Follow-up from https://github.com/acquia/cli/pull/1195