### PR TITLE
IDE-2865: Simplify xdebug handling

### DIFF
--- a/src/Command/Ide/IdeCommandBase.php
+++ b/src/Command/Ide/IdeCommandBase.php
@@ -16,11 +16,12 @@ abstract class IdeCommandBase extends CommandBase {
   use IdeCommandTrait;
 
   /**
-   * @var string
+   * @var string[]
    */
-  private string $xdebugIniFilepath;
-
-  public const DEFAULT_XDEBUG_INI_FILEPATH = '/home/ide/configs/php/xdebug.ini';
+  private array $xdebugIniFilepaths = [
+    '/home/ide/configs/php/xdebug2.ini',
+    '/home/ide/configs/php/xdebug3.ini',
+  ];
 
   /**
    * @param string $question_text
@@ -42,8 +43,8 @@ abstract class IdeCommandBase extends CommandBase {
     }
 
     $choices = [];
-    foreach ($ides as $key => $ide) {
-      $choices[] = "{$ide->label} ($ide->uuid)";
+    foreach ($ides as $ide) {
+      $choices[] = "$ide->label ($ide->uuid)";
     }
     $choice = $this->io->choice($question_text, $choices, $choices[0]);
     $chosen_environment_index = array_search($choice, $choices, TRUE);
@@ -106,35 +107,18 @@ abstract class IdeCommandBase extends CommandBase {
   }
 
   /**
-   * @param string $file_path
+   * @param string[] $file_paths
    */
-  public function setXdebugIniFilepath(string $file_path): void {
-    $this->xdebugIniFilepath = $file_path;
+  public function setXdebugIniFilepaths(array $file_paths): void {
+    $this->xdebugIniFilepaths = $file_paths;
   }
 
   /**
    *
-   * @return string
+   * @return string[]
    */
-  protected function getXdebugIniFilePath(): string {
-    if (!isset($this->xdebugIniFilepath)) {
-      $this->xdebugIniFilepath = self::DEFAULT_XDEBUG_INI_FILEPATH;
-    }
-    return $this->xdebugIniFilepath;
-  }
-
-  /**
-   * @param string $php_version
-   *   The current php version.
-   *
-   * @return string
-   *   The file path to the xdebug template.
-   */
-  protected function getXdebugTemplateFilePath(string $php_version): string {
-    return match ($php_version) {
-      '7.4' => '/home/ide/configs/php/xdebug2.ini',
-      default => '/home/ide/configs/php/xdebug3.ini',
-    };
+  protected function getXdebugIniFilePaths(): array {
+    return $this->xdebugIniFilepaths;
   }
 
 }

--- a/src/Command/Ide/IdePhpVersionCommand.php
+++ b/src/Command/Ide/IdePhpVersionCommand.php
@@ -50,7 +50,6 @@ class IdePhpVersionCommand extends IdeCommandBase {
     $version = $input->getArgument('version');
     $this->validatePhpVersion($version);
     $this->localMachineHelper->getFilesystem()->dumpFile($this->getIdePhpVersionFilePath(), $version);
-    $this->localMachineHelper->getFilesystem()->copy($this->getXdebugTemplateFilePath($version), IdeCommandBase::DEFAULT_XDEBUG_INI_FILEPATH, TRUE);
     $this->restartService('php-fpm');
 
     return 0;
@@ -75,6 +74,8 @@ class IdePhpVersionCommand extends IdeCommandBase {
 
   /**
    * {inheritdoc}.
+   *
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
    */
   protected function validatePhpVersion(string $version): string {
     parent::validatePhpVersion($version);

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -2,6 +2,7 @@
 
 namespace Acquia\Cli\Command\Ide;
 
+use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -44,21 +45,22 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->requireCloudIdeEnvironment();
-    $ini_file = $this->getXdebugIniFilePath();
-    $contents = file_get_contents($ini_file);
-    $this->setXDebugStatus($contents);
+    $ini_files = $this->getXdebugIniFilePaths();
+    foreach ($ini_files as $ini_file) {
+      $contents = file_get_contents($ini_file);
+      $this->setXDebugStatus($contents);
 
-    if ($this->getXDebugStatus() === FALSE) {
-      $this->enableXDebug($ini_file, $contents);
-      $this->restartService('php-fpm');
+      if ($this->getXDebugStatus() === FALSE) {
+        $this->enableXDebug($ini_file, $contents);
+      }
+      elseif ($this->getXDebugStatus() === TRUE) {
+        $this->disableXDebug($ini_file, $contents);
+      }
+      else {
+        throw new AcquiaCliException("Could not find xdebug zend extension in $ini_file!");
+      }
     }
-    elseif ($this->getXDebugStatus() === TRUE) {
-      $this->disableXDebug($ini_file, $contents);
-      $this->restartService('php-fpm');
-    }
-    else {
-      $this->logger->error("Could not find xdebug zend extension in $ini_file!");
-    }
+    $this->restartService('php-fpm');
 
     return 0;
   }

--- a/tests/phpunit/src/Commands/Ide/IdePhpVersionCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdePhpVersionCommandTest.php
@@ -7,7 +7,6 @@ use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\LocalMachineHelper;
 use Acquia\Cli\Tests\CommandTestBase;
 use Exception;
-use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Filesystem\Filesystem;
@@ -55,7 +54,6 @@ class IdePhpVersionCommandTest extends CommandTestBase {
     $local_machine_helper = $this->mockLocalMachineHelper();
     $this->mockRestartPhp($local_machine_helper);
     $mock_file_system = $this->mockGetFilesystem($local_machine_helper);
-    $mock_file_system->copy(Argument::type('string'), '/home/ide/configs/php/xdebug.ini', TRUE)->willReturn(TRUE);
     $php_filepath_prefix = $this->fs->tempnam(sys_get_temp_dir(), 'acli_php_stub_');
     $php_stub_filepath = $php_filepath_prefix . $version;
     $mock_file_system->exists($php_stub_filepath)->willReturn(TRUE);

--- a/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
@@ -32,7 +32,7 @@ class IdeXdebugToggleCommandTest extends CommandTestBase {
   public function setUpXdebug($php_version): void {
     $this->xdebugFilePath = $this->fs->tempnam(sys_get_temp_dir(), 'acli_xdebug_ini_');
     $this->fs->copy($this->realFixtureDir . '/xdebug.ini', $this->xdebugFilePath, TRUE);
-    $this->command->setXdebugIniFilepath($this->xdebugFilePath);
+    $this->command->setXdebugIniFilepaths([$this->xdebugFilePath]);
 
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);


### PR DESCRIPTION
**Motivation**

xdebug.ini frequently gets out of sync with the current PHP version.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Instead of "flip flopping" xdebug.ini to match the current PHP version, just modify the template xdebug2.ini / xdebug3.ini files in place to enable/disable xdebug. The IDE will link the corresponding Xdebug file and PHP version.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
I considered as alternatives installing Xdebug 3 in PHP 7.4, but this would move us away from Acquia PHP, and also combining Xdebug 2/3 settings in a single file, but this logs deprecation warnings.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
