### PR TITLE
CLI-975: Fix false positive updates

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -35,6 +35,7 @@ use AcquiaCloudApi\Response\SubscriptionResponse;
 use AcquiaLogstream\LogstreamManager;
 use ArrayObject;
 use Closure;
+use Composer\Semver\Comparator;
 use Composer\Semver\VersionParser;
 use Exception;
 use GuzzleHttp\HandlerStack;
@@ -1070,7 +1071,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
          */
         $version = $release->tag_name;
         $versionStability = VersionParser::parseStability($version);
-        $versionIsNewer = version_compare($version, $this->getApplication()->getVersion());
+        $versionIsNewer = Comparator::greaterThanOrEqualTo($version, $this->getApplication()->getVersion());
         if ($versionStability === 'stable' && $versionIsNewer) {
           return $version;
         }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
ACLI wrongly reports available updates when running commands _other_ than `self-update`, because ACLI doesn't use the same upstream version comparisons as self-update 🙄 

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Use the same Comparator as consolidation/self-update. Longer-term, fix this in https://github.com/acquia/cli/issues/1403

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to test the update command, using `2.8.2.0` as the version to replicate the currently-available phar. Ensure that you are not prompted for updates when running commands like `ide:create`.
