### PR TITLE
CLI-1006: [ssh-key:upload] determineSshKeyLabel(): Return value must …

### DIFF
--- a/src/Command/Acsf/AcsfApiAuthLoginCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLoginCommand.php
@@ -75,11 +75,9 @@ class AcsfApiAuthLoginCommand extends AcsfCommandBase {
       $factory_url = $this->determineOption('factory-url', $input);
     }
 
-    $this->determineOption('username', $input);
-    $this->determineOption('key', $input, TRUE);
+    $username = $this->determineOption('username', $input);
+    $key = $this->determineOption('key', $input, TRUE);
 
-    $username = $input->getOption('username');
-    $key = $input->getOption('key');
     $this->writeAcsfCredentialsToDisk($factory_url, $username, $key);
     $output->writeln("<info>Saved credentials</info>");
 

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -47,7 +47,7 @@ class IdeCreateCommand extends IdeCommandBase {
     $account_resource = new Account($acquia_cloud_client);
     $account = $account_resource->get();
     $default = "$account->first_name $account->last_name's IDE";
-    $ide_label = $this->determineOption('label', $input, FALSE, \Closure::fromCallable([$this, 'validateIdeLabel']), $default);
+    $ide_label = $this->determineOption('label', $input, FALSE, \Closure::fromCallable([$this, 'validateIdeLabel']), NULL, $default);
 
     // Create it.
     $checklist->addItem('Creating your Cloud IDE');

--- a/src/Command/Ssh/SshKeyCreateUploadCommand.php
+++ b/src/Command/Ssh/SshKeyCreateUploadCommand.php
@@ -20,6 +20,7 @@ class SshKeyCreateUploadCommand extends SshKeyCreateCommand {
     $this->setDescription('Create an SSH key on your local machine and upload it to the Cloud Platform')
       ->addOption('filename', NULL, InputOption::VALUE_REQUIRED, 'The filename of the SSH key')
       ->addOption('password', NULL, InputOption::VALUE_REQUIRED, 'The password for the SSH key')
+      ->addOption('label', NULL, InputOption::VALUE_REQUIRED, 'The SSH key label to be used with the Cloud Platform')
       ->addOption('no-wait', NULL, InputOption::VALUE_NONE, "Don't wait for the SSH key to be uploaded to the Cloud Platform");
   }
 

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
@@ -13,17 +13,18 @@ use Symfony\Component\Console\Command\Command;
  * @property \Acquia\Cli\Command\Ide\Wizard\IdeWizardCreateSshKeyCommand $command
  * @package Acquia\Cli\Tests\Ide
  *
- * The IdeWizardCreateSshKeyCommand command is designed to thrown an exception if it
- * is executed from a non Cloud Platform IDE environment. Therefore we do not test Windows
+ * The IdeWizardCreateSshKeyCommand command is designed to throw an exception if it
+ * is executed from a non Cloud Platform IDE environment. Therefore, we do not test Windows
  * compatibility. It should only ever be run in a Linux environment.
  * @requires OS linux|darwin
  */
 class IdeWizardCreateSshKeyCommandTest extends IdeWizardTestBase {
 
-  protected $ide;
+  protected IdeResponse $ide;
 
   /**
    * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \JsonException
    */
   public function setUp($output = NULL): void {
     parent::setUp($output);
@@ -44,17 +45,25 @@ class IdeWizardCreateSshKeyCommandTest extends IdeWizardTestBase {
 
   /**
    * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \JsonException
    */
   protected function mockIdeRequest(): IdeResponse {
     $ide_response = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
     $this->clientProphecy->request('get', '/ides/' . IdeHelper::$remote_ide_uuid)->willReturn($ide_response)->shouldBeCalled();
-    return new IdeResponse((object) $ide_response);
+    return new IdeResponse($ide_response);
   }
 
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \JsonException
+   */
   public function testCreate(): void {
     parent::runTestCreate();
   }
 
+  /**
+   * @throws \Psr\Cache\InvalidArgumentException
+   */
   public function testSshKeyAlreadyUploaded(): void {
     parent::runTestSshKeyAlreadyUploaded();
   }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
@@ -42,8 +42,11 @@ class SshKeyCreateUploadCommandTest extends CommandTestBase {
    *
    * @throws \Psr\Cache\InvalidArgumentException
    * @throws \Acquia\Cli\Exception\AcquiaCliException
+   * @throws \Exception
    */
   public function testCreateUpload(): void {
+    $mock_request_args = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+
     // Create.
     $ssh_key_filename = 'id_rsa';
     $local_machine_helper = $this->mockLocalMachineHelper();
@@ -52,10 +55,9 @@ class SshKeyCreateUploadCommandTest extends CommandTestBase {
     $file_system = $this->prophet->prophesize(Filesystem::class);
     $this->mockAddSshKeyToAgent($local_machine_helper, $file_system);
     $this->mockSshAgentList($local_machine_helper);
-    $this->mockGenerateSshKey($local_machine_helper);
+    $this->mockGenerateSshKey($local_machine_helper, $mock_request_args['public_key']);
 
     // Upload.
-    $mock_request_args = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
     $this->mockUploadSshKey();
     //$this->mockListSshKeyRequestWithUploadedKey($mock_request_args);
     //$applications_response = $this->mockApplicationsRequest();

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -23,6 +23,7 @@ class SshKeyListCommandTest extends CommandTestBase {
 
   /**
    * @throws \JsonException
+   * @throws \Exception
    */
   public function setUp($output = NULL): void {
     parent::setUp($output);
@@ -31,12 +32,12 @@ class SshKeyListCommandTest extends CommandTestBase {
   }
 
   /**
-   * Tests the 'ssh-key:upload' command.
+   * Tests the 'ssh-key:list' command.
    *
    * @throws \Psr\Cache\InvalidArgumentException
    * @throws \Exception
    */
-  public function testUpload(): void {
+  public function testList(): void {
 
     $mock_body = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
     $this->clientProphecy->request('get', '/account/ssh-keys')->willReturn($mock_body->{'_embedded'}->items)->shouldBeCalled();

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -78,6 +78,10 @@ class SshKeyUploadCommandTest extends CommandTestBase {
    *
    * Tests the 'ssh-key:upload' command.
    * @throws \Psr\Cache\InvalidArgumentException
+   * @throws \JsonException
+   * @throws \Acquia\Cli\Exception\AcquiaCliException
+   * @throws \Safe\Exceptions\FilesystemException
+   * @throws \Exception
    */
   public function testUpload($args, $inputs, $perms): void {
     $this->sshKeysRequestBody = $this->getMockRequestBodyFromSpec('/account/ssh-keys');


### PR DESCRIPTION
…be of type string, null returned

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
