### PR TITLE
CLI-996: [env:certificate-create] new command

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -663,8 +663,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * Determine the Cloud environment.
    *
    * @throws \Exception
+   * @return string
+   *   The environment UUID.
    */
-  protected function determineCloudEnvironment(): mixed {
+  protected function determineCloudEnvironment(): string {
     if ($this->input->hasArgument('environmentId') && $this->input->getArgument('environmentId')) {
       return $this->input->getArgument('environmentId');
     }

--- a/src/Command/Env/EnvCertCreateCommand.php
+++ b/src/Command/Env/EnvCertCreateCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Acquia\Cli\Command\Env;
+
+use Acquia\Cli\Command\CommandBase;
+use AcquiaCloudApi\Endpoints\SslCertificates;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class EnvCertCreateCommand.
+ */
+class EnvCertCreateCommand extends CommandBase {
+
+  protected static $defaultName = 'env:certificate-create';
+
+  /**
+   * {inheritdoc}.
+   */
+  protected function configure(): void {
+    $this->setDescription('Install an SSL certificate.')
+      ->addArgument('certificate', InputArgument::REQUIRED, 'Filename of the SSL certificate being installed.')
+      ->addArgument('private_key', InputArgument::REQUIRED, 'Filename of the SSL private key.')
+      ->addOption('legacy', '', InputOption::VALUE_OPTIONAL, 'Must be set to true for legacy certificates', FALSE)
+      ->addOption('ca_certificates', '', InputOption::VALUE_OPTIONAL, 'Filename of the CA intermediary certificates.')
+      ->addOption('csr_id', '', InputOption::VALUE_OPTIONAL, 'The CSR (certificate signing request) to associate with this certificate. Optional.')
+      ->addOption('label', '', InputOption::VALUE_OPTIONAL, 'The label for this certificate. Required for standard certificates. Optional for legacy certificates.', 'My certificate')
+      ->acceptEnvironmentId();
+  }
+
+  /**
+   * @return int 0 if everything went fine, or an exit code
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    $environment_uuid = $this->determineCloudEnvironment();
+    $sslCertificates = new SslCertificates($acquia_cloud_client);
+    $sslCertificates->create(
+      $environment_uuid,
+      $input->getOption('label'),
+      $this->localMachineHelper->readFile($input->getArgument('certificate')),
+      $this->localMachineHelper->readFile($input->getArgument('private_key')),
+      $this->localMachineHelper->readFile($input->getOption('ca_certificates')),
+      $input->getOption('csr_id'),
+      $input->getOption('legacy')
+    );
+    $this->io->success('Certificate was installed');
+    return 0;
+  }
+
+}


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->

The existing `api:environments:certificate-create` command is difficult to use because you have to pass certificates as arguments, which can be thousands of characters, and the help text is incorrect and certificate `---` lines are interpreted as Bash argument separators.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

Add a new command `env:certificate-create` that accepts filenames of certicates.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

Change help text on `api:environments:certificate-create` to show people how to simply read a file as an argument. But the existing help text would still be broken.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. `wacli env:certificate-create ~/Downloads/cert.pem ~/Downloads/key.pem foo.dev --ca_certificates=~/Downloads/ca.pem`
