### PR TITLE
Deprecation in ide:php-version redispatch

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -765,7 +765,7 @@ abstract class PullCommandBase extends CommandBase {
       $answer = $this->io->confirm("Would you like to change the PHP version on this IDE to match the PHP version on the <bg=cyan;options=bold>{$chosen_environment->label} ({$chosen_environment->configuration->php->version})</> environment?", FALSE);
       if ($answer) {
         $command = $this->getApplication()->find('ide:php-version');
-        $command->run(new ArrayInput(['version' => $chosen_environment->configuration->php->version]),
+        $command->run(new ArrayInput(['command' => 'ide:php-version', 'version' => $chosen_environment->configuration->php->version]),
           $output);
       }
     }


### PR DESCRIPTION
`str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated`

Reported via bugsnag