### PR TITLE
CLI-868: Refresh Tokens are invalidated too frequently while Acquia C…

### DIFF
--- a/src/CloudApi/AccessTokenConnector.php
+++ b/src/CloudApi/AccessTokenConnector.php
@@ -2,6 +2,7 @@
 
 namespace Acquia\Cli\CloudApi;
 
+use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Connector\Connector;
 use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Token\AccessToken;
@@ -21,14 +22,21 @@ class AccessTokenConnector extends Connector {
    * @inheritdoc
    */
   public function __construct(array $config, string $base_uri = NULL) {
-    $this->accessToken = $config['access_token'];
+    $this->accessToken = new AccessToken(['access_token' => $config['access_token']]);
     parent::__construct($config, $base_uri);
   }
 
   /**
    * @inheritdoc
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   public function createRequest($verb, $path): RequestInterface {
+    if ($file = getenv('ACLI_ACCESS_TOKEN_FILE')) {
+      if (!file_exists($file)) {
+        throw new AcquiaCliException('Access token file not found at {file}', ['file' => $file]);
+      }
+      $this->accessToken = new AccessToken(['access_token' => trim(file_get_contents($file), "\"\n")]);
+    }
     return $this->provider->getAuthenticatedRequest(
       $verb,
       $this->baseUri . $path,


### PR DESCRIPTION
This is a hack in several ways... this class shouldn't be looking at environment variables directly, and really we shouldn't have a separate AccessTokenConnector class at all, it should use the League built-in refresh functionality, etc etc

But it works.

