### PR TITLE
CLI-1050: Grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
-      symfony:
+      dependencies:
         patterns:
-          - "symfony/*"
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      symfony:
+        patterns:
+          - "symfony/*"


### PR DESCRIPTION
Originally I was thinking of grouping updates by major package (i.e., symfony, guzzle), but now I'm thinking it's better to group everything together. Basically a weekly `composer update`.

Commits become less granular, which makes tracing breaking updates harder, but overall I think the tradeoff is worth it to reduce Git history pollution.