### PR TITLE
CLI-936: Upgrade Box

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
             "rm -rf gardener"
         ],
         "box-install": [
-            "curl -f -L https://github.com/box-project/box/releases/download/3.15.0/box.phar -o build/box.phar"
+            "curl -f -L https://github.com/box-project/box/releases/download/4.2.0/box.phar -o build/box.phar"
         ],
         "box-compile": [
             "php build/box.phar compile"


### PR DESCRIPTION
Local compiles are broken unless you run `composer install --no-dev` first, but it sounds like that will be fixed soon: https://github.com/box-project/box/issues/580