### PR TITLE
Fix #1322: Adding flag to show only deployed VCS

### DIFF
--- a/tests/phpunit/src/Commands/App/AppVcsInfoTest.php
+++ b/tests/phpunit/src/Commands/App/AppVcsInfoTest.php
@@ -96,7 +96,6 @@ class AppVcsInfoTest extends CommandTestBase {
 +-------------------+----------+----------------------+
 | master            | Yes      | Dev                  |
 | tags/01-01-2015   | Yes      | Production           |
-|                   | Yes      | Stage                |
 | feature-branch    | No       | None                 |
 | tags/2014-09-03   | No       | None                 |
 | tags/2014-09-03.0 | No       | None                 |

--- a/tests/phpunit/src/Commands/App/AppVcsInfoTest.php
+++ b/tests/phpunit/src/Commands/App/AppVcsInfoTest.php
@@ -106,4 +106,68 @@ EOD;
     self::assertStringContainsStringIgnoringLineEndings($expected, $output);
   }
 
+  /**
+   * Test the list of deployed VCS but no deployed VCS available.
+   *
+   * @throws \Exception
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function testNoDeployedVcs(): void {
+    $applications_response = $this->mockApplicationsRequest();
+    $this->mockApplicationRequest();
+    $response = $this->getMockEnvironmentsResponse();
+    foreach ($response->_embedded->items as $key => $item) {
+      // Empty the VCS
+      $item->vcs = new \stdClass();
+      $response->_embedded->items[$key] = $item;
+    }
+
+    $this->clientProphecy->request('get',
+      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
+      ->willReturn($response->_embedded->items)
+      ->shouldBeCalled();
+    $this->mockApplicationCodeRequest($applications_response);
+
+    $this->expectException(AcquiaCliException::class);
+    $this->expectExceptionMessage('No branch or tag is deployed on any of the environment of this application.');
+    $this->executeCommand(
+      [
+        'applicationUuid' => 'a47ac10b-58cc-4372-a567-0e02b2c3d470',
+        '--deployed',
+      ],
+    );
+  }
+
+  /**
+   * Test the list of the only deployed VCS.
+   *
+   * @throws \Exception
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
+  public function testListOnlyDeployedVcs(): void {
+    $applications_response = $this->mockApplicationsRequest();
+    $this->mockApplicationRequest();
+    $this->mockEnvironmentsRequest($applications_response);
+    $this->mockApplicationCodeRequest($applications_response);
+
+    $this->executeCommand(
+      [
+        'applicationUuid' => 'a47ac10b-58cc-4372-a567-0e02b2c3d470',
+        '--deployed',
+      ],
+    );
+
+    $output = $this->getDisplay();
+    $expected = <<<EOD
++-- Status of Branches and Tags of the Application ---+
+| Branch / Tag Name | Deployed | Deployed Environment |
++-------------------+----------+----------------------+
+| master            | Yes      | Dev                  |
+| tags/01-01-2015   | Yes      | Production           |
++-------------------+----------+----------------------+
+
+EOD;
+    self::assertStringContainsStringIgnoringLineEndings($expected, $output);
+  }
+
 }


### PR DESCRIPTION
Fix #1322

Added a new flag `--deployed`

<img width="880" alt="Screenshot 2023-01-23 at 6 15 15 PM" src="https://user-images.githubusercontent.com/1336423/214043044-f0c3e8bb-4893-43a1-a5b4-8e07ecae8ffe.png">

```
➜  ~/projects/acli_git git:(show_only_deployed_vcs) ./bin/acli app:vcs:info --help
Description:
  Get all branches and tags of the application with the deployment status

Usage:
  app:vcs:info [options] [--] [<applicationUuid>]
  app:vcs:info [<applicationAlias>] --deployed
  app:vcs:info [<applicationAlias>]
  app:vcs:info myapp
  app:vcs:info prod:myapp
  app:vcs:info abcd1234-1111-2222-3333-0e02b2c3d470

Arguments:
  applicationUuid            The Cloud Platform application UUID or alias (i.e. an application name optionally prefixed with the realm)

Options:
      --deployed[=DEPLOYED]  Show only deployed branches and tags
  -h, --help                 Display help for the given command. When no command is given display help for the list command
  -q, --quiet                Do not output any message
  -V, --version              Display this application version
      --ansi|--no-ansi       Force (or disable --no-ansi) ANSI output
  -n, --no-interaction       Do not ask any interactive question
  -v|vv|vvv, --verbose       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```