### PR TITLE
CLI-1042: Suppress warnings from posix_isatty

### DIFF
--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -105,7 +105,7 @@ class LocalMachineHelper {
    * @param array|null $env
    */
   private function configureProcess(Process $process, string $cwd = NULL, ?bool $print_output = TRUE, float $timeout = NULL, array $env = NULL): Process {
-    if (function_exists('posix_isatty') && !posix_isatty(STDIN)) {
+    if (function_exists('posix_isatty') && !@posix_isatty(STDIN)) {
       $process->setInput(STDIN);
     }
     if ($cwd) {
@@ -194,7 +194,7 @@ class LocalMachineHelper {
     // of a tty if stdout is redirected.
     // Otherwise, let the local machine helper decide whether to use a tty.
     if (function_exists('posix_isatty')) {
-      return (posix_isatty(STDOUT) && posix_isatty(STDIN));
+      return (@posix_isatty(STDOUT) && @posix_isatty(STDIN));
     }
 
     return FALSE;


### PR DESCRIPTION
I don't think PHP should be emitting these warnings in the first place. If they are legitimate (which I don't think they are), it's unclear how to resolve them. https://github.com/php/php-src/issues/10092