### PR TITLE
php-openssl is required when building Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ RUN apk add \
   php-mbstring \
   php-phar \
   php-xml \
+  php-openssl \
   && curl https://github.com/acquia/cli/releases/latest/download/acli.phar -L -o /usr/local/bin/acli \
   && chmod +x /usr/local/bin/acli


### PR DESCRIPTION
**Motivation**

If I build the [Dockerfile](https://github.com/acquia/cli/blob/main/Dockerfile) and run the resulting image, it tells me:

    git clone https://github.com/acquia/cli.git
    cd cli
    docker build -t acquia-cli .
    docker run --rm acquia-cli php /usr/local/bin/acli

```
Box Requirements Checker
========================

> Using PHP 8.1.18
> PHP is using the following php.ini file:
  /etc/php81/php.ini

> Checking Box requirements:
  .......E.......

                                                                                
 [ERROR] Your system is not ready to run the application.                       
                                                                                

Fix the following mandatory requirements:
=========================================

 * The package "composer/ca-bundle" requires the extension "openssl". You either
   need to enable it or request the application to be shipped with a polyfill
   for this extension.

```
**Proposed changes**

Install php-openssl in the Dockerfile.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

Test the following with and without the proposed change:

    git clone https://github.com/acquia/cli.git
    cd cli
    docker build -t acquia-cli .
    docker run --rm acquia-cli php /usr/local/bin/acli
 
