### PR TITLE
CLI-1009: [api:environments:clear-caches] OutputFormatter::escape(): …

### DIFF
--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -404,7 +404,9 @@ class ApiBaseCommand extends CommandBase {
    * @param array $params
    */
   private function askFreeFormQuestion(InputArgument $argument, array $params): mixed {
-    $question = new Question("Enter a value for {$argument->getName()}", $argument->getDefault());
+    // Default value may be an empty array, which causes Question to choke.
+    $default = $argument->getDefault() ?: NULL;
+    $question = new Question("Enter a value for {$argument->getName()}", $default);
     switch ($argument->getName()) {
       case 'applicationUuid':
         // @todo Provide a list of application UUIDs.


### PR DESCRIPTION
…Argument #1 () must be of type string, array given

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
