### PR TITLE
CLI-1053: Convert snake case to camel case

### DIFF
--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -97,8 +97,8 @@ services:
         secret: '@=service("cloud.credentials").getCloudSecret()'
         accessToken: '@=service("cloud.credentials").getCloudAccessToken()'
         accessTokenExpiry: '@=service("cloud.credentials").getCloudAccessTokenExpiry()'
-      $base_uri: '@=service("cloud.credentials").getBaseUri()'
-      $accounts_uri: '@=service("cloud.credentials").getAccountsUri()'
+      $baseUri: '@=service("cloud.credentials").getBaseUri()'
+      $accountsUri: '@=service("cloud.credentials").getAccountsUri()'
   AcquiaCloudApi\Connector\ConnectorInterface:
     alias: Acquia\Cli\CloudApi\ConnectorFactory
   AcquiaCloudApi\Connector\Connector:

--- a/src/AcsfApi/AcsfClient.php
+++ b/src/AcsfApi/AcsfClient.php
@@ -9,8 +9,8 @@ use Psr\Http\Message\ResponseInterface;
 class AcsfClient extends Client {
 
   public function processResponse(ResponseInterface $response): mixed {
-    $body_json = $response->getBody();
-    $body = json_decode($body_json, FALSE, 512, JSON_THROW_ON_ERROR);
+    $bodyJson = $response->getBody();
+    $body = json_decode($bodyJson, FALSE, 512, JSON_THROW_ON_ERROR);
 
     // ACSF sometimes returns an array rather than an object.
     if (is_array($body)) {

--- a/src/AcsfApi/AcsfClientService.php
+++ b/src/AcsfApi/AcsfClientService.php
@@ -10,8 +10,8 @@ use Acquia\Cli\CloudApi\ClientService;
  */
 class AcsfClientService extends ClientService {
 
-  public function __construct(AcsfConnectorFactory $connector_factory, Application $application, AcsfCredentials $cloudCredentials) {
-    parent::__construct($connector_factory, $application, $cloudCredentials);
+  public function __construct(AcsfConnectorFactory $connectorFactory, Application $application, AcsfCredentials $cloudCredentials) {
+    parent::__construct($connectorFactory, $application, $cloudCredentials);
   }
 
   public function getClient(): AcsfClient {

--- a/src/AcsfApi/AcsfConnector.php
+++ b/src/AcsfApi/AcsfConnector.php
@@ -13,11 +13,11 @@ class AcsfConnector extends Connector {
 
   /**
    * @param array $config
-   * @param string|null $base_uri
-   * @param string|null $url_access_token
+   * @param string|null $baseUri
+   * @param string|null $urlAccessToken
    */
-  public function __construct(array $config, string $base_uri = NULL, string $url_access_token = NULL) {
-    parent::__construct($config, $base_uri, $url_access_token);
+  public function __construct(array $config, string $baseUri = NULL, string $urlAccessToken = NULL) {
+    parent::__construct($config, $baseUri, $urlAccessToken);
 
     $this->client = new GuzzleClient([
       'auth' => [

--- a/src/AcsfApi/AcsfCredentials.php
+++ b/src/AcsfApi/AcsfCredentials.php
@@ -18,8 +18,8 @@ class AcsfCredentials implements ApiCredentialsInterface {
       return getenv('ACSF_USERNAME');
     }
 
-    if (($current_factory = $this->getCurrentFactory()) && $active_user = $this->getFactoryActiveUser($current_factory)) {
-      return $active_user['username'];
+    if (($currentFactory = $this->getCurrentFactory()) && $activeUser = $this->getFactoryActiveUser($currentFactory)) {
+      return $activeUser['username'];
     }
 
     return NULL;
@@ -30,9 +30,9 @@ class AcsfCredentials implements ApiCredentialsInterface {
    */
   public function getFactoryActiveUser(array $factory): mixed {
     if (array_key_exists('active_user', $factory)) {
-      $active_user = $factory['active_user'];
-      if (array_key_exists($active_user, $factory['users'])) {
-        return $factory['users'][$active_user];
+      $activeUser = $factory['active_user'];
+      if (array_key_exists($activeUser, $factory['users'])) {
+        return $factory['users'][$activeUser];
       }
     }
 
@@ -40,8 +40,8 @@ class AcsfCredentials implements ApiCredentialsInterface {
   }
 
   private function getCurrentFactory(): mixed {
-    if (($factory = $this->datastoreCloud->get('acsf_active_factory')) && ($acsf_factories = $this->datastoreCloud->get('acsf_factories')) && array_key_exists($factory, $acsf_factories)) {
-      return $acsf_factories[$factory];
+    if (($factory = $this->datastoreCloud->get('acsf_active_factory')) && ($acsfFactories = $this->datastoreCloud->get('acsf_factories')) && array_key_exists($factory, $acsfFactories)) {
+      return $acsfFactories[$factory];
     }
     return NULL;
   }
@@ -51,8 +51,8 @@ class AcsfCredentials implements ApiCredentialsInterface {
       return getenv('ACSF_KEY');
     }
 
-    if (($current_factory = $this->getCurrentFactory()) && $active_user = $this->getFactoryActiveUser($current_factory)) {
-      return $active_user['key'];
+    if (($currentFactory = $this->getCurrentFactory()) && $activeUser = $this->getFactoryActiveUser($currentFactory)) {
+      return $activeUser['key'];
     }
 
     return NULL;

--- a/src/Application.php
+++ b/src/Application.php
@@ -34,8 +34,8 @@ class Application extends \Symfony\Component\Console\Application {
 
     if ($this->getHelpMessages()) {
       $io = new SymfonyStyle(new ArrayInput([]), $output);
-      $output_style = new OutputFormatterStyle('white', 'blue');
-      $output->getFormatter()->setStyle('help', $output_style);
+      $outputStyle = new OutputFormatterStyle('white', 'blue');
+      $output->getFormatter()->setStyle('help', $outputStyle);
       $io->block($this->getHelpMessages(), 'help', 'help', ' ', TRUE, FALSE);
     }
   }

--- a/src/CloudApi/AccessTokenConnector.php
+++ b/src/CloudApi/AccessTokenConnector.php
@@ -16,9 +16,9 @@ class AccessTokenConnector extends Connector {
    */
   protected AbstractProvider $provider;
 
-  public function __construct(array $config, string $base_uri = NULL, string $url_access_token = NULL) {
+  public function __construct(array $config, string $baseUri = NULL, string $urlAccessToken = NULL) {
     $this->accessToken = new AccessToken(['access_token' => $config['access_token']]);
-    parent::__construct($config, $base_uri, $url_access_token);
+    parent::__construct($config, $baseUri, $urlAccessToken);
   }
 
   public function createRequest($verb, $path): RequestInterface {

--- a/src/CloudApi/ClientService.php
+++ b/src/CloudApi/ClientService.php
@@ -24,11 +24,11 @@ class ClientService implements ClientServiceInterface {
   protected ?bool $machineIsAuthenticated = NULL;
 
   /**
-   * @param \Acquia\Cli\CloudApi\ConnectorFactory $connector_factory
+   * @param \Acquia\Cli\CloudApi\ConnectorFactory $connectorFactory
    */
-  public function __construct(ConnectorFactoryInterface $connector_factory, Application $application, protected ApiCredentialsInterface $credentials) {
-    $this->connectorFactory = $connector_factory;
-    $this->setConnector($connector_factory->createConnector());
+  public function __construct(ConnectorFactoryInterface $connectorFactory, Application $application, protected ApiCredentialsInterface $credentials) {
+    $this->connectorFactory = $connectorFactory;
+    $this->setConnector($connectorFactory->createConnector());
     $this->setApplication($application);
   }
 
@@ -48,14 +48,14 @@ class ClientService implements ClientServiceInterface {
   }
 
   protected function configureClient(Client $client): void {
-    $user_agent = sprintf("acli/%s", $this->application->getVersion());
-    $custom_headers = [
-      'User-Agent' => [$user_agent],
+    $userAgent = sprintf("acli/%s", $this->application->getVersion());
+    $customHeaders = [
+      'User-Agent' => [$userAgent],
     ];
     if ($uuid = getenv("REMOTEIDE_UUID")) {
-      $custom_headers['X-Cloud-IDE-UUID'] = $uuid;
+      $customHeaders['X-Cloud-IDE-UUID'] = $uuid;
     }
-    $client->addOption('headers', $custom_headers);
+    $client->addOption('headers', $customHeaders);
   }
 
   public function isMachineAuthenticated(): bool {

--- a/src/CloudApi/CloudCredentials.php
+++ b/src/CloudApi/CloudCredentials.php
@@ -61,11 +61,11 @@ class CloudCredentials implements ApiCredentialsInterface {
       return $secret;
     }
 
-    $acli_key = $this->getCloudKey();
+    $acliKey = $this->getCloudKey();
     if ($this->datastoreCloud->get('keys')) {
       $keys = $this->datastoreCloud->get('keys');
-      if (is_array($keys) && array_key_exists($acli_key, $keys)) {
-        return $this->datastoreCloud->get('keys')[$acli_key]['secret'];
+      if (is_array($keys) && array_key_exists($acliKey, $keys)) {
+        return $this->datastoreCloud->get('keys')[$acliKey]['secret'];
       }
     }
 

--- a/src/CloudApi/ConnectorFactory.php
+++ b/src/CloudApi/ConnectorFactory.php
@@ -8,17 +8,7 @@ use League\OAuth2\Client\Token\AccessToken;
 
 class ConnectorFactory implements ConnectorFactoryInterface {
 
-  protected ?string $baseUri;
-  protected ?string $accountsUri;
-
-  /**
-   * ConnectorFactory constructor.
-   *
-   * @param array $config
-   */
-  public function __construct(protected array $config, ?string $base_uri = NULL, ?string $accounts_uri = NULL) {
-    $this->baseUri = $base_uri;
-    $this->accountsUri = $accounts_uri;
+  public function __construct(protected array $config, protected ?string $baseUri = NULL, protected ?string $accountsUri = NULL) {
   }
 
   /**
@@ -32,11 +22,11 @@ class ConnectorFactory implements ConnectorFactoryInterface {
 
     // Fall back to a valid access token.
     if ($this->config['accessToken']) {
-      $access_token = $this->createAccessToken();
-      if (!$access_token->hasExpired()) {
+      $accessToken = $this->createAccessToken();
+      if (!$accessToken->hasExpired()) {
         // @todo Add debug log entry indicating that access token is being used.
         return new AccessTokenConnector([
-          'access_token' => $access_token,
+          'access_token' => $accessToken,
           'key' => NULL,
           'secret' => NULL,
         ], $this->baseUri, $this->accountsUri);

--- a/src/Command/Acsf/AcsfApiAuthLoginCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLoginCommand.php
@@ -26,67 +26,67 @@ class AcsfApiAuthLoginCommand extends AcsfCommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
     if ($input->getOption('factory-url')) {
-      $factory_url = $input->getOption('factory-url');
+      $factoryUrl = $input->getOption('factory-url');
     }
     elseif ($input->isInteractive() && $this->datastoreCloud->get('acsf_factories')) {
       $factories = $this->datastoreCloud->get('acsf_factories');
-      $factory_choices = $factories;
-      foreach ($factory_choices as $url => $factory_choice) {
-        $factory_choices[$url]['url'] = $url;
+      $factoryChoices = $factories;
+      foreach ($factoryChoices as $url => $factoryChoice) {
+        $factoryChoices[$url]['url'] = $url;
       }
-      $factory_choices['add_new'] = [
+      $factoryChoices['add_new'] = [
         'url' => 'Enter a new factory URL',
       ];
-      $factory = $this->promptChooseFromObjectsOrArrays($factory_choices, 'url', 'url', 'Choose a Factory to login to');
+      $factory = $this->promptChooseFromObjectsOrArrays($factoryChoices, 'url', 'url', 'Choose a Factory to login to');
       if ($factory['url'] === 'Enter a new factory URL') {
-        $factory_url = $this->io->ask('Enter the full URL of the factory');
+        $factoryUrl = $this->io->ask('Enter the full URL of the factory');
         $factory = [
-          'url' => $factory_url,
+          'url' => $factoryUrl,
           'users' => [],
         ];
       }
       else {
-        $factory_url = $factory['url'];
+        $factoryUrl = $factory['url'];
       }
 
       $users = $factory['users'];
       $users['add_new'] = [
         'username' => 'Enter a new user',
       ];
-      $selected_user = $this->promptChooseFromObjectsOrArrays($users, 'username', 'username', 'Choose which user to login as');
-      if ($selected_user['username'] !== 'Enter a new user') {
-        $this->datastoreCloud->set('acsf_active_factory', $factory_url);
-        $factories[$factory_url]['active_user'] = $selected_user['username'];
+      $selectedUser = $this->promptChooseFromObjectsOrArrays($users, 'username', 'username', 'Choose which user to login as');
+      if ($selectedUser['username'] !== 'Enter a new user') {
+        $this->datastoreCloud->set('acsf_active_factory', $factoryUrl);
+        $factories[$factoryUrl]['active_user'] = $selectedUser['username'];
         $this->datastoreCloud->set('acsf_factories', $factories);
         $output->writeln([
-          "<info>Acquia CLI is now logged in to <options=bold>{$factory['url']}</> as <options=bold>{$selected_user['username']}</></info>",
+          "<info>Acquia CLI is now logged in to <options=bold>{$factory['url']}</> as <options=bold>{$selectedUser['username']}</></info>",
         ]);
         return 0;
       }
     }
     else {
-      $factory_url = $this->determineOption('factory-url');
+      $factoryUrl = $this->determineOption('factory-url');
     }
 
     $username = $this->determineOption('username');
     $key = $this->determineOption('key', TRUE);
 
-    $this->writeAcsfCredentialsToDisk($factory_url, $username, $key);
+    $this->writeAcsfCredentialsToDisk($factoryUrl, $username, $key);
     $output->writeln("<info>Saved credentials</info>");
 
     return 0;
   }
 
-  private function writeAcsfCredentialsToDisk(?string $factory_url, string $username, string $key): void {
+  private function writeAcsfCredentialsToDisk(?string $factoryUrl, string $username, string $key): void {
     $keys = $this->datastoreCloud->get('acsf_factories');
-    $keys[$factory_url]['users'][$username] = [
+    $keys[$factoryUrl]['users'][$username] = [
       'key' => $key,
       'username' => $username,
     ];
-    $keys[$factory_url]['url'] = $factory_url;
-    $keys[$factory_url]['active_user'] = $username;
+    $keys[$factoryUrl]['url'] = $factoryUrl;
+    $keys[$factoryUrl]['active_user'] = $username;
     $this->datastoreCloud->set('acsf_factories', $keys);
-    $this->datastoreCloud->set('acsf_active_factory', $factory_url);
+    $this->datastoreCloud->set('acsf_active_factory', $factoryUrl);
   }
 
 }

--- a/src/Command/Acsf/AcsfApiAuthLogoutCommand.php
+++ b/src/Command/Acsf/AcsfApiAuthLogoutCommand.php
@@ -30,25 +30,25 @@ class AcsfApiAuthLogoutCommand extends AcsfCommandBase {
       $factories[$url]['url'] = $url;
     }
     $factory = $this->promptChooseFromObjectsOrArrays($factories, 'url', 'url', 'Choose a Factory to logout of');
-    $factory_url = $factory['url'];
+    $factoryUrl = $factory['url'];
 
-    /** @var \Acquia\Cli\AcsfApi\AcsfCredentials $cloud_credentials */
-    $cloud_credentials = $this->cloudCredentials;
-    $active_user = $cloud_credentials->getFactoryActiveUser($factory);
+    /** @var \Acquia\Cli\AcsfApi\AcsfCredentials $cloudCredentials */
+    $cloudCredentials = $this->cloudCredentials;
+    $activeUser = $cloudCredentials->getFactoryActiveUser($factory);
     // @todo Only show factories the user is logged into.
-    if (!$active_user) {
-      $this->io->error("You're already logged out of $factory_url");
+    if (!$activeUser) {
+      $this->io->error("You're already logged out of $factoryUrl");
       return 1;
     }
-    $answer = $this->io->confirm("Are you sure you'd like to logout the user {$active_user['username']} from $factory_url?");
+    $answer = $this->io->confirm("Are you sure you'd like to logout the user {$activeUser['username']} from $factoryUrl?");
     if (!$answer) {
       return 0;
     }
-    $factories[$factory_url]['active_user'] = NULL;
+    $factories[$factoryUrl]['active_user'] = NULL;
     $this->datastoreCloud->set('acsf_factories', $factories);
     $this->datastoreCloud->remove('acsf_active_factory');
 
-    $output->writeln("Logged {$active_user['username']} out of $factory_url</info>");
+    $output->writeln("Logged {$activeUser['username']} out of $factoryUrl</info>");
 
     return 0;
   }

--- a/src/Command/Acsf/AcsfListCommandBase.php
+++ b/src/Command/Acsf/AcsfListCommandBase.php
@@ -47,9 +47,9 @@ class AcsfListCommandBase extends CommandBase {
       'command' => 'list',
       'namespace' => 'acsf',
     ];
-    $list_input = new ArrayInput($arguments);
+    $listInput = new ArrayInput($arguments);
 
-    return $command->run($list_input, $output);
+    return $command->run($listInput, $output);
   }
 
 }

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -23,11 +23,11 @@ class ApiCommandHelper {
   /**
    * @return array
    */
-  public function getApiCommands(string $acquia_cloud_spec_file_path, string $command_prefix, CommandFactoryInterface $command_factory): array {
-    $acquia_cloud_spec = $this->getCloudApiSpec($acquia_cloud_spec_file_path);
-    $api_commands = $this->generateApiCommandsFromSpec($acquia_cloud_spec, $command_prefix, $command_factory);
-    $api_list_commands = $this->generateApiListCommands($api_commands, $command_prefix, $command_factory);
-    return array_merge($api_commands, $api_list_commands);
+  public function getApiCommands(string $acquiaCloudSpecFilePath, string $commandPrefix, CommandFactoryInterface $commandFactory): array {
+    $acquiaCloudSpec = $this->getCloudApiSpec($acquiaCloudSpecFilePath);
+    $apiCommands = $this->generateApiCommandsFromSpec($acquiaCloudSpec, $commandPrefix, $commandFactory);
+    $apiListCommands = $this->generateApiListCommands($apiCommands, $commandPrefix, $commandFactory);
+    return array_merge($apiCommands, $apiListCommands);
   }
 
   private function useCloudApiSpecCache(): bool {
@@ -35,18 +35,18 @@ class ApiCommandHelper {
   }
 
   /**
-   * @param array $param_definition
+   * @param array $paramDefinition
    */
-  protected function addArgumentExampleToUsageForGetEndpoint(array $param_definition, string $usage): mixed {
-    if (array_key_exists('example', $param_definition)) {
-      if (is_array($param_definition['example'])) {
-        $usage = reset($param_definition['example']);
+  protected function addArgumentExampleToUsageForGetEndpoint(array $paramDefinition, string $usage): mixed {
+    if (array_key_exists('example', $paramDefinition)) {
+      if (is_array($paramDefinition['example'])) {
+        $usage = reset($paramDefinition['example']);
       }
-      elseif (str_contains($param_definition['example'], ' ')) {
-        $usage .= '"' . $param_definition['example'] . '" ';
+      elseif (str_contains($paramDefinition['example'], ' ')) {
+        $usage .= '"' . $paramDefinition['example'] . '" ';
       }
       else {
-        $usage .= $param_definition['example'] . ' ';
+        $usage .= $paramDefinition['example'] . ' ';
       }
     }
 
@@ -54,11 +54,11 @@ class ApiCommandHelper {
   }
 
   /**
-   * @param array $param_definition
+   * @param array $paramDefinition
    */
-  private function addOptionExampleToUsageForGetEndpoint(array $param_definition, string $usage): string {
-    if (array_key_exists('example', $param_definition)) {
-      $usage .= '--' . $param_definition['name'] . '="' . $param_definition['example'] . '" ';
+  private function addOptionExampleToUsageForGetEndpoint(array $paramDefinition, string $usage): string {
+    if (array_key_exists('example', $paramDefinition)) {
+      $usage .= '--' . $paramDefinition['name'] . '="' . $paramDefinition['example'] . '" ';
     }
 
     return $usage;
@@ -66,133 +66,133 @@ class ApiCommandHelper {
 
   /**
    * @param array $schema
-   * @param array $acquia_cloud_spec
+   * @param array $acquiaCloudSpec
    */
-  private function addApiCommandParameters(array $schema, array $acquia_cloud_spec, CommandBase $command): void {
-    $input_definition = [];
+  private function addApiCommandParameters(array $schema, array $acquiaCloudSpec, CommandBase $command): void {
+    $inputDefinition = [];
     $usage = '';
 
     // Parameters to be used in the request query and path.
     if (array_key_exists('parameters', $schema)) {
-      [$query_input_definition, $query_param_usage_suffix] = $this->addApiCommandParametersForPathAndQuery($schema, $acquia_cloud_spec);
-      /** @var \Symfony\Component\Console\Input\InputOption|InputArgument $parameter_definition */
-      foreach ($query_input_definition as $parameter_definition) {
-        $parameter_specification = $this->getParameterDefinitionFromSpec($parameter_definition->getName(), $acquia_cloud_spec, $schema);
-        if ($parameter_specification['in'] === 'query') {
-          $command->addQueryParameter($parameter_definition->getName(), $parameter_specification);
+      [$queryInputDefinition, $queryParamUsageSuffix] = $this->addApiCommandParametersForPathAndQuery($schema, $acquiaCloudSpec);
+      /** @var \Symfony\Component\Console\Input\InputOption|InputArgument $parameterDefinition */
+      foreach ($queryInputDefinition as $parameterDefinition) {
+        $parameterSpecification = $this->getParameterDefinitionFromSpec($parameterDefinition->getName(), $acquiaCloudSpec, $schema);
+        if ($parameterSpecification['in'] === 'query') {
+          $command->addQueryParameter($parameterDefinition->getName(), $parameterSpecification);
         }
-        elseif ($parameter_specification['in'] === 'path') {
-          $command->addPathParameter($parameter_definition->getName(), $parameter_specification);
+        elseif ($parameterSpecification['in'] === 'path') {
+          $command->addPathParameter($parameterDefinition->getName(), $parameterSpecification);
         }
         // @todo Remove this! It is a workaround for CLI-769.
-        elseif ($parameter_specification['in'] === 'header') {
-          $command->addPostParameter($parameter_definition->getName(), $parameter_specification);
+        elseif ($parameterSpecification['in'] === 'header') {
+          $command->addPostParameter($parameterDefinition->getName(), $parameterSpecification);
         }
       }
-      $usage .= $query_param_usage_suffix;
-      $input_definition = array_merge($input_definition, $query_input_definition);
+      $usage .= $queryParamUsageSuffix;
+      $inputDefinition = array_merge($inputDefinition, $queryInputDefinition);
     }
 
     // Parameters to be used in the request body.
     if (array_key_exists('requestBody', $schema)) {
       [
-        $body_input_definition,
-        $request_body_param_usage_suffix,
-      ] = $this->addApiCommandParametersForRequestBody($schema, $acquia_cloud_spec);
-      $request_body_schema = $this->getRequestBodyFromParameterSchema($schema, $acquia_cloud_spec);
-      /** @var \Symfony\Component\Console\Input\InputOption|InputArgument $parameter_definition */
-      foreach ($body_input_definition as $parameter_definition) {
-        $parameter_specification = $this->getPropertySpecFromRequestBodyParam($request_body_schema, $parameter_definition);
-        $command->addPostParameter($parameter_definition->getName(), $parameter_specification);
+        $bodyInputDefinition,
+        $requestBodyParamUsageSuffix,
+      ] = $this->addApiCommandParametersForRequestBody($schema, $acquiaCloudSpec);
+      $requestBodySchema = $this->getRequestBodyFromParameterSchema($schema, $acquiaCloudSpec);
+      /** @var \Symfony\Component\Console\Input\InputOption|InputArgument $parameterDefinition */
+      foreach ($bodyInputDefinition as $parameterDefinition) {
+        $parameterSpecification = $this->getPropertySpecFromRequestBodyParam($requestBodySchema, $parameterDefinition);
+        $command->addPostParameter($parameterDefinition->getName(), $parameterSpecification);
       }
-      $usage .= $request_body_param_usage_suffix;
-      $input_definition = array_merge($input_definition, $body_input_definition);
+      $usage .= $requestBodyParamUsageSuffix;
+      $inputDefinition = array_merge($inputDefinition, $bodyInputDefinition);
     }
 
-    $command->setDefinition(new InputDefinition($input_definition));
+    $command->setDefinition(new InputDefinition($inputDefinition));
     if ($usage) {
       $command->addUsage(rtrim($usage));
     }
-    $this->addAliasUsageExamples($command, $input_definition, rtrim($usage));
+    $this->addAliasUsageExamples($command, $inputDefinition, rtrim($usage));
   }
 
   /**
    * @param array $schema
-   * @param array $acquia_cloud_spec
+   * @param array $acquiaCloudSpec
    * @return array
    */
-  private function addApiCommandParametersForRequestBody(array $schema, array $acquia_cloud_spec): array {
+  private function addApiCommandParametersForRequestBody(array $schema, array $acquiaCloudSpec): array {
     $usage = '';
-    $input_definition = [];
-    $request_body_schema = $this->getRequestBodyFromParameterSchema($schema, $acquia_cloud_spec);
+    $inputDefinition = [];
+    $requestBodySchema = $this->getRequestBodyFromParameterSchema($schema, $acquiaCloudSpec);
 
-    if (!array_key_exists('properties', $request_body_schema)) {
+    if (!array_key_exists('properties', $requestBodySchema)) {
       return [];
     }
-    foreach ($request_body_schema['properties'] as $prop_key => $param_definition) {
-      $is_required = array_key_exists('required', $request_body_schema) && in_array($prop_key, $request_body_schema['required'], TRUE);
-      $prop_key = self::renameParameter($prop_key);
+    foreach ($requestBodySchema['properties'] as $propKey => $paramDefinition) {
+      $isRequired = array_key_exists('required', $requestBodySchema) && in_array($propKey, $requestBodySchema['required'], TRUE);
+      $propKey = self::renameParameter($propKey);
 
-      if ($is_required) {
-        if (!array_key_exists('description', $param_definition)) {
-          $description = $param_definition["additionalProperties"]["description"];
+      if ($isRequired) {
+        if (!array_key_exists('description', $paramDefinition)) {
+          $description = $paramDefinition["additionalProperties"]["description"];
         }
         else {
-          $description = $param_definition['description'];
+          $description = $paramDefinition['description'];
         }
-        $input_definition[] = new InputArgument(
-          $prop_key,
-          array_key_exists('type', $param_definition) && $param_definition['type'] === 'array' ? InputArgument::IS_ARRAY | InputArgument::REQUIRED : InputArgument::REQUIRED,
+        $inputDefinition[] = new InputArgument(
+          $propKey,
+          array_key_exists('type', $paramDefinition) && $paramDefinition['type'] === 'array' ? InputArgument::IS_ARRAY | InputArgument::REQUIRED : InputArgument::REQUIRED,
               $description
           );
-        $usage = $this->addPostArgumentUsageToExample($schema['requestBody'], $prop_key, $param_definition, 'argument', $usage);
+        $usage = $this->addPostArgumentUsageToExample($schema['requestBody'], $propKey, $paramDefinition, 'argument', $usage);
       }
       else {
-        $input_definition[] = new InputOption(
-          $prop_key,
+        $inputDefinition[] = new InputOption(
+          $propKey,
               NULL,
-              array_key_exists('type', $param_definition) && $param_definition['type'] === 'array' ? InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED : InputOption::VALUE_REQUIRED,
-              array_key_exists('description', $param_definition) ? $param_definition['description'] : $prop_key
+              array_key_exists('type', $paramDefinition) && $paramDefinition['type'] === 'array' ? InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED : InputOption::VALUE_REQUIRED,
+              array_key_exists('description', $paramDefinition) ? $paramDefinition['description'] : $propKey
                 );
-        $usage = $this->addPostArgumentUsageToExample($schema["requestBody"], $prop_key, $param_definition, 'option', $usage);
+        $usage = $this->addPostArgumentUsageToExample($schema["requestBody"], $propKey, $paramDefinition, 'option', $usage);
         // @todo Add validator for $param['enum'] values?
       }
     }
-    /** @var \Symfony\Component\Console\Input\InputArgument|InputOption $parameter_definition */
-    foreach ($input_definition as $index => $parameter_definition) {
-      if ($parameter_definition->isArray()) {
+    /** @var \Symfony\Component\Console\Input\InputArgument|InputOption $parameterDefinition */
+    foreach ($inputDefinition as $index => $parameterDefinition) {
+      if ($parameterDefinition->isArray()) {
         // Move to the end of the array.
-        unset($input_definition[$index]);
-        $input_definition[] = $parameter_definition;
+        unset($inputDefinition[$index]);
+        $inputDefinition[] = $parameterDefinition;
       }
     }
 
-    return [$input_definition, $usage];
+    return [$inputDefinition, $usage];
   }
 
   /**
-   * @param $request_body
-   * @param $prop_key
-   * @param $param_definition
+   * @param $requestBody
+   * @param $propKey
+   * @param $paramDefinition
    * @param $type
    * @param $usage
    */
-  private function addPostArgumentUsageToExample($request_body, $prop_key, $param_definition, $type, $usage): string {
-    $request_body_content = $this->getRequestBodyContent($request_body);
+  private function addPostArgumentUsageToExample($requestBody, $propKey, $paramDefinition, $type, $usage): string {
+    $requestBodyContent = $this->getRequestBodyContent($requestBody);
 
-    if (array_key_exists('example', $request_body_content)) {
-      $example = $request_body_content['example'];
-      $prefix = $type === 'argument' ? '' : "--{$prop_key}=";
-      if (array_key_exists($prop_key, $example)) {
-        switch ($param_definition['type']) {
+    if (array_key_exists('example', $requestBodyContent)) {
+      $example = $requestBodyContent['example'];
+      $prefix = $type === 'argument' ? '' : "--{$propKey}=";
+      if (array_key_exists($propKey, $example)) {
+        switch ($paramDefinition['type']) {
           case 'object':
-            $usage .= $prefix . '"' . json_encode($example[$prop_key], JSON_THROW_ON_ERROR) . '"" ';
+            $usage .= $prefix . '"' . json_encode($example[$propKey], JSON_THROW_ON_ERROR) . '"" ';
             break;
 
           case 'array':
-            $is_multidimensional = count($example[$prop_key]) !== count($example[$prop_key], COUNT_RECURSIVE);
-            if (!$is_multidimensional) {
-              foreach ($example[$prop_key] as $value) {
+            $isMultidimensional = count($example[$propKey]) !== count($example[$propKey], COUNT_RECURSIVE);
+            if (!$isMultidimensional) {
+              foreach ($example[$propKey] as $value) {
                 $usage .= $prefix . "\"$value\" ";
               }
             }
@@ -200,7 +200,7 @@ class ApiCommandHelper {
               // @todo Pretty sure prevents the user from using the arguments.
               // Probably a bug. How can we allow users to specify a multidimensional array as an
               // argument?
-              $value = json_encode($example[$prop_key], JSON_THROW_ON_ERROR);
+              $value = json_encode($example[$propKey], JSON_THROW_ON_ERROR);
               $usage .= $prefix . "\"$value\" ";
             }
             break;
@@ -208,11 +208,11 @@ class ApiCommandHelper {
           case 'string':
           case 'boolean':
           case 'integer':
-            if (is_array($example[$prop_key])) {
-              $value = reset($example[$prop_key]);
+            if (is_array($example[$propKey])) {
+              $value = reset($example[$propKey]);
             }
             else {
-              $value = $example[$prop_key];
+              $value = $example[$propKey];
             }
             $usage .= $prefix . "\"{$value}\" ";
             break;
@@ -224,61 +224,61 @@ class ApiCommandHelper {
 
   /**
    * @param array $schema
-   * @param array $acquia_cloud_spec
+   * @param array $acquiaCloudSpec
    * @return array
    */
-  private function addApiCommandParametersForPathAndQuery(array $schema, array $acquia_cloud_spec): array {
+  private function addApiCommandParametersForPathAndQuery(array $schema, array $acquiaCloudSpec): array {
     $usage = '';
-    $input_definition = [];
+    $inputDefinition = [];
     if (!array_key_exists('parameters', $schema)) {
       return [];
     }
     foreach ($schema['parameters'] as $parameter) {
       if (array_key_exists('$ref', $parameter)) {
         $parts = explode('/', $parameter['$ref']);
-        $param_key = end($parts);
-        $param_definition = $this->getParameterDefinitionFromSpec($param_key, $acquia_cloud_spec, $schema);
+        $paramKey = end($parts);
+        $paramDefinition = $this->getParameterDefinitionFromSpec($paramKey, $acquiaCloudSpec, $schema);
       }
       else {
-        $param_definition = $parameter;
+        $paramDefinition = $parameter;
       }
 
-      $required = array_key_exists('required', $param_definition) && $param_definition['required'];
-      $this->addAliasParameterDescriptions($param_definition);
+      $required = array_key_exists('required', $paramDefinition) && $paramDefinition['required'];
+      $this->addAliasParameterDescriptions($paramDefinition);
       if ($required) {
-        $input_definition[] = new InputArgument(
-              $param_definition['name'],
+        $inputDefinition[] = new InputArgument(
+              $paramDefinition['name'],
               InputArgument::REQUIRED,
-              $param_definition['description']
+              $paramDefinition['description']
           );
-        $usage = $this->addArgumentExampleToUsageForGetEndpoint($param_definition, $usage);
+        $usage = $this->addArgumentExampleToUsageForGetEndpoint($paramDefinition, $usage);
       }
       else {
-        $input_definition[] = new InputOption(
-              $param_definition['name'],
+        $inputDefinition[] = new InputOption(
+              $paramDefinition['name'],
               NULL,
               InputOption::VALUE_REQUIRED,
-              $param_definition['description']
+              $paramDefinition['description']
                 );
-        $usage = $this->addOptionExampleToUsageForGetEndpoint($param_definition, $usage);
+        $usage = $this->addOptionExampleToUsageForGetEndpoint($paramDefinition, $usage);
       }
     }
 
-    return [$input_definition, $usage];
+    return [$inputDefinition, $usage];
   }
 
   /**
-   * @param array $acquia_cloud_spec
+   * @param array $acquiaCloudSpec
    * @param $schema
    */
-  private function getParameterDefinitionFromSpec(string $param_key, array $acquia_cloud_spec, $schema): mixed {
-    $uppercase_key = ucfirst($param_key);
-    if (array_key_exists('parameters', $acquia_cloud_spec['components'])
-      && array_key_exists($uppercase_key, $acquia_cloud_spec['components']['parameters'])) {
-      return $acquia_cloud_spec['components']['parameters'][$uppercase_key];
+  private function getParameterDefinitionFromSpec(string $paramKey, array $acquiaCloudSpec, $schema): mixed {
+    $uppercaseKey = ucfirst($paramKey);
+    if (array_key_exists('parameters', $acquiaCloudSpec['components'])
+      && array_key_exists($uppercaseKey, $acquiaCloudSpec['components']['parameters'])) {
+      return $acquiaCloudSpec['components']['parameters'][$uppercaseKey];
     }
     foreach ($schema['parameters'] as $parameter) {
-      if ($parameter['name'] === $param_key) {
+      if ($parameter['name'] === $paramKey) {
         return $parameter;
       }
     }
@@ -286,22 +286,22 @@ class ApiCommandHelper {
   }
 
   /**
-   * @param array $acquia_cloud_spec
+   * @param array $acquiaCloudSpec
    */
-  private function getParameterSchemaFromSpec(string $param_key, array $acquia_cloud_spec): mixed {
-    return $acquia_cloud_spec['components']['schemas'][$param_key];
+  private function getParameterSchemaFromSpec(string $paramKey, array $acquiaCloudSpec): mixed {
+    return $acquiaCloudSpec['components']['schemas'][$paramKey];
   }
 
   /**
-   * @param $cache_item
+   * @param $cacheItem
    */
-  private function isApiSpecChecksumCacheValid($cache_item, string $acquia_cloud_spec_file_checksum): bool {
+  private function isApiSpecChecksumCacheValid($cacheItem, string $acquiaCloudSpecFileChecksum): bool {
     // If the spec file doesn't exist, assume cache is valid.
-    if ($cache_item->isHit() && !$acquia_cloud_spec_file_checksum) {
+    if ($cacheItem->isHit() && !$acquiaCloudSpecFileChecksum) {
       return TRUE;
     }
     // If there's an invalid entry OR there's no entry, return false.
-    if (!$cache_item->isHit() || ($cache_item->isHit() && $cache_item->get() !== $acquia_cloud_spec_file_checksum)) {
+    if (!$cacheItem->isHit() || ($cacheItem->isHit() && $cacheItem->get() !== $acquiaCloudSpecFileChecksum)) {
       return FALSE;
     }
 
@@ -311,44 +311,44 @@ class ApiCommandHelper {
   /**
    * @return array
    */
-  private function getCloudApiSpec(string $spec_file_path): array {
-    $cache_key = basename($spec_file_path);
-    $cache = new PhpArrayAdapter(__DIR__ . '/../../../var/cache/' . $cache_key . '.cache', new NullAdapter());
-    $cache_item_checksum = $cache->getItem($cache_key . '.checksum');
-    $cache_item_spec = $cache->getItem($cache_key);
+  private function getCloudApiSpec(string $specFilePath): array {
+    $cacheKey = basename($specFilePath);
+    $cache = new PhpArrayAdapter(__DIR__ . '/../../../var/cache/' . $cacheKey . '.cache', new NullAdapter());
+    $cacheItemChecksum = $cache->getItem($cacheKey . '.checksum');
+    $cacheItemSpec = $cache->getItem($cacheKey);
 
     // When running the phar, the original file may not exist. In that case, always use the cache.
-    if (!file_exists($spec_file_path) && $cache_item_spec->isHit()) {
-      return $cache_item_spec->get();
+    if (!file_exists($specFilePath) && $cacheItemSpec->isHit()) {
+      return $cacheItemSpec->get();
     }
 
     // Otherwise, only use cache when it is valid.
-    $checksum = md5_file($spec_file_path);
+    $checksum = md5_file($specFilePath);
     if ($this->useCloudApiSpecCache()
-      && $this->isApiSpecChecksumCacheValid($cache_item_checksum, $checksum) && $cache_item_spec->isHit()
+      && $this->isApiSpecChecksumCacheValid($cacheItemChecksum, $checksum) && $cacheItemSpec->isHit()
     ) {
-      return $cache_item_spec->get();
+      return $cacheItemSpec->get();
     }
 
     // Parse file. This can take a long while!
     $this->logger->debug("Rebuilding caches...");
-    $spec = Yaml::parseFile($spec_file_path);
+    $spec = Yaml::parseFile($specFilePath);
 
     $cache->warmUp([
-      $cache_key => $spec,
-      $cache_key . '.checksum' => $checksum,
+      $cacheKey => $spec,
+      $cacheKey . '.checksum' => $checksum,
     ]);
 
     return $spec;
   }
 
   /**
-   * @param array $acquia_cloud_spec
+   * @param array $acquiaCloudSpec
    * @return ApiBaseCommand[]
    */
-  private function generateApiCommandsFromSpec(array $acquia_cloud_spec, string $command_prefix, CommandFactoryInterface $command_factory): array {
-    $api_commands = [];
-    foreach ($acquia_cloud_spec['paths'] as $path => $endpoint) {
+  private function generateApiCommandsFromSpec(array $acquiaCloudSpec, string $commandPrefix, CommandFactoryInterface $commandFactory): array {
+    $apiCommands = [];
+    foreach ($acquiaCloudSpec['paths'] as $path => $endpoint) {
       // Skip internal endpoints. These shouldn't actually be in the spec.
       if (array_key_exists('x-internal', $endpoint) && $endpoint['x-internal']) {
         continue;
@@ -368,24 +368,24 @@ class ApiCommandHelper {
           continue;
         }
 
-        $command_name = $command_prefix . ':' . $schema['x-cli-name'];
-        $command = $command_factory->createCommand();
-        $command->setName($command_name);
+        $commandName = $commandPrefix . ':' . $schema['x-cli-name'];
+        $command = $commandFactory->createCommand();
+        $command->setName($commandName);
         $command->setDescription($schema['summary']);
         $command->setMethod($method);
         $command->setResponses($schema['responses']);
         $command->setHidden(FALSE);
-        if (array_key_exists('servers', $acquia_cloud_spec)) {
-          $command->setServers($acquia_cloud_spec['servers']);
+        if (array_key_exists('servers', $acquiaCloudSpec)) {
+          $command->setServers($acquiaCloudSpec['servers']);
         }
         $command->setPath($path);
         $command->setHelp("For more help, see https://cloudapi-docs.acquia.com/ or https://dev.acquia.com/api-documentation/acquia-cloud-site-factory-api for acsf commands.");
-        $this->addApiCommandParameters($schema, $acquia_cloud_spec, $command);
-        $api_commands[] = $command;
+        $this->addApiCommandParameters($schema, $acquiaCloudSpec, $command);
+        $apiCommands[] = $command;
       }
     }
 
-    return $api_commands;
+    return $apiCommands;
   }
 
   /**
@@ -410,62 +410,62 @@ class ApiCommandHelper {
   }
 
   /**
-   * @param array $input_definition
+   * @param array $inputDefinition
    */
-  private function addAliasUsageExamples(ApiBaseCommand $command, array $input_definition, string $usage): void {
-    foreach ($input_definition as $key => $parameter) {
+  private function addAliasUsageExamples(ApiBaseCommand $command, array $inputDefinition, string $usage): void {
+    foreach ($inputDefinition as $key => $parameter) {
       if ($parameter->getName() === 'applicationUuid') {
-        $usage_parts = explode(' ', $usage);
-        $usage_parts[$key] = "myapp";
-        $usage = implode(' ', $usage_parts);
+        $usageParts = explode(' ', $usage);
+        $usageParts[$key] = "myapp";
+        $usage = implode(' ', $usageParts);
         $command->addUsage($usage);
       }
       if ($parameter->getName() === 'environmentId') {
-        $usage_parts = explode(' ', $usage);
-        $usage_parts[$key] = "myapp.dev";
-        $usage = implode(' ', $usage_parts);
+        $usageParts = explode(' ', $usage);
+        $usageParts[$key] = "myapp.dev";
+        $usage = implode(' ', $usageParts);
         $command->addUsage($usage);
       }
     }
   }
 
   /**
-   * @param $param_definition
+   * @param $paramDefinition
    */
-  private function addAliasParameterDescriptions(&$param_definition): void {
-    if ($param_definition['name'] === 'applicationUuid') {
-      $param_definition['description'] .= ' You may also use an application alias or omit the argument if you run the command in a linked directory.';
+  private function addAliasParameterDescriptions(&$paramDefinition): void {
+    if ($paramDefinition['name'] === 'applicationUuid') {
+      $paramDefinition['description'] .= ' You may also use an application alias or omit the argument if you run the command in a linked directory.';
     }
-    if ($param_definition['name'] === 'environmentId') {
-      $param_definition['description'] .= " You may also use an environment alias or UUID.";
+    if ($paramDefinition['name'] === 'environmentId') {
+      $paramDefinition['description'] .= " You may also use an environment alias or UUID.";
     }
   }
 
   /**
    * @param array $schema
-   * @param $acquia_cloud_spec
+   * @param $acquiaCloudSpec
    * @return array
    */
-  private function getRequestBodyFromParameterSchema(array $schema, $acquia_cloud_spec): array {
-    $request_body_content = $this->getRequestBodyContent($schema['requestBody']);
-    $request_body_schema = $request_body_content['schema'];
+  private function getRequestBodyFromParameterSchema(array $schema, $acquiaCloudSpec): array {
+    $requestBodyContent = $this->getRequestBodyContent($schema['requestBody']);
+    $requestBodySchema = $requestBodyContent['schema'];
 
     // If this is a reference to the top level schema, go grab the referenced component.
-    if (array_key_exists('$ref', $request_body_schema)) {
-      $parts = explode('/', $request_body_schema['$ref']);
-      $param_key = end($parts);
-      $request_body_schema = $this->getParameterSchemaFromSpec($param_key, $acquia_cloud_spec);
+    if (array_key_exists('$ref', $requestBodySchema)) {
+      $parts = explode('/', $requestBodySchema['$ref']);
+      $paramKey = end($parts);
+      $requestBodySchema = $this->getParameterSchemaFromSpec($paramKey, $acquiaCloudSpec);
     }
 
-    return $request_body_schema;
+    return $requestBodySchema;
   }
 
   /**
-   * @param array $request_body_schema
-   * @param $parameter_definition
+   * @param array $requestBodySchema
+   * @param $parameterDefinition
    */
-  private function getPropertySpecFromRequestBodyParam(array $request_body_schema, $parameter_definition): mixed {
-    return $request_body_schema['properties'][$parameter_definition->getName()] ?? NULL;
+  private function getPropertySpecFromRequestBodyParam(array $requestBodySchema, $parameterDefinition): mixed {
+    return $requestBodySchema['properties'][$parameterDefinition->getName()] ?? NULL;
   }
 
   /*
@@ -482,48 +482,48 @@ class ApiCommandHelper {
   }
 
   /**
-   * @param $prop_key
+   * @param $propKey
    */
-  public static function renameParameter($prop_key): mixed {
-    $parameter_rename_map = self::getParameterRenameMap();
-    if (array_key_exists($prop_key, $parameter_rename_map)) {
-      $prop_key = $parameter_rename_map[$prop_key];
+  public static function renameParameter($propKey): mixed {
+    $parameterRenameMap = self::getParameterRenameMap();
+    if (array_key_exists($propKey, $parameterRenameMap)) {
+      $propKey = $parameterRenameMap[$propKey];
     }
-    return $prop_key;
+    return $propKey;
   }
 
-  public static function restoreRenamedParameter(string $prop_key): int|string {
-    $parameter_rename_map = array_flip(self::getParameterRenameMap());
-    if (array_key_exists($prop_key, $parameter_rename_map)) {
-      $prop_key = $parameter_rename_map[$prop_key];
+  public static function restoreRenamedParameter(string $propKey): int|string {
+    $parameterRenameMap = array_flip(self::getParameterRenameMap());
+    if (array_key_exists($propKey, $parameterRenameMap)) {
+      $propKey = $parameterRenameMap[$propKey];
     }
-    return $prop_key;
+    return $propKey;
   }
 
   /**
-   * @param array $api_commands
+   * @param array $apiCommands
    * @return ApiListCommandBase[]
    */
-  private function generateApiListCommands(array $api_commands, string $command_prefix, CommandFactoryInterface $command_factory): array {
-    $api_list_commands = [];
-    foreach ($api_commands as $api_command) {
-      $command_name_parts = explode(':', $api_command->getName());
-      if (count($command_name_parts) < 3) {
+  private function generateApiListCommands(array $apiCommands, string $commandPrefix, CommandFactoryInterface $commandFactory): array {
+    $apiListCommands = [];
+    foreach ($apiCommands as $apiCommand) {
+      $commandNameParts = explode(':', $apiCommand->getName());
+      if (count($commandNameParts) < 3) {
         continue;
       }
-      $namespace = $command_name_parts[1];
-      if (!array_key_exists($namespace, $api_list_commands)) {
+      $namespace = $commandNameParts[1];
+      if (!array_key_exists($namespace, $apiListCommands)) {
         /** @var \Acquia\Cli\Command\Acsf\AcsfListCommand|\Acquia\Cli\Command\Api\ApiListCommand $command */
-        $command = $command_factory->createListCommand();
-        $name = $command_prefix . ':' . $namespace;
+        $command = $commandFactory->createListCommand();
+        $name = $commandPrefix . ':' . $namespace;
         $command->setName($name);
         $command->setNamespace($name);
         $command->setAliases([]);
         $command->setDescription("List all API commands for the {$namespace} resource");
-        $api_list_commands[$name] = $command;
+        $apiListCommands[$name] = $command;
       }
     }
-    return $api_list_commands;
+    return $apiListCommands;
   }
 
   /**

--- a/src/Command/Api/ApiListCommandBase.php
+++ b/src/Command/Api/ApiListCommandBase.php
@@ -38,9 +38,9 @@ class ApiListCommandBase extends CommandBase {
       'command' => 'list',
       'namespace' => 'api',
     ];
-    $list_input = new ArrayInput($arguments);
+    $listInput = new ArrayInput($arguments);
 
-    return $command->run($list_input, $output);
+    return $command->run($listInput, $output);
   }
 
 }

--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -22,8 +22,8 @@ class AppOpenCommand extends CommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $application_uuid = $this->determineCloudApplication();
-    $this->localMachineHelper->startBrowser('https://cloud.acquia.com/a/applications/' . $application_uuid);
+    $applicationUuid = $this->determineCloudApplication();
+    $this->localMachineHelper->startBrowser('https://cloud.acquia.com/a/applications/' . $applicationUuid);
 
     return 0;
   }

--- a/src/Command/App/AppVcsInfo.php
+++ b/src/Command/App/AppVcsInfo.php
@@ -26,64 +26,64 @@ class AppVcsInfo extends CommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $application_uuid = $this->determineCloudApplication();
+    $applicationUuid = $this->determineCloudApplication();
 
-    $cloud_api_client = $this->cloudApiClientService->getClient();
+    $cloudApiClient = $this->cloudApiClientService->getClient();
 
-    $env_resource = new Environments($cloud_api_client);
-    $environments = $env_resource->getAll($application_uuid);
+    $envResource = new Environments($cloudApiClient);
+    $environments = $envResource->getAll($applicationUuid);
 
     if (!$environments->count()) {
       throw new AcquiaCliException('There are no environments available with this application.');
     }
 
     // To show branches and tags which are deployed only.
-    $show_deployed_vcs_only = $input->hasParameterOption('--deployed');
+    $showDeployedVcsOnly = $input->hasParameterOption('--deployed');
 
     // Prepare list of all deployed VCS paths.
-    $deployed_vcs = [];
+    $deployedVcs = [];
     foreach ($environments as $environment) {
       if (isset($environment->vcs->path)) {
-        $deployed_vcs[$environment->vcs->path] = $environment->label;
+        $deployedVcs[$environment->vcs->path] = $environment->label;
       }
     }
 
     // If only to show the deployed VCS but no VCS is deployed.
-    if ($show_deployed_vcs_only && empty($deployed_vcs)) {
+    if ($showDeployedVcsOnly && empty($deployedVcs)) {
       throw new AcquiaCliException('No branch or tag is deployed on any of the environment of this application.');
     }
 
-    $application_code_resource = new Code($cloud_api_client);
-    $all_branches_and_tags = $application_code_resource->getAll($application_uuid);
+    $applicationCodeResource = new Code($cloudApiClient);
+    $allBranchesAndTags = $applicationCodeResource->getAll($applicationUuid);
 
-    if (!$all_branches_and_tags->count()) {
+    if (!$allBranchesAndTags->count()) {
       throw new AcquiaCliException('No branch or tag is available with this application.');
     }
 
-    $non_deployed_vcs = [];
+    $nonDeployedVcs = [];
     // Show both deployed and non-deployed VCS.
-    if (!$show_deployed_vcs_only) {
+    if (!$showDeployedVcsOnly) {
       // Prepare list of all non-deployed VCS paths.
-      foreach ($all_branches_and_tags as $branch_tag) {
-        if (!isset($deployed_vcs[$branch_tag->name])) {
-          $non_deployed_vcs[$branch_tag->name] = $branch_tag->name;
+      foreach ($allBranchesAndTags as $branchTag) {
+        if (!isset($deployedVcs[$branchTag->name])) {
+          $nonDeployedVcs[$branchTag->name] = $branchTag->name;
         }
       }
     }
 
     // To show the deployed VCS paths on top.
-    $all_vcs = array_merge($deployed_vcs, $non_deployed_vcs);
+    $allVcs = array_merge($deployedVcs, $nonDeployedVcs);
     $headers = ['Branch / Tag Name', 'Deployed', 'Deployed Environment'];
     $table = new Table($output);
     $table->setHeaders($headers);
     $table->setHeaderTitle('Status of Branches and Tags of the Application');
-    foreach ($all_vcs as $vsc_path => $env) {
+    foreach ($allVcs as $vscPath => $env) {
       $table->addRow([
-        $vsc_path,
+        $vscPath,
         // If VCS and env name is not same, it means it is deployed.
-        $vsc_path !== $env ? 'Yes' : 'No',
+        $vscPath !== $env ? 'Yes' : 'No',
         // If VCS and env name is same, it means it is deployed.
-        $vsc_path !== $env ? $env : 'None',
+        $vscPath !== $env ? $env : 'None',
       ]);
     }
 

--- a/src/Command/App/LinkCommand.php
+++ b/src/Command/App/LinkCommand.php
@@ -21,9 +21,9 @@ class LinkCommand extends CommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->validateCwdIsValidDrupalProject();
-    if ($cloud_application_uuid = $this->getCloudUuidFromDatastore()) {
-      $cloud_application = $this->getCloudApplication($cloud_application_uuid);
-      $output->writeln('This repository is already linked to Cloud application <options=bold>' . $cloud_application->name . '</>. Run <options=bold>acli unlink</> to unlink it.');
+    if ($cloudApplicationUuid = $this->getCloudUuidFromDatastore()) {
+      $cloudApplication = $this->getCloudApplication($cloudApplicationUuid);
+      $output->writeln('This repository is already linked to Cloud application <options=bold>' . $cloudApplication->name . '</>. Run <options=bold>acli unlink</> to unlink it.');
       return 1;
     }
     $this->determineCloudApplication(TRUE);

--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -21,17 +21,17 @@ class LogTailCommand extends CommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $environment_id = $this->determineCloudEnvironment();
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    $environmentId = $this->determineCloudEnvironment();
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
     $logs = $this->promptChooseLogs();
-    $log_types = array_map(static function ($log) {
+    $logTypes = array_map(static function ($log) {
       return $log['type'];
     }, $logs);
-    $logs_resource = new Logs($acquia_cloud_client);
-    $stream = $logs_resource->stream($environment_id);
+    $logsResource = new Logs($acquiaCloudClient);
+    $stream = $logsResource->stream($environmentId);
     $this->logstreamManager->setParams($stream->logstream->params);
     $this->logstreamManager->setColourise(TRUE);
-    $this->logstreamManager->setLogTypeFilter($log_types);
+    $this->logstreamManager->setLogTypeFilter($logTypes);
     $output->writeln('<info>Streaming has started and new logs will appear below. Use Ctrl+C to exit.</info>');
     $this->logstreamManager->stream();
     return 0;

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -47,12 +47,12 @@ class NewCommand extends CommandBase {
     $output->writeln('<info>Creating project. This may take a few minutes.</info>');
 
     if ($project === 'acquia_next_acms') {
-      $success_message = "<info>New Next JS project created in $dir. 🎉</info>";
+      $successMessage = "<info>New Next JS project created in $dir. 🎉</info>";
       $this->localMachineHelper->checkRequiredBinariesExist(['node']);
       $this->createNextJsProject($dir);
     }
     else {
-      $success_message = "<info>New 💧 Drupal project created in $dir. 🎉</info>";
+      $successMessage = "<info>New 💧 Drupal project created in $dir. 🎉</info>";
       $this->localMachineHelper->checkRequiredBinariesExist(['composer']);
       $this->createDrupalProject($distros[$project], $dir);
     }
@@ -60,7 +60,7 @@ class NewCommand extends CommandBase {
     $this->initializeGitRepository($dir);
 
     $output->writeln('');
-    $output->writeln($success_message);
+    $output->writeln($successMessage);
 
     return 0;
   }

--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -20,14 +20,14 @@ class TaskWaitCommand extends CommandBase {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $notification_uuid = $this->getNotificationUuid($input);
-    $this->waitForNotificationToComplete($this->cloudApiClientService->getClient(), $notification_uuid, "Waiting for task $notification_uuid to complete");
+    $notificationUuid = $this->getNotificationUuid($input);
+    $this->waitForNotificationToComplete($this->cloudApiClientService->getClient(), $notificationUuid, "Waiting for task $notificationUuid to complete");
     return 0;
   }
 
   private function getNotificationUuid(InputInterface $input): string {
-    $notification_uuid = $input->getArgument('notification-uuid');
-    $json = json_decode($notification_uuid, FALSE);
+    $notificationUuid = $input->getArgument('notification-uuid');
+    $json = json_decode($notificationUuid, FALSE);
     if (json_last_error() === JSON_ERROR_NONE) {
       if (is_object($json) && property_exists($json, '_links') && property_exists($json->_links, 'notification') && property_exists($json->_links->notification, 'href')) {
         return $this->getNotificationUuidFromResponse($json);

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -42,35 +42,35 @@ class AuthLoginCommand extends CommandBase {
         'label' => 'Enter a new API key',
         'uuid' => 'create_new',
       ];
-      $selected_key = $this->promptChooseFromObjectsOrArrays($keys, 'uuid', 'label', 'Choose which API key to use');
-      if ($selected_key['uuid'] !== 'create_new') {
-        $this->datastoreCloud->set('acli_key', $selected_key['uuid']);
-        $output->writeln("<info>Acquia CLI will use the API Key <options=bold>{$selected_key['label']}</></info>");
+      $selectedKey = $this->promptChooseFromObjectsOrArrays($keys, 'uuid', 'label', 'Choose which API key to use');
+      if ($selectedKey['uuid'] !== 'create_new') {
+        $this->datastoreCloud->set('acli_key', $selectedKey['uuid']);
+        $output->writeln("<info>Acquia CLI will use the API Key <options=bold>{$selectedKey['label']}</></info>");
         $this->reAuthenticate($this->cloudCredentials->getCloudKey(), $this->cloudCredentials->getCloudSecret(), $this->cloudCredentials->getBaseUri(), $this->cloudCredentials->getAccountsUri());
         return 0;
       }
     }
 
     $this->promptOpenBrowserToCreateToken($input);
-    $api_key = $this->determineApiKey();
-    $api_secret = $this->determineApiSecret();
-    $this->reAuthenticate($api_key, $api_secret, $this->cloudCredentials->getBaseUri(), $this->cloudCredentials->getAccountsUri());
-    $this->writeApiCredentialsToDisk($api_key, $api_secret);
+    $apiKey = $this->determineApiKey();
+    $apiSecret = $this->determineApiSecret();
+    $this->reAuthenticate($apiKey, $apiSecret, $this->cloudCredentials->getBaseUri(), $this->cloudCredentials->getAccountsUri());
+    $this->writeApiCredentialsToDisk($apiKey, $apiSecret);
     $output->writeln("<info>Saved credentials</info>");
 
     return 0;
   }
 
-  private function writeApiCredentialsToDisk(string $api_key, string $api_secret): void {
-    $token_info = $this->cloudApiClientService->getClient()->request('get', "/account/tokens/{$api_key}");
+  private function writeApiCredentialsToDisk(string $apiKey, string $apiSecret): void {
+    $tokenInfo = $this->cloudApiClientService->getClient()->request('get', "/account/tokens/{$apiKey}");
     $keys = $this->datastoreCloud->get('keys');
-    $keys[$api_key] = [
-      'label' => $token_info->label,
-      'secret' => $api_secret,
-      'uuid' => $api_key,
+    $keys[$apiKey] = [
+      'label' => $tokenInfo->label,
+      'secret' => $apiSecret,
+      'uuid' => $apiKey,
     ];
     $this->datastoreCloud->set('keys', $keys);
-    $this->datastoreCloud->set('acli_key', $api_key);
+    $this->datastoreCloud->set('acli_key', $apiKey);
   }
 
 }

--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -14,41 +14,41 @@ class CodeStudioCiCdVariables {
   /**
    * @return array[]
    */
-  public static function getDefaults(?string $cloud_application_uuid = NULL, ?string $cloud_key = NULL, ?string $cloud_secret = NULL, ?string $project_access_token_name = NULL, ?string $project_access_token = NULL): array {
+  public static function getDefaults(?string $cloudApplicationUuid = NULL, ?string $cloudKey = NULL, ?string $cloudSecret = NULL, ?string $projectAccessTokenName = NULL, ?string $projectAccessToken = NULL): array {
     return [
       [
         'key' => 'ACQUIA_APPLICATION_UUID',
         'masked' => FALSE,
         'protected' => FALSE,
-        'value' => $cloud_application_uuid,
+        'value' => $cloudApplicationUuid,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_CLOUD_API_TOKEN_KEY',
         'masked' => FALSE,
         'protected' => FALSE,
-        'value' => $cloud_key,
+        'value' => $cloudKey,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_CLOUD_API_TOKEN_SECRET',
         'masked' => FALSE,
         'protected' => FALSE,
-        'value' => $cloud_secret,
+        'value' => $cloudSecret,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_GLAB_TOKEN_NAME',
         'masked' => FALSE,
         'protected' => FALSE,
-        'value' => $project_access_token_name,
+        'value' => $projectAccessTokenName,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_GLAB_TOKEN_SECRET',
         'masked' => TRUE,
         'protected' => FALSE,
-        'value' => $project_access_token,
+        'value' => $projectAccessToken,
         'variable_type' => 'env_var',
       ],
     ];

--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -30,7 +30,7 @@ trait CodeStudioCommandTrait {
   /**
    * Getting the gitlab token from user.
    */
-  private function getGitLabToken(string $gitlab_host): string {
+  private function getGitLabToken(string $gitlabHost): string {
     if ($this->input->getOption('gitlab-token')) {
       return $this->input->getOption('gitlab-token');
     }
@@ -42,7 +42,7 @@ trait CodeStudioCommandTrait {
       'config',
       'get',
       'token',
-      '--host=' . $gitlab_host,
+      '--host=' . $gitlabHost,
     ], NULL, NULL, FALSE);
     if ($process->isSuccessful() && trim($process->getOutput())) {
       return trim($process->getOutput());
@@ -51,10 +51,10 @@ trait CodeStudioCommandTrait {
     $this->io->writeln([
       "",
       "You must first authenticate with Code Studio by creating a personal access token:",
-      "* Visit https://$gitlab_host/-/profile/personal_access_tokens",
+      "* Visit https://$gitlabHost/-/profile/personal_access_tokens",
       "* Create a token and grant it both <comment>api</comment> and <comment>write repository</comment> scopes",
       "* Copy the token to your clipboard",
-      "* Run <comment>glab auth login --hostname=$gitlab_host</comment> and paste the token when prompted",
+      "* Run <comment>glab auth login --hostname=$gitlabHost</comment> and paste the token when prompted",
       "* Try this command again.",
     ]);
 
@@ -83,21 +83,21 @@ trait CodeStudioCommandTrait {
       throw new AcquiaCliException("Could not determine GitLab host: {error_message}", ['error_message' => $process->getErrorOutput()]);
     }
     $output = trim($process->getOutput());
-    $url_parts = parse_url($output);
-    if (!array_key_exists('scheme', $url_parts) && !array_key_exists('host', $url_parts)) {
+    $urlParts = parse_url($output);
+    if (!array_key_exists('scheme', $urlParts) && !array_key_exists('host', $urlParts)) {
       // $output looks like code.cloudservices.acquia.io.
       return $output;
     }
     // $output looks like http://code.cloudservices.acquia.io/.
-    return $url_parts['host'];
+    return $urlParts['host'];
   }
 
   private function getGitLabClient(): Client {
     if (!isset($this->gitLabClient)) {
-      $gitlab_client = new Client(new Builder(new \GuzzleHttp\Client()));
-      $gitlab_client->setUrl('https://' . $this->gitLabHost);
-      $gitlab_client->authenticate($this->gitLabToken, Client::AUTH_OAUTH_TOKEN);
-      $this->setGitLabClient($gitlab_client);
+      $gitlabClient = new Client(new Builder(new \GuzzleHttp\Client()));
+      $gitlabClient->setUrl('https://' . $this->gitLabHost);
+      $gitlabClient->authenticate($this->gitLabToken, Client::AUTH_OAUTH_TOKEN);
+      $this->setGitLabClient($gitlabClient);
     }
     return $this->gitLabClient;
   }
@@ -109,7 +109,7 @@ trait CodeStudioCommandTrait {
   private function writeApiTokenMessage(InputInterface $input): void {
     // Get Cloud access tokens.
     if (!$input->getOption('key') || !$input->getOption('secret')) {
-      $token_url = 'https://cloud.acquia.com/a/profile/tokens';
+      $tokenUrl = 'https://cloud.acquia.com/a/profile/tokens';
       $this->io->writeln([
         "",
         "This will configure AutoDevOps for a Code Studio project using credentials",
@@ -121,7 +121,7 @@ trait CodeStudioCommandTrait {
         "need to be re-configured using a different user account.",
         "",
         "<options=bold>To begin, visit this URL and create a new API Token for Code Studio to use:</>",
-        "<href=$token_url>$token_url</>",
+        "<href=$tokenUrl>$tokenUrl</>",
       ]);
     }
   }
@@ -155,14 +155,14 @@ trait CodeStudioCommandTrait {
   /**
    * @return array
    */
-  private function determineGitLabProject(ApplicationResponse $cloud_application): array {
+  private function determineGitLabProject(ApplicationResponse $cloudApplication): array {
     // Use command option.
     if ($this->input->getOption('gitlab-project-id')) {
       $id = $this->input->getOption('gitlab-project-id');
       return $this->gitLabClient->projects()->show($id);
     }
     // Search for existing project that matches expected description pattern.
-    $projects = $this->gitLabClient->projects()->all(['search' => $cloud_application->uuid]);
+    $projects = $this->gitLabClient->projects()->all(['search' => $cloudApplication->uuid]);
     if ($projects) {
       if (count($projects) == 1) {
         return reset($projects);
@@ -172,19 +172,19 @@ trait CodeStudioCommandTrait {
         $projects,
         'id',
         'path_with_namespace',
-        "Found multiple projects that could match the {$cloud_application->name} application. Choose which one to configure."
+        "Found multiple projects that could match the {$cloudApplication->name} application. Choose which one to configure."
       );
     }
     // Prompt to create project.
 
     $this->io->writeln([
       "",
-      "Could not find any existing Code Studio project for Acquia Cloud Platform application <comment>{$cloud_application->name}</comment>.",
-      "Searched for UUID <comment>{$cloud_application->uuid}</comment> in project descriptions.",
+      "Could not find any existing Code Studio project for Acquia Cloud Platform application <comment>{$cloudApplication->name}</comment>.",
+      "Searched for UUID <comment>{$cloudApplication->uuid}</comment> in project descriptions.",
     ]);
-    $create_project = $this->io->confirm('Would you like to create a new Code Studio project? If you select "no" you may choose from a full list of existing projects.');
-    if ($create_project) {
-      return $this->createGitLabProject($cloud_application);
+    $createProject = $this->io->confirm('Would you like to create a new Code Studio project? If you select "no" you may choose from a full list of existing projects.');
+    if ($createProject) {
+      return $this->createGitLabProject($cloudApplication);
     }
     // Prompt to choose from full list, regardless of description.
 
@@ -192,28 +192,28 @@ trait CodeStudioCommandTrait {
       $this->gitLabClient->projects()->all(),
       'id',
       'path_with_namespace',
-      "Choose a Code Studio project to configure for the {$cloud_application->name} application"
+      "Choose a Code Studio project to configure for the {$cloudApplication->name} application"
     );
   }
 
   /**
    * @return array
    */
-  private function createGitLabProject(ApplicationResponse $cloud_application): array {
-    $user_groups = $this->gitLabClient->groups()->all([
+  private function createGitLabProject(ApplicationResponse $cloudApplication): array {
+    $userGroups = $this->gitLabClient->groups()->all([
       'all_available' => TRUE,
       'min_access_level' => 40,
     ]);
     $parameters = $this->getGitLabProjectDefaults();
-    if ($user_groups) {
-      $user_groups[] = $this->gitLabClient->namespaces()->show($this->gitLabAccount['username']);
-      $project_group = $this->promptChooseFromObjectsOrArrays($user_groups, 'id', 'path', 'Choose which group this new project should belong to:');
-      $parameters['namespace_id'] = $project_group['id'];
+    if ($userGroups) {
+      $userGroups[] = $this->gitLabClient->namespaces()->show($this->gitLabAccount['username']);
+      $projectGroup = $this->promptChooseFromObjectsOrArrays($userGroups, 'id', 'path', 'Choose which group this new project should belong to:');
+      $parameters['namespace_id'] = $projectGroup['id'];
     }
 
     $slugger = new AsciiSlugger();
-    $project_name = $slugger->slug($cloud_application->name);
-    $project = $this->gitLabClient->projects()->create($project_name, $parameters);
+    $projectName = $slugger->slug($cloudApplication->name);
+    $project = $this->gitLabClient->projects()->create($projectName, $parameters);
     try {
       $this->gitLabClient->projects()
         ->uploadAvatar($project['id'], __DIR__ . '/drupal_icon.png');
@@ -226,8 +226,8 @@ trait CodeStudioCommandTrait {
     return $project;
   }
 
-  private function setGitLabProjectDescription($cloud_application_uuid): void {
-    $this->gitLabProjectDescription = "Source repository for Acquia Cloud Platform application <comment>$cloud_application_uuid</comment>";
+  private function setGitLabProjectDescription($cloudApplicationUuid): void {
+    $this->gitLabProjectDescription = "Source repository for Acquia Cloud Platform application <comment>$cloudApplicationUuid</comment>";
   }
 
   /**

--- a/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
@@ -24,14 +24,14 @@ class CodeStudioPhpVersionCommand extends CommandBase {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $php_version = $input->getArgument('php-version');
-    $this->validatePhpVersion($php_version);
+    $phpVersion = $input->getArgument('php-version');
+    $this->validatePhpVersion($phpVersion);
     $this->authenticateWithGitLab();
     $acquiaCloudAppId = $this->determineCloudApplication();
 
     // Get the GitLab project details attached with the given Cloud application.
-    $cloud_application = $this->getCloudApplication($acquiaCloudAppId);
-    $project = $this->determineGitLabProject($cloud_application);
+    $cloudApplication = $this->getCloudApplication($acquiaCloudAppId);
+    $project = $this->determineGitLabProject($cloudApplication);
 
     // If CI/CD is not enabled for the project in Code Studio.
     if (empty($project['jobs_enabled'])) {
@@ -40,28 +40,28 @@ class CodeStudioPhpVersionCommand extends CommandBase {
     }
 
     try {
-      $php_version_already_set = FALSE;
+      $phpVersionAlreadySet = FALSE;
       // Get all variables of the project.
-      $all_project_variables = $this->gitLabClient->projects()->variables($project['id']);
-      if (!empty($all_project_variables)) {
-        $variables = array_column($all_project_variables, 'value', 'key');
-        $php_version_already_set = $variables['PHP_VERSION'] ?? FALSE;
+      $allProjectVariables = $this->gitLabClient->projects()->variables($project['id']);
+      if (!empty($allProjectVariables)) {
+        $variables = array_column($allProjectVariables, 'value', 'key');
+        $phpVersionAlreadySet = $variables['PHP_VERSION'] ?? FALSE;
       }
       // If PHP version is not set in variables.
-      if (!$php_version_already_set) {
-        $this->gitLabClient->projects()->addVariable($project['id'], 'PHP_VERSION', $php_version);
+      if (!$phpVersionAlreadySet) {
+        $this->gitLabClient->projects()->addVariable($project['id'], 'PHP_VERSION', $phpVersion);
       }
       else {
         // If variable already exists, updating the variable.
-        $this->gitLabClient->projects()->updateVariable($project['id'], 'PHP_VERSION', $php_version);
+        $this->gitLabClient->projects()->updateVariable($project['id'], 'PHP_VERSION', $phpVersion);
       }
     }
     catch (RuntimeException) {
-      $this->io->error("Unable to update the PHP version to $php_version");
+      $this->io->error("Unable to update the PHP version to $phpVersion");
       return self::FAILURE;
     }
 
-    $this->io->success("PHP version is updated to $php_version successfully!");
+    $this->io->success("PHP version is updated to $phpVersion successfully!");
     return self::SUCCESS;
   }
 

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -35,35 +35,35 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->authenticateWithGitLab();
     $this->writeApiTokenMessage($input);
-    $cloud_key = $this->determineApiKey();
-    $cloud_secret = $this->determineApiSecret();
+    $cloudKey = $this->determineApiKey();
+    $cloudSecret = $this->determineApiSecret();
     // We may already be authenticated with Acquia Cloud Platform via a refresh token.
     // But, we specifically need an API Token key-pair of Code Studio.
     // So we reauthenticate to be sure we're using the provided credentials.
-    $this->reAuthenticate($cloud_key, $cloud_secret, $this->cloudCredentials->getBaseUri(), $this->cloudCredentials->getAccountsUri());
-    $cloud_application_uuid = $this->determineCloudApplication();
+    $this->reAuthenticate($cloudKey, $cloudSecret, $this->cloudCredentials->getBaseUri(), $this->cloudCredentials->getAccountsUri());
+    $cloudApplicationUuid = $this->determineCloudApplication();
 
     // Get Cloud account.
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $account_adapter = new Account($acquia_cloud_client);
-    $account = $account_adapter->get();
-    $this->setGitLabProjectDescription($cloud_application_uuid);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $accountAdapter = new Account($acquiaCloudClient);
+    $account = $accountAdapter->get();
+    $this->setGitLabProjectDescription($cloudApplicationUuid);
 
     // Get Cloud application.
-    $cloud_application = $this->getCloudApplication($cloud_application_uuid);
-    $project = $this->determineGitLabProject($cloud_application);
+    $cloudApplication = $this->getCloudApplication($cloudApplicationUuid);
+    $project = $this->determineGitLabProject($cloudApplication);
 
     // Migrate acquia-pipeline file
     $this->checkGitLabCiCdVariables($project);
     $this->validateCwdIsValidDrupalProject();
-    $acquia_pipelines_file_details = $this->getAcquiaPipelinesFileContents($project);
-    $acquia_pipelines_file_contents = $acquia_pipelines_file_details['file_contents'];
-    $acquia_pipelines_file_name = $acquia_pipelines_file_details['filename'];
-    $gitlab_ci_file_contents = $this->getGitLabCiFileTemplate();
-    $this->migrateVariablesSection($acquia_pipelines_file_contents, $gitlab_ci_file_contents);
-    $this->migrateEventsSection($acquia_pipelines_file_contents, $gitlab_ci_file_contents);
-    $this->removeEmptyScript($gitlab_ci_file_contents);
-    $this->createGitLabCiFile($gitlab_ci_file_contents, $acquia_pipelines_file_name);
+    $acquiaPipelinesFileDetails = $this->getAcquiaPipelinesFileContents($project);
+    $acquiaPipelinesFileContents = $acquiaPipelinesFileDetails['file_contents'];
+    $acquiaPipelinesFileName = $acquiaPipelinesFileDetails['filename'];
+    $gitlabCiFileContents = $this->getGitLabCiFileTemplate();
+    $this->migrateVariablesSection($acquiaPipelinesFileContents, $gitlabCiFileContents);
+    $this->migrateEventsSection($acquiaPipelinesFileContents, $gitlabCiFileContents);
+    $this->removeEmptyScript($gitlabCiFileContents);
+    $this->createGitLabCiFile($gitlabCiFileContents, $acquiaPipelinesFileName);
     $this->io->success([
       "",
       "Migration completed successfully.",
@@ -85,12 +85,12 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    * @param array $project
    */
   private function checkGitLabCiCdVariables(array $project): void {
-    $gitlab_cicd_variables = CodeStudioCiCdVariables::getList();
-    $gitlab_cicd_existing_variables = $this->gitLabClient->projects()->variables($project['id']);
-    $existing_keys = array_column($gitlab_cicd_existing_variables, 'key');
-    foreach ($gitlab_cicd_variables as $gitlab_cicd_variable) {
-      if (!in_array($gitlab_cicd_variable, $existing_keys, TRUE)) {
-        throw new AcquiaCliException("Code Studio CI/CD variable {$gitlab_cicd_variable} is not configured properly");
+    $gitlabCicdVariables = CodeStudioCiCdVariables::getList();
+    $gitlabCicdExistingVariables = $this->gitLabClient->projects()->variables($project['id']);
+    $existingKeys = array_column($gitlabCicdExistingVariables, 'key');
+    foreach ($gitlabCicdVariables as $gitlabCicdVariable) {
+      if (!in_array($gitlabCicdVariable, $existingKeys, TRUE)) {
+        throw new AcquiaCliException("Code Studio CI/CD variable {$gitlabCicdVariable} is not configured properly");
       }
     }
   }
@@ -102,20 +102,20 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
    * @return array
    */
   private function getAcquiaPipelinesFileContents(array $project): array {
-    $pipelines_filepath_yml = Path::join($this->projectDir, 'acquia-pipelines.yml');
-    $pipelines_filepath_yaml = Path::join($this->projectDir, 'acquia-pipelines.yaml');
-    if ($this->localMachineHelper->getFilesystem()->exists($pipelines_filepath_yml) ||
-      $this->localMachineHelper->getFilesystem()->exists($pipelines_filepath_yaml)
+    $pipelinesFilepathYml = Path::join($this->projectDir, 'acquia-pipelines.yml');
+    $pipelinesFilepathYaml = Path::join($this->projectDir, 'acquia-pipelines.yaml');
+    if ($this->localMachineHelper->getFilesystem()->exists($pipelinesFilepathYml) ||
+      $this->localMachineHelper->getFilesystem()->exists($pipelinesFilepathYaml)
     ) {
       $this->gitLabClient->projects()->update($project['id'], ['ci_config_path' => '']);
-      $pipelines_filenames = ['acquia-pipelines.yml', 'acquia-pipelines.yaml'];
-      foreach ($pipelines_filenames as $pipelines_filename) {
-        $pipelines_filepath = Path::join($this->projectDir, $pipelines_filename);
-        if (file_exists($pipelines_filepath)) {
-          $file_contents = file_get_contents($pipelines_filepath);
+      $pipelinesFilenames = ['acquia-pipelines.yml', 'acquia-pipelines.yaml'];
+      foreach ($pipelinesFilenames as $pipelinesFilename) {
+        $pipelinesFilepath = Path::join($this->projectDir, $pipelinesFilename);
+        if (file_exists($pipelinesFilepath)) {
+          $fileContents = file_get_contents($pipelinesFilepath);
           return [
-            'filename' => $pipelines_filename,
-            'file_contents' => Yaml::parse($file_contents, Yaml::PARSE_OBJECT),
+            'filename' => $pipelinesFilename,
+            'file_contents' => Yaml::parse($fileContents, Yaml::PARSE_OBJECT),
 ];
         }
       }
@@ -138,12 +138,12 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
   /**
    * Migrating `variables` section to .gitlab-ci.yml file.
    */
-  private function migrateVariablesSection($acquia_pipelines_file_contents, &$gitlab_ci_file_contents): void {
-    if (array_key_exists('variables', $acquia_pipelines_file_contents)) {
-      $variables_dump = Yaml::dump(['variables' => $acquia_pipelines_file_contents['variables']]);
-      $remove_global = preg_replace('/global:/', '', $variables_dump);
-      $variables_parse = Yaml::parse($remove_global);
-      $gitlab_ci_file_contents = array_merge($gitlab_ci_file_contents, $variables_parse);
+  private function migrateVariablesSection($acquiaPipelinesFileContents, &$gitlabCiFileContents): void {
+    if (array_key_exists('variables', $acquiaPipelinesFileContents)) {
+      $variablesDump = Yaml::dump(['variables' => $acquiaPipelinesFileContents['variables']]);
+      $removeGlobal = preg_replace('/global:/', '', $variablesDump);
+      $variablesParse = Yaml::parse($removeGlobal);
+      $gitlabCiFileContents = array_merge($gitlabCiFileContents, $variablesParse);
       $this->io->success([
         "Migrated `variables` section of acquia-pipelines.yml to .gitlab-ci.yml",
       ]);
@@ -156,28 +156,28 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
   }
 
   /**
-   * @param array $acquia_pipelines_file_contents
+   * @param array $acquiaPipelinesFileContents
    */
-  private function getPipelinesSection(array $acquia_pipelines_file_contents, string $event_name): mixed {
-    if (!array_key_exists('events', $acquia_pipelines_file_contents)) {
+  private function getPipelinesSection(array $acquiaPipelinesFileContents, string $eventName): mixed {
+    if (!array_key_exists('events', $acquiaPipelinesFileContents)) {
       return NULL;
     }
-    if (array_key_exists('build', $acquia_pipelines_file_contents['events']) && empty($acquia_pipelines_file_contents['events']['build'])) {
+    if (array_key_exists('build', $acquiaPipelinesFileContents['events']) && empty($acquiaPipelinesFileContents['events']['build'])) {
       return NULL;
     }
-    if (!array_key_exists($event_name, $acquia_pipelines_file_contents['events'])) {
+    if (!array_key_exists($eventName, $acquiaPipelinesFileContents['events'])) {
       return NULL;
     }
-    return $acquia_pipelines_file_contents['events'][$event_name]['steps'] ?? NULL;
+    return $acquiaPipelinesFileContents['events'][$eventName]['steps'] ?? NULL;
   }
 
   /**
-   * @param array $acquia_pipelines_file_contents
-   * @param array $gitlab_ci_file_contents
+   * @param array $acquiaPipelinesFileContents
+   * @param array $gitlabCiFileContents
    */
-  private function migrateEventsSection(array $acquia_pipelines_file_contents, array &$gitlab_ci_file_contents): void {
+  private function migrateEventsSection(array $acquiaPipelinesFileContents, array &$gitlabCiFileContents): void {
     // phpcs:disable SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys
-    $events_map = [
+    $eventsMap = [
       'build' => [
         'skip' => [
           'composer install' => [
@@ -223,69 +223,69 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
     ];
     // phpcs:enable
 
-    $code_studio_jobs = [];
-    foreach ($events_map as $event_name => $event_map) {
-      $event_steps = $this->getPipelinesSection($acquia_pipelines_file_contents, $event_name);
-      if ($event_steps) {
-        foreach ($event_steps as $step) {
-          $script_name = array_keys($step)[0];
-          if (!array_key_exists('script', $step[$script_name]) || empty($step[$script_name]['script'])) {
+    $codeStudioJobs = [];
+    foreach ($eventsMap as $eventName => $eventMap) {
+      $eventSteps = $this->getPipelinesSection($acquiaPipelinesFileContents, $eventName);
+      if ($eventSteps) {
+        foreach ($eventSteps as $step) {
+          $scriptName = array_keys($step)[0];
+          if (!array_key_exists('script', $step[$scriptName]) || empty($step[$scriptName]['script'])) {
             continue;
           }
-          if ($stage = $this->assignStageFromKeywords($event_map['stage'], $script_name)) {
-            $code_studio_jobs[$script_name]['stage'] = $stage;
+          if ($stage = $this->assignStageFromKeywords($eventMap['stage'], $scriptName)) {
+            $codeStudioJobs[$scriptName]['stage'] = $stage;
           }
-          foreach ($step[$script_name]['script'] as $command) {
-            foreach ($event_map['skip'] as $needle => $message_config) {
+          foreach ($step[$scriptName]['script'] as $command) {
+            foreach ($eventMap['skip'] as $needle => $messageConfig) {
               if (str_contains($command, $needle)) {
-                if ($message_config['prompt']) {
-                  $answer = $this->io->confirm($message_config['message'] . PHP_EOL . $command, FALSE);
+                if ($messageConfig['prompt']) {
+                  $answer = $this->io->confirm($messageConfig['message'] . PHP_EOL . $command, FALSE);
                   if ($answer == 1) {
-                    $code_studio_jobs[$script_name]['script'][] = $command;
-                    $code_studio_jobs[$script_name]['script'] = array_values(array_unique($code_studio_jobs[$script_name]['script']));
+                    $codeStudioJobs[$scriptName]['script'][] = $command;
+                    $codeStudioJobs[$scriptName]['script'] = array_values(array_unique($codeStudioJobs[$scriptName]['script']));
                   }
-                  else if (($key = array_search($command, $code_studio_jobs[$script_name]['script'], TRUE)) !== FALSE) {
-                    unset($code_studio_jobs[$script_name]['script'][$key]);
+                  else if (($key = array_search($command, $codeStudioJobs[$scriptName]['script'], TRUE)) !== FALSE) {
+                    unset($codeStudioJobs[$scriptName]['script'][$key]);
                   }
                 }
                 else {
                   $this->io->note([
-                    $message_config['message'],
+                    $messageConfig['message'],
                     $command,
                   ]);
                 }
                 break;
               }
 
-              if (array_key_exists($script_name, $code_studio_jobs) && array_key_exists('script', $code_studio_jobs[$script_name]) && in_array($command, $code_studio_jobs[$script_name]['script'], TRUE)) {
+              if (array_key_exists($scriptName, $codeStudioJobs) && array_key_exists('script', $codeStudioJobs[$scriptName]) && in_array($command, $codeStudioJobs[$scriptName]['script'], TRUE)) {
                 break;
               }
-              if (!array_key_exists($script_name, $event_map['skip']) ) {
-                $code_studio_jobs[$script_name]['script'][] = $command;
-                $code_studio_jobs[$script_name]['script'] = array_values(array_unique($code_studio_jobs[$script_name]['script']));
+              if (!array_key_exists($scriptName, $eventMap['skip']) ) {
+                $codeStudioJobs[$scriptName]['script'][] = $command;
+                $codeStudioJobs[$scriptName]['script'] = array_values(array_unique($codeStudioJobs[$scriptName]['script']));
               }
-              else if ($script_name === 'launch_ode') {
-                $code_studio_jobs[$script_name]['script'][] = $command;
+              else if ($scriptName === 'launch_ode') {
+                $codeStudioJobs[$scriptName]['script'][] = $command;
               }
             }
-            if (array_key_exists($script_name, $code_studio_jobs) && !array_key_exists('stage', $code_studio_jobs[$script_name])
-              && $stage = $this->assignStageFromKeywords($event_map['stage'], $command)) {
-              $code_studio_jobs[$script_name]['stage'] = $stage;
+            if (array_key_exists($scriptName, $codeStudioJobs) && !array_key_exists('stage', $codeStudioJobs[$scriptName])
+              && $stage = $this->assignStageFromKeywords($eventMap['stage'], $command)) {
+              $codeStudioJobs[$scriptName]['stage'] = $stage;
             }
           }
-          if (!array_key_exists('stage', $code_studio_jobs[$script_name])) {
-            $code_studio_jobs[$script_name]['stage'] = $event_map['default_stage'];
+          if (!array_key_exists('stage', $codeStudioJobs[$scriptName])) {
+            $codeStudioJobs[$scriptName]['stage'] = $eventMap['default_stage'];
           }
-          $code_studio_jobs[$script_name]['needs'] = $event_map['needs'];
+          $codeStudioJobs[$scriptName]['needs'] = $eventMap['needs'];
         }
-        $gitlab_ci_file_contents = array_merge($gitlab_ci_file_contents, $code_studio_jobs);
+        $gitlabCiFileContents = array_merge($gitlabCiFileContents, $codeStudioJobs);
         $this->io->success([
-          "Completed migration of the $event_name step in your acquia-pipelines.yml file",
+          "Completed migration of the $eventName step in your acquia-pipelines.yml file",
         ]);
       }
       else {
         $this->io->writeln([
-          "acquia-pipeline.yml file does not contain $event_name step to migrate",
+          "acquia-pipeline.yml file does not contain $eventName step to migrate",
         ]);
       }
     }
@@ -295,10 +295,10 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
   /**
    * Removing empty script.
    */
-  private function removeEmptyScript(array &$gitlab_ci_file_contents): void {
-    foreach ($gitlab_ci_file_contents as $key => $value) {
+  private function removeEmptyScript(array &$gitlabCiFileContents): void {
+    foreach ($gitlabCiFileContents as $key => $value) {
       if (array_key_exists('script', $value) && empty($value['script'])) {
-        unset($gitlab_ci_file_contents[$key]);
+        unset($gitlabCiFileContents[$key]);
       }
     }
   }
@@ -306,10 +306,10 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
   /**
    * Creating .gitlab-ci.yml file.
    */
-  private function createGitLabCiFile(array $contents,$acquia_pipelines_file_name): void {
-    $gitlab_ci_filepath = Path::join($this->projectDir, '.gitlab-ci.yml');
-    $this->localMachineHelper->getFilesystem()->dumpFile($gitlab_ci_filepath, Yaml::dump($contents, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
-    $this->localMachineHelper->getFilesystem()->remove($acquia_pipelines_file_name);
+  private function createGitLabCiFile(array $contents,$acquiaPipelinesFileName): void {
+    $gitlabCiFilepath = Path::join($this->projectDir, '.gitlab-ci.yml');
+    $this->localMachineHelper->getFilesystem()->dumpFile($gitlabCiFilepath, Yaml::dump($contents, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
+    $this->localMachineHelper->getFilesystem()->remove($acquiaPipelinesFileName);
   }
 
   /**

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -127,8 +127,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
   private function setLocalDbUser(): void {
     $this->localDbUser = 'drupal';
-    if ($lando_info = self::getLandoInfo()) {
-      $this->localDbUser = $lando_info->database->creds->user;
+    if ($landoInfo = self::getLandoInfo()) {
+      $this->localDbUser = $landoInfo->database->creds->user;
     }
     if (getenv('ACLI_DB_USER')) {
       $this->localDbUser = getenv('ACLI_DB_USER');
@@ -145,8 +145,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
   private function setLocalDbPassword(): void {
     $this->localDbPassword = 'drupal';
-    if ($lando_info = self::getLandoInfo()) {
-      $this->localDbPassword = $lando_info->database->creds->password;
+    if ($landoInfo = self::getLandoInfo()) {
+      $this->localDbPassword = $landoInfo->database->creds->password;
     }
     if (getenv('ACLI_DB_PASSWORD')) {
       $this->localDbPassword = getenv('ACLI_DB_PASSWORD');
@@ -163,8 +163,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
   private function setLocalDbName(): void {
     $this->localDbName = 'drupal';
-    if ($lando_info = self::getLandoInfo()) {
-      $this->localDbName = $lando_info->database->creds->database;
+    if ($landoInfo = self::getLandoInfo()) {
+      $this->localDbName = $landoInfo->database->creds->database;
     }
     if (getenv('ACLI_DB_NAME')) {
       $this->localDbName = getenv('ACLI_DB_NAME');
@@ -181,8 +181,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
   private function setLocalDbHost(): void {
     $this->localDbHost = 'localhost';
-    if ($lando_info = self::getLandoInfo()) {
-      $this->localDbHost = $lando_info->database->hostnames[0];
+    if ($landoInfo = self::getLandoInfo()) {
+      $this->localDbHost = $landoInfo->database->hostnames[0];
     }
     if (getenv('ACLI_DB_HOST')) {
       $this->localDbHost = getenv('ACLI_DB_HOST');
@@ -237,8 +237,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * Check if telemetry preference is set, prompt if not.
    */
   public function checkAndPromptTelemetryPreference(): void {
-    $send_telemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
-    if ($this->getName() !== 'telemetry' && (!isset($send_telemetry)) && $this->input->isInteractive()) {
+    $sendTelemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
+    if ($this->getName() !== 'telemetry' && (!isset($sendTelemetry)) && $this->input->isInteractive()) {
       $this->output->writeln('We strive to give you the best tools for development.');
       $this->output->writeln('You can really help us improve by sharing anonymous performance and usage data.');
       $style = new SymfonyStyle($this->input, $this->output);
@@ -257,24 +257,24 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   public function run(InputInterface $input, OutputInterface $output): int {
-    $exit_code = parent::run($input, $output);
-    if ($exit_code === 0 && in_array($input->getFirstArgument(), ['self-update', 'update'])) {
+    $exitCode = parent::run($input, $output);
+    if ($exitCode === 0 && in_array($input->getFirstArgument(), ['self-update', 'update'])) {
       // Exit immediately to avoid loading additional classes breaking updates.
       // @see https://github.com/acquia/cli/issues/218
-      return $exit_code;
+      return $exitCode;
     }
-    $event_properties = [
+    $eventProperties = [
       'app_version' => $this->getApplication()->getVersion(),
       'arguments' => $input->getArguments(),
-      'exit_code' => $exit_code,
+      'exit_code' => $exitCode,
       'options' => $input->getOptions(),
       'os_name' => OsInfo::os(),
       'os_version' => OsInfo::version(),
       'platform' => OsInfo::family(),
     ];
-    Amplitude::getInstance()->queueEvent('Ran command', $event_properties);
+    Amplitude::getInstance()->queueEvent('Ran command', $eventProperties);
 
-    return $exit_code;
+    return $exitCode;
   }
 
   /**
@@ -331,16 +331,16 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * applications.
    */
   private function promptChooseSubscription(
-    Client $acquia_cloud_client
+    Client $acquiaCloudClient
   ): ?SubscriptionResponse {
-    $subscriptions_resource = new Subscriptions($acquia_cloud_client);
-    $customer_subscriptions = $subscriptions_resource->getAll();
+    $subscriptionsResource = new Subscriptions($acquiaCloudClient);
+    $customerSubscriptions = $subscriptionsResource->getAll();
 
-    if (!$customer_subscriptions->count()) {
+    if (!$customerSubscriptions->count()) {
       throw new AcquiaCliException("You have no Cloud subscriptions.");
     }
     return $this->promptChooseFromObjectsOrArrays(
-      $customer_subscriptions,
+      $customerSubscriptions,
       'uuid',
       'name',
       'Select a Cloud Platform subscription:'
@@ -352,16 +352,16 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * applications.
    */
   private function promptChooseApplication(
-    Client $acquia_cloud_client
+    Client $acquiaCloudClient
   ): object|array|null {
-    $applications_resource = new Applications($acquia_cloud_client);
-    $customer_applications = $applications_resource->getAll();
+    $applicationsResource = new Applications($acquiaCloudClient);
+    $customerApplications = $applicationsResource->getAll();
 
-    if (!$customer_applications->count()) {
+    if (!$customerApplications->count()) {
       throw new AcquiaCliException("You have no Cloud applications.");
     }
     return $this->promptChooseFromObjectsOrArrays(
-      $customer_applications,
+      $customerApplications,
       'uuid',
       'name',
       'Select a Cloud Platform application:'
@@ -372,11 +372,11 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * Prompts the user to choose from a list of environments for a given Cloud Platform application.
    */
   private function promptChooseEnvironment(
-    Client $acquia_cloud_client,
-    string $application_uuid
+    Client $acquiaCloudClient,
+    string $applicationUuid
   ): object|array|null {
-    $environment_resource = new Environments($acquia_cloud_client);
-    $environments = $environment_resource->getAll($application_uuid);
+    $environmentResource = new Environments($acquiaCloudClient);
+    $environments = $environmentResource->getAll($applicationUuid);
     // @todo Make sure there are actually environments here.
     return $this->promptChooseFromObjectsOrArrays(
       $environments,
@@ -390,10 +390,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * Prompts the user to choose from a list of logs for a given Cloud Platform environment.
    */
   protected function promptChooseLogs(): object|array|null {
-    $logs = array_map(static function ($log_type, $log_label) {
+    $logs = array_map(static function ($logType, $logLabel) {
       return [
-        'label' => $log_label,
-        'type' => $log_type,
+        'label' => $logLabel,
+        'type' => $logType,
       ];
     }, array_keys(LogstreamManager::AVAILABLE_TYPES), LogstreamManager::AVAILABLE_TYPES);
     return $this->promptChooseFromObjectsOrArrays(
@@ -412,47 +412,47 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * property that can be used as a human-readable label.
    *
    * @param array[]|object[] $items An array of objects or arrays.
-   * @param string $unique_property The property of the $item that will be used to identify the object.
+   * @param string $uniqueProperty The property of the $item that will be used to identify the object.
    */
-  public function promptChooseFromObjectsOrArrays(array|ArrayObject $items, string $unique_property, string $label_property, string $question_text, bool $multiselect = FALSE): object|array|null {
+  public function promptChooseFromObjectsOrArrays(array|ArrayObject $items, string $uniqueProperty, string $labelProperty, string $questionText, bool $multiselect = FALSE): object|array|null {
     $list = [];
     foreach ($items as $item) {
       if (is_array($item)) {
-        $list[$item[$unique_property]] = trim($item[$label_property]);
+        $list[$item[$uniqueProperty]] = trim($item[$labelProperty]);
       }
       else {
-        $list[$item->$unique_property] = trim($item->$label_property);
+        $list[$item->$uniqueProperty] = trim($item->$labelProperty);
       }
     }
     $labels = array_values($list);
     $default = $multiselect ? NULL : $labels[0];
-    $question = new ChoiceQuestion($question_text, $labels, $default);
+    $question = new ChoiceQuestion($questionText, $labels, $default);
     $question->setMultiselect($multiselect);
-    $choice_id = $this->io->askQuestion($question);
+    $choiceId = $this->io->askQuestion($question);
     if (!$multiselect) {
-      $identifier = array_search($choice_id, $list, TRUE);
+      $identifier = array_search($choiceId, $list, TRUE);
       foreach ($items as $item) {
         if (is_array($item)) {
-          if ($item[$unique_property] === $identifier) {
+          if ($item[$uniqueProperty] === $identifier) {
             return $item;
           }
         }
-        else if ($item->$unique_property === $identifier) {
+        else if ($item->$uniqueProperty === $identifier) {
           return $item;
         }
       }
     }
     else {
       $chosen = [];
-      foreach ($choice_id as $choice) {
+      foreach ($choiceId as $choice) {
         $identifier = array_search($choice, $list, TRUE);
         foreach ($items as $item) {
           if (is_array($item)) {
-            if ($item[$unique_property] === $identifier) {
+            if ($item[$uniqueProperty] === $identifier) {
               $chosen[] = $item;
             }
           }
-          else if ($item->$unique_property === $identifier) {
+          else if ($item->$uniqueProperty === $identifier) {
             $chosen[] = $item;
           }
         }
@@ -469,9 +469,9 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @return array|null
    */
   private function getGitConfig(): ?array {
-    $file_path = $this->projectDir . '/.git/config';
-    if (file_exists($file_path)) {
-      return parse_ini_file($file_path, TRUE);
+    $filePath = $this->projectDir . '/.git/config';
+    if (file_exists($filePath)) {
+      return parse_ini_file($filePath, TRUE);
     }
 
     return NULL;
@@ -480,56 +480,56 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * Gets an array of git remotes from a .git/config array.
    *
-   * @param array $git_config
+   * @param array $gitConfig
    * @return array
    *   A flat array of git remote urls.
    */
-  private function getGitRemotes(array $git_config): array {
-    $local_vcs_remotes = [];
-    foreach ($git_config as $section_name => $section) {
-      if ((str_contains($section_name, 'remote ')) &&
+  private function getGitRemotes(array $gitConfig): array {
+    $localVcsRemotes = [];
+    foreach ($gitConfig as $sectionName => $section) {
+      if ((str_contains($sectionName, 'remote ')) &&
         (strpos($section['url'], 'acquia.com') || strpos($section['url'], 'acquia-sites.com'))
       ) {
-        $local_vcs_remotes[] = $section['url'];
+        $localVcsRemotes[] = $section['url'];
       }
     }
 
-    return $local_vcs_remotes;
+    return $localVcsRemotes;
   }
 
   /**
-   * @param array $local_git_remotes
+   * @param array $localGitRemotes
    */
   private function findCloudApplicationByGitUrl(
-        Client $acquia_cloud_client,
-        array $local_git_remotes
+        Client $acquiaCloudClient,
+        array $localGitRemotes
     ): ?ApplicationResponse {
 
     // Set up API resources.
-    $applications_resource = new Applications($acquia_cloud_client);
-    $customer_applications = $applications_resource->getAll();
-    $environments_resource = new Environments($acquia_cloud_client);
+    $applicationsResource = new Applications($acquiaCloudClient);
+    $customerApplications = $applicationsResource->getAll();
+    $environmentsResource = new Environments($acquiaCloudClient);
 
     // Create progress bar.
-    $count = count($customer_applications);
+    $count = count($customerApplications);
     $progressBar = new ProgressBar($this->output, $count);
     $progressBar->setFormat('message');
     $progressBar->setMessage("Searching <options=bold>$count applications</> on the Cloud Platform...");
     $progressBar->start();
 
     // Search Cloud applications.
-    $terminal_width = (new Terminal())->getWidth();
-    foreach ($customer_applications as $application) {
+    $terminalWidth = (new Terminal())->getWidth();
+    foreach ($customerApplications as $application) {
       // Ensure that the message takes up the full terminal width to prevent display artifacts.
       $message = "Searching <options=bold>{$application->name}</> for matching git URLs";
-      $suffix_length = $terminal_width - strlen($message) - 17;
-      $suffix = $suffix_length > 0 ? str_repeat(' ', $suffix_length) : '';
+      $suffixLength = $terminalWidth - strlen($message) - 17;
+      $suffix = $suffixLength > 0 ? str_repeat(' ', $suffixLength) : '';
       $progressBar->setMessage($message . $suffix);
-      $application_environments = $environments_resource->getAll($application->uuid);
+      $applicationEnvironments = $environmentsResource->getAll($application->uuid);
       if ($application = $this->searchApplicationEnvironmentsForGitUrl(
             $application,
-            $application_environments,
-            $local_git_remotes
+            $applicationEnvironments,
+            $localGitRemotes
         )) {
         $progressBar->finish();
         $progressBar->clear();
@@ -545,28 +545,28 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   protected function createTable(OutputInterface $output, string $title, $headers, $widths): Table {
-    $terminal_width = (new Terminal())->getWidth();
-    $terminal_width *= .90;
+    $terminalWidth = (new Terminal())->getWidth();
+    $terminalWidth *= .90;
     $table = new Table($output);
     $table->setHeaders($headers);
     $table->setHeaderTitle($title);
-    $set_widths = static function ($width) use ($terminal_width) {
-      return (int) ($terminal_width * $width);
+    $setWidths = static function ($width) use ($terminalWidth) {
+      return (int) ($terminalWidth * $width);
     };
-    $table->setColumnWidths(array_map($set_widths, $widths));
+    $table->setColumnWidths(array_map($setWidths, $widths));
     return $table;
   }
 
   /**
-   * @param array $local_git_remotes
+   * @param array $localGitRemotes
    */
   private function searchApplicationEnvironmentsForGitUrl(
     ApplicationResponse $application,
-    EnvironmentsResponse $application_environments,
-    array $local_git_remotes
+    EnvironmentsResponse $applicationEnvironments,
+    array $localGitRemotes
     ): ?ApplicationResponse {
-    foreach ($application_environments as $environment) {
-      if ($environment->flags->production && in_array($environment->vcs->url, $local_git_remotes, TRUE)) {
+    foreach ($applicationEnvironments as $environment) {
+      if ($environment->flags->production && in_array($environment->vcs->url, $localGitRemotes, TRUE)) {
         $this->logger->debug("Found matching Cloud application! {$application->name} with uuid {$application->uuid} matches local git URL {$environment->vcs->url}");
 
         return $application;
@@ -583,19 +583,19 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * that we have a match.
    */
   protected function inferCloudAppFromLocalGitConfig(
-    Client $acquia_cloud_client
+    Client $acquiaCloudClient
     ): ?ApplicationResponse {
     if ($this->projectDir && $this->input->isInteractive()) {
       $this->output->writeln("There is no Cloud Platform application linked to <options=bold>{$this->projectDir}/.git</>.");
       $answer = $this->io->confirm('Would you like Acquia CLI to search for a Cloud application that matches your local git config?');
       if ($answer) {
         $this->output->writeln('Searching for a matching Cloud application...');
-        if ($git_config = $this->getGitConfig()) {
-          $local_git_remotes = $this->getGitRemotes($git_config);
-          if ($cloud_application = $this->findCloudApplicationByGitUrl($acquia_cloud_client,
-            $local_git_remotes)) {
+        if ($gitConfig = $this->getGitConfig()) {
+          $localGitRemotes = $this->getGitRemotes($gitConfig);
+          if ($cloudApplication = $this->findCloudApplicationByGitUrl($acquiaCloudClient,
+            $localGitRemotes)) {
             $this->output->writeln('<info>Found a matching application!</info>');
-            return $cloud_application;
+            return $cloudApplication;
           }
 
           $this->output->writeln('<comment>Could not find a matching Cloud application.</comment>');
@@ -622,24 +622,24 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       throw new RuntimeException('Not enough arguments (missing: "environmentId").');
     }
 
-    $application_uuid = $this->determineCloudApplication();
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $environment = $this->promptChooseEnvironment($acquia_cloud_client, $application_uuid);
+    $applicationUuid = $this->determineCloudApplication();
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $environment = $this->promptChooseEnvironment($acquiaCloudClient, $applicationUuid);
 
     return $environment->uuid;
   }
 
   protected function determineCloudSubscription(): ?SubscriptionResponse {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
 
     if ($this->input->hasArgument('subscriptionUuid') && $this->input->getArgument('subscriptionUuid')) {
-      $cloud_subscription_uuid = $this->input->getArgument('subscriptionUuid');
-      self::validateUuid($cloud_subscription_uuid);
-      return (new Subscriptions($acquia_cloud_client))->get($cloud_subscription_uuid);
+      $cloudSubscriptionUuid = $this->input->getArgument('subscriptionUuid');
+      self::validateUuid($cloudSubscriptionUuid);
+      return (new Subscriptions($acquiaCloudClient))->get($cloudSubscriptionUuid);
     }
 
     // Finally, just ask.
-    if ($this->input->isInteractive() && $subscription = $this->promptChooseSubscription($acquia_cloud_client)) {
+    if ($this->input->isInteractive() && $subscription = $this->promptChooseSubscription($acquiaCloudClient)) {
       return $subscription;
     }
 
@@ -650,16 +650,16 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * Determine the Cloud application.
    */
-  protected function determineCloudApplication(bool $prompt_link_app = FALSE): ?string {
-    $application_uuid = $this->doDetermineCloudApplication();
-    if (!isset($application_uuid)) {
+  protected function determineCloudApplication(bool $promptLinkApp = FALSE): ?string {
+    $applicationUuid = $this->doDetermineCloudApplication();
+    if (!isset($applicationUuid)) {
       throw new AcquiaCliException("Could not determine Cloud Application. Run this command interactively or use `acli link` to link a Cloud Application before running non-interactively.");
     }
 
-    $application = $this->getCloudApplication($application_uuid);
+    $application = $this->getCloudApplication($applicationUuid);
     // No point in trying to link a directory that's not a repo.
     if (!empty($this->projectDir) && !$this->getCloudUuidFromDatastore()) {
-      if ($prompt_link_app) {
+      if ($promptLinkApp) {
         $this->saveCloudUuidToDatastore($application);
       }
       elseif (!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !$this->getCloudApplicationUuidFromBltYaml()) {
@@ -667,40 +667,40 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       }
     }
 
-    return $application_uuid;
+    return $applicationUuid;
   }
 
   protected function doDetermineCloudApplication(): mixed {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
 
     if ($this->input->hasArgument('applicationUuid') && $this->input->getArgument('applicationUuid')) {
-      $cloud_application_uuid = $this->input->getArgument('applicationUuid');
-      return self::validateUuid($cloud_application_uuid);
+      $cloudApplicationUuid = $this->input->getArgument('applicationUuid');
+      return self::validateUuid($cloudApplicationUuid);
     }
 
     // Try local project info.
-    if ($application_uuid = $this->getCloudUuidFromDatastore()) {
-      $this->logger->debug("Using Cloud application UUID: $application_uuid from {$this->datastoreAcli->filepath}");
-      return $application_uuid;
+    if ($applicationUuid = $this->getCloudUuidFromDatastore()) {
+      $this->logger->debug("Using Cloud application UUID: $applicationUuid from {$this->datastoreAcli->filepath}");
+      return $applicationUuid;
     }
 
-    if ($application_uuid = $this->getCloudApplicationUuidFromBltYaml()) {
-      $this->logger->debug("Using Cloud application UUID $application_uuid from blt/blt.yml");
-      return $application_uuid;
+    if ($applicationUuid = $this->getCloudApplicationUuidFromBltYaml()) {
+      $this->logger->debug("Using Cloud application UUID $applicationUuid from blt/blt.yml");
+      return $applicationUuid;
     }
 
     // Get from the Cloud Platform env var.
-    if ($application_uuid = self::getThisCloudIdeCloudAppUuid()) {
-      return $application_uuid;
+    if ($applicationUuid = self::getThisCloudIdeCloudAppUuid()) {
+      return $applicationUuid;
     }
 
     // Try to guess based on local git url config.
-    if ($cloud_application = $this->inferCloudAppFromLocalGitConfig($acquia_cloud_client)) {
-      return $cloud_application->uuid;
+    if ($cloudApplication = $this->inferCloudAppFromLocalGitConfig($acquiaCloudClient)) {
+      return $cloudApplication->uuid;
     }
 
     // Finally, just ask.
-    if ($this->input->isInteractive() && $application = $this->promptChooseApplication($acquia_cloud_client)) {
+    if ($this->input->isInteractive() && $application = $this->promptChooseApplication($acquiaCloudClient)) {
       return $application->uuid;
     }
 
@@ -708,9 +708,9 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   protected function getCloudApplicationUuidFromBltYaml(): ?string {
-    $blt_yaml_file_path = Path::join($this->projectDir, 'blt', 'blt.yml');
-    if (file_exists($blt_yaml_file_path)) {
-      $contents = Yaml::parseFile($blt_yaml_file_path);
+    $bltYamlFilePath = Path::join($this->projectDir, 'blt', 'blt.yml');
+    if (file_exists($bltYamlFilePath)) {
+      $contents = Yaml::parseFile($bltYamlFilePath);
       if (array_key_exists('cloud', $contents) && array_key_exists('appId', $contents['cloud'])) {
         return $contents['cloud']['appId'];
       }
@@ -745,11 +745,11 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   private function promptLinkApplication(
-    ?ApplicationResponse $cloud_application
+    ?ApplicationResponse $cloudApplication
     ): bool {
-    $answer = $this->io->confirm("Would you like to link the Cloud application <bg=cyan;options=bold>{$cloud_application->name}</> to this repository?");
+    $answer = $this->io->confirm("Would you like to link the Cloud application <bg=cyan;options=bold>{$cloudApplication->name}</> to this repository?");
     if ($answer) {
-      return $this->saveCloudUuidToDatastore($cloud_application);
+      return $this->saveCloudUuidToDatastore($cloudApplication);
     }
     return FALSE;
   }
@@ -790,15 +790,15 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return getenv('REMOTEIDE_UUID');
   }
 
-  protected function getCloudApplication(string $application_uuid): ApplicationResponse {
-    $applications_resource = new Applications($this->cloudApiClientService->getClient());
-    return $applications_resource->get($application_uuid);
+  protected function getCloudApplication(string $applicationUuid): ApplicationResponse {
+    $applicationsResource = new Applications($this->cloudApiClientService->getClient());
+    return $applicationsResource->get($applicationUuid);
   }
 
-  protected function getCloudEnvironment(string $environment_id): EnvironmentResponse {
-    $environment_resource = new Environments($this->cloudApiClientService->getClient());
+  protected function getCloudEnvironment(string $environmentId): EnvironmentResponse {
+    $environmentResource = new Environments($this->cloudApiClientService->getClient());
 
-    return $environment_resource->get($environment_id);
+    return $environmentResource->get($environmentId);
   }
 
   public static function validateEnvironmentAlias(string $alias): string {
@@ -835,28 +835,28 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * @param $alias
    */
   private function doGetEnvFromAlias($alias): EnvironmentResponse {
-    $site_env_parts = explode('.', $alias);
-    [$application_alias, $environment_alias] = $site_env_parts;
-    $this->logger->debug("Searching for an environment matching alias $application_alias.$environment_alias.");
-    $customer_application = $this->getApplicationFromAlias($application_alias);
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $environments_resource = new Environments($acquia_cloud_client);
-    $environments = $environments_resource->getAll($customer_application->uuid);
+    $siteEnvParts = explode('.', $alias);
+    [$applicationAlias, $environmentAlias] = $siteEnvParts;
+    $this->logger->debug("Searching for an environment matching alias $applicationAlias.$environmentAlias.");
+    $customerApplication = $this->getApplicationFromAlias($applicationAlias);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $environmentsResource = new Environments($acquiaCloudClient);
+    $environments = $environmentsResource->getAll($customerApplication->uuid);
     foreach ($environments as $environment) {
-      if ($environment->name === $environment_alias) {
-        $this->logger->debug("Found environment {$environment->uuid} matching $environment_alias.");
+      if ($environment->name === $environmentAlias) {
+        $this->logger->debug("Found environment {$environment->uuid} matching $environmentAlias.");
 
         return $environment;
       }
     }
 
-    throw new AcquiaCliException("Environment not found matching the alias {alias}", ['alias' => "$application_alias.$environment_alias"]);
+    throw new AcquiaCliException("Environment not found matching the alias {alias}", ['alias' => "$applicationAlias.$environmentAlias"]);
   }
 
-  private function getApplicationFromAlias(string $application_alias): mixed {
+  private function getApplicationFromAlias(string $applicationAlias): mixed {
     return self::getAliasCache()
-      ->get($application_alias, function () use ($application_alias) {
-        return $this->doGetApplicationFromAlias($application_alias);
+      ->get($applicationAlias, function () use ($applicationAlias) {
+        return $this->doGetApplicationFromAlias($applicationAlias);
       });
   }
 
@@ -868,41 +868,41 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   /**
-   * @param $application_alias
+   * @param $applicationAlias
    */
-  private function doGetApplicationFromAlias($application_alias): mixed {
-    if (!strpos($application_alias, ':')) {
-      $application_alias = '*:' . $application_alias;
+  private function doGetApplicationFromAlias($applicationAlias): mixed {
+    if (!strpos($applicationAlias, ':')) {
+      $applicationAlias = '*:' . $applicationAlias;
     }
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
     // No need to clear this query later since getClient() is a factory method.
-    $acquia_cloud_client->addQuery('filter', 'hosting=@' . $application_alias);
+    $acquiaCloudClient->addQuery('filter', 'hosting=@' . $applicationAlias);
     // Allow Cloud Platform users with 'support' role to resolve aliases for applications to
     // which they don't explicitly belong.
-    $account_resource = new Account($acquia_cloud_client);
-    $account = $account_resource->get();
+    $accountResource = new Account($acquiaCloudClient);
+    $account = $accountResource->get();
     if ($account->flags->support) {
-      $acquia_cloud_client->addQuery('all', 'true');
+      $acquiaCloudClient->addQuery('all', 'true');
     }
-    $applications_resource = new Applications($acquia_cloud_client);
-    $customer_applications = $applications_resource->getAll();
-    if (count($customer_applications) === 0) {
-      throw new AcquiaCliException("No applications match the alias {applicationAlias}", ['applicationAlias' => $application_alias]);
+    $applicationsResource = new Applications($acquiaCloudClient);
+    $customerApplications = $applicationsResource->getAll();
+    if (count($customerApplications) === 0) {
+      throw new AcquiaCliException("No applications match the alias {applicationAlias}", ['applicationAlias' => $applicationAlias]);
     }
-    if (count($customer_applications) > 1) {
+    if (count($customerApplications) > 1) {
       $callback = static function ($element) {
         return $element->hosting->id;
       };
-      $aliases = array_map($callback, (array) $customer_applications);
+      $aliases = array_map($callback, (array) $customerApplications);
       $this->io->error(sprintf("Use a unique application alias: %s", implode(', ', $aliases)));
-      throw new AcquiaCliException("Multiple applications match the alias {applicationAlias}", ['applicationAlias' => $application_alias]);
+      throw new AcquiaCliException("Multiple applications match the alias {applicationAlias}", ['applicationAlias' => $applicationAlias]);
     }
 
-    $customer_application = $customer_applications[0];
+    $customerApplication = $customerApplications[0];
 
-    $this->logger->debug("Found application {$customer_application->uuid} matching alias $application_alias.");
+    $this->logger->debug("Found application {$customerApplication->uuid} matching alias $applicationAlias.");
 
-    return $customer_application;
+    return $customerApplication;
   }
 
   protected function requireCloudIdeEnvironment(): void {
@@ -914,15 +914,15 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * @return \stdClass|null
    */
-  protected function findIdeSshKeyOnCloud(string $ide_uuid): ?stdClass {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
-    $ides_resource = new Ides($acquia_cloud_client);
-    $ide = $ides_resource->get($ide_uuid);
-    $ssh_key_label = SshKeyCommandBase::getIdeSshKeyLabel($ide);
-    foreach ($cloud_keys as $cloud_key) {
-      if ($cloud_key->label === $ssh_key_label) {
-        return $cloud_key;
+  protected function findIdeSshKeyOnCloud(string $ideUuid): ?stdClass {
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $cloudKeys = $acquiaCloudClient->request('get', '/account/ssh-keys');
+    $idesResource = new Ides($acquiaCloudClient);
+    $ide = $idesResource->get($ideUuid);
+    $sshKeyLabel = SshKeyCommandBase::getIdeSshKeyLabel($ide);
+    foreach ($cloudKeys as $cloudKey) {
+      if ($cloudKey->label === $sshKeyLabel) {
+        return $cloudKey;
       }
     }
     return NULL;
@@ -1016,52 +1016,52 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected function fillMissingRequiredApplicationUuid(InputInterface $input, OutputInterface $output): void {
     if ($input->hasArgument('applicationUuid') && !$input->getArgument('applicationUuid') && $this->getDefinition()->getArgument('applicationUuid')->isRequired()) {
       $output->writeln('Inferring Cloud Application UUID for this command since none was provided...', OutputInterface::VERBOSITY_VERBOSE);
-      if ($application_uuid = $this->determineCloudApplication()) {
-        $output->writeln("Set application uuid to <options=bold>$application_uuid</>", OutputInterface::VERBOSITY_VERBOSE);
-        $input->setArgument('applicationUuid', $application_uuid);
+      if ($applicationUuid = $this->determineCloudApplication()) {
+        $output->writeln("Set application uuid to <options=bold>$applicationUuid</>", OutputInterface::VERBOSITY_VERBOSE);
+        $input->setArgument('applicationUuid', $applicationUuid);
       }
     }
   }
 
   protected function convertApplicationAliasToUuid(InputInterface $input): void {
     if ($input->hasArgument('applicationUuid') && $input->getArgument('applicationUuid')) {
-      $application_uuid_argument = $input->getArgument('applicationUuid');
-      $application_uuid = $this->validateApplicationUuid($application_uuid_argument);
-      $input->setArgument('applicationUuid', $application_uuid);
+      $applicationUuidArgument = $input->getArgument('applicationUuid');
+      $applicationUuid = $this->validateApplicationUuid($applicationUuidArgument);
+      $input->setArgument('applicationUuid', $applicationUuid);
     }
   }
 
   /**
-   * @param $argument_name
+   * @param $argumentName
    */
-  protected function convertEnvironmentAliasToUuid(InputInterface $input, $argument_name): void {
-    if ($input->hasArgument($argument_name) && $input->getArgument($argument_name)) {
-      $env_uuid_argument = $input->getArgument($argument_name);
-      $environment_uuid = $this->validateEnvironmentUuid($env_uuid_argument, $argument_name);
-      $input->setArgument($argument_name, $environment_uuid);
+  protected function convertEnvironmentAliasToUuid(InputInterface $input, $argumentName): void {
+    if ($input->hasArgument($argumentName) && $input->getArgument($argumentName)) {
+      $envUuidArgument = $input->getArgument($argumentName);
+      $environmentUuid = $this->validateEnvironmentUuid($envUuidArgument, $argumentName);
+      $input->setArgument($argumentName, $environmentUuid);
     }
   }
 
   /**
-   * @param string $ssh_url
+   * @param string $sshUrl
    *   The SSH URL to the server.
    * @return string
    *   The sitegroup. E.g., eemgrasmick.
    */
-  public static function getSiteGroupFromSshUrl(string $ssh_url): string {
-    $ssh_url_parts = explode('.', $ssh_url);
-    return reset($ssh_url_parts);
+  public static function getSiteGroupFromSshUrl(string $sshUrl): string {
+    $sshUrlParts = explode('.', $sshUrl);
+    return reset($sshUrlParts);
   }
 
   /**
-   * @param $cloud_environment
+   * @param $cloudEnvironment
    * @return bool
    */
-  protected function isAcsfEnv($cloud_environment): bool {
-    if (str_contains($cloud_environment->sshUrl, 'enterprise-g1')) {
+  protected function isAcsfEnv($cloudEnvironment): bool {
+    if (str_contains($cloudEnvironment->sshUrl, 'enterprise-g1')) {
       return TRUE;
     }
-    foreach ($cloud_environment->domains as $domain) {
+    foreach ($cloudEnvironment->domains as $domain) {
       if (str_contains($domain, 'acsitefactory')) {
         return TRUE;
       }
@@ -1071,13 +1071,13 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   /**
-   * @param \AcquiaCloudApi\Response\EnvironmentResponse $cloud_environment
+   * @param \AcquiaCloudApi\Response\EnvironmentResponse $cloudEnvironment
    * @return array
    */
-  protected function getAcsfSites(EnvironmentResponse $cloud_environment): array {
-    $sitegroup = self::getSiteGroupFromSshUrl($cloud_environment->sshUrl);
-    $command = ['cat', "/var/www/site-php/$sitegroup.{$cloud_environment->name}/multisite-config.json"];
-    $process = $this->sshHelper->executeCommand($cloud_environment, $command, FALSE);
+  protected function getAcsfSites(EnvironmentResponse $cloudEnvironment): array {
+    $sitegroup = self::getSiteGroupFromSshUrl($cloudEnvironment->sshUrl);
+    $command = ['cat', "/var/www/site-php/$sitegroup.{$cloudEnvironment->name}/multisite-config.json"];
+    $process = $this->sshHelper->executeCommand($cloudEnvironment, $command, FALSE);
     if ($process->isSuccessful()) {
       return json_decode($process->getOutput(), TRUE, 512, JSON_THROW_ON_ERROR);
     }
@@ -1087,44 +1087,44 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * @return array
    */
-  private function getCloudSites(EnvironmentResponse $cloud_environment): array {
-    $sitegroup = self::getSiteGroupFromSshUrl($cloud_environment->sshUrl);
-    $command = ['ls', $this->getCloudSitesPath($cloud_environment, $sitegroup)];
-    $process = $this->sshHelper->executeCommand($cloud_environment, $command, FALSE);
+  private function getCloudSites(EnvironmentResponse $cloudEnvironment): array {
+    $sitegroup = self::getSiteGroupFromSshUrl($cloudEnvironment->sshUrl);
+    $command = ['ls', $this->getCloudSitesPath($cloudEnvironment, $sitegroup)];
+    $process = $this->sshHelper->executeCommand($cloudEnvironment, $command, FALSE);
     $sites = array_filter(explode("\n", trim($process->getOutput())));
     if ($process->isSuccessful() && $sites) {
       return $sites;
     }
 
-    throw new AcquiaCliException("Could not get Cloud sites for " . $cloud_environment->name);
+    throw new AcquiaCliException("Could not get Cloud sites for " . $cloudEnvironment->name);
   }
 
-  protected function getCloudSitesPath($cloud_environment, $sitegroup): string {
-    if ($cloud_environment->platform === 'cloud-next') {
-      $path = "/home/clouduser/{$cloud_environment->name}/sites";
+  protected function getCloudSitesPath($cloudEnvironment, $sitegroup): string {
+    if ($cloudEnvironment->platform === 'cloud-next') {
+      $path = "/home/clouduser/{$cloudEnvironment->name}/sites";
     }
     else {
-      $path = "/mnt/files/$sitegroup.{$cloud_environment->name}/sites";
+      $path = "/mnt/files/$sitegroup.{$cloudEnvironment->name}/sites";
     }
     return $path;
   }
 
-  protected function promptChooseAcsfSite(EnvironmentResponse $cloud_environment): mixed {
+  protected function promptChooseAcsfSite(EnvironmentResponse $cloudEnvironment): mixed {
     $choices = [];
-    $acsf_sites = $this->getAcsfSites($cloud_environment);
-    foreach ($acsf_sites['sites'] as $domain => $acsf_site) {
-      $choices[] = "{$acsf_site['name']} ($domain)";
+    $acsfSites = $this->getAcsfSites($cloudEnvironment);
+    foreach ($acsfSites['sites'] as $domain => $acsfSite) {
+      $choices[] = "{$acsfSite['name']} ($domain)";
     }
     $choice = $this->io->choice('Choose a site', $choices, $choices[0]);
     $key = array_search($choice, $choices, TRUE);
-    $sites = array_values($acsf_sites['sites']);
+    $sites = array_values($acsfSites['sites']);
     $site = $sites[$key];
 
     return $site['name'];
   }
 
-  protected function promptChooseCloudSite(EnvironmentResponse $cloud_environment): mixed {
-    $sites = $this->getCloudSites($cloud_environment);
+  protected function promptChooseCloudSite(EnvironmentResponse $cloudEnvironment): mixed {
+    $sites = $this->getCloudSites($cloudEnvironment);
     if (count($sites) === 1) {
       $site = reset($sites);
       $this->logger->debug("Only a single Cloud site was detected. Assuming site is $site");
@@ -1136,8 +1136,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   public static function getLandoInfo() {
-    if ($lando_info = AcquiaDrupalEnvironmentDetector::getLandoInfo()) {
-      return json_decode($lando_info, FALSE, 512, JSON_THROW_ON_ERROR);
+    if ($landoInfo = AcquiaDrupalEnvironmentDetector::getLandoInfo()) {
+      return json_decode($landoInfo, FALSE, 512, JSON_THROW_ON_ERROR);
     }
     return NULL;
   }
@@ -1146,14 +1146,14 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return (bool) self::getLandoInfo();
   }
 
-  protected function reAuthenticate(string $api_key, string $api_secret, ?string $base_uri, ?string $accounts_uri): void {
+  protected function reAuthenticate(string $apiKey, string $apiSecret, ?string $baseUri, ?string $accountsUri): void {
     // Client service needs to be reinitialized with new credentials in case
     // this is being run as a sub-command.
     // @see https://github.com/acquia/cli/issues/403
     $this->cloudApiClientService->setConnector(new Connector([
-      'key' => $api_key,
-      'secret' => $api_secret,
-    ], $base_uri, $accounts_uri));
+      'key' => $apiKey,
+      'secret' => $apiSecret,
+    ], $baseUri, $accountsUri));
   }
 
   private function warnMultisite(): void {
@@ -1192,7 +1192,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     };
   }
 
-  protected function getDrushDatabaseConnectionStatus(Closure $output_callback = NULL): bool {
+  protected function getDrushDatabaseConnectionStatus(Closure $outputCallback = NULL): bool {
     if (isset($this->drushHasActiveDatabaseConnection)) {
       return $this->drushHasActiveDatabaseConnection;
     }
@@ -1203,10 +1203,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
         '--fields=db-status,drush-version',
         '--format=json',
         '--no-interaction',
-      ], $output_callback, $this->dir, FALSE);
+      ], $outputCallback, $this->dir, FALSE);
       if ($process->isSuccessful()) {
-        $drush_status_return_output = json_decode($process->getOutput(), TRUE, 512);
-        if (is_array($drush_status_return_output) && array_key_exists('db-status', $drush_status_return_output) && $drush_status_return_output['db-status'] === 'Connected') {
+        $drushStatusReturnOutput = json_decode($process->getOutput(), TRUE, 512);
+        if (is_array($drushStatusReturnOutput) && array_key_exists('db-status', $drushStatusReturnOutput) && $drushStatusReturnOutput['db-status'] === 'Connected') {
           $this->drushHasActiveDatabaseConnection = TRUE;
           return $this->drushHasActiveDatabaseConnection;
         }
@@ -1218,41 +1218,41 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return $this->drushHasActiveDatabaseConnection;
   }
 
-  protected function createMySqlDumpOnLocal(string $db_host, string $db_user, string $db_name, string $db_password, Closure $output_callback = NULL): string {
+  protected function createMySqlDumpOnLocal(string $dbHost, string $dbUser, string $dbName, string $dbPassword, Closure $outputCallback = NULL): string {
     $this->localMachineHelper->checkRequiredBinariesExist(['mysqldump', 'gzip']);
-    $filename = "acli-mysql-dump-{$db_name}.sql.gz";
-    $local_temp_dir = sys_get_temp_dir();
-    $local_filepath = $local_temp_dir . '/' . $filename;
-    $this->logger->debug("Dumping MySQL database to $local_filepath on this machine");
+    $filename = "acli-mysql-dump-{$dbName}.sql.gz";
+    $localTempDir = sys_get_temp_dir();
+    $localFilepath = $localTempDir . '/' . $filename;
+    $this->logger->debug("Dumping MySQL database to $localFilepath on this machine");
     $this->localMachineHelper->checkRequiredBinariesExist(['mysqldump', 'gzip']);
-    if ($output_callback) {
-      $output_callback('out', "Dumping MySQL database to $local_filepath on this machine");
+    if ($outputCallback) {
+      $outputCallback('out', "Dumping MySQL database to $localFilepath on this machine");
     }
     if ($this->localMachineHelper->commandExists('pv')) {
-      $command = "MYSQL_PWD={$db_password} mysqldump --host={$db_host} --user={$db_user} {$db_name} | pv --rate --bytes | gzip -9 > $local_filepath";
+      $command = "MYSQL_PWD={$dbPassword} mysqldump --host={$dbHost} --user={$dbUser} {$dbName} | pv --rate --bytes | gzip -9 > $localFilepath";
     }
     else {
       $this->io->warning('Install `pv` to see progress bar');
-      $command = "MYSQL_PWD={$db_password} mysqldump --host={$db_host} --user={$db_user} {$db_name} | gzip -9 > $local_filepath";
+      $command = "MYSQL_PWD={$dbPassword} mysqldump --host={$dbHost} --user={$dbUser} {$dbName} | gzip -9 > $localFilepath";
     }
 
-    $process = $this->localMachineHelper->executeFromCmd($command, $output_callback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
+    $process = $this->localMachineHelper->executeFromCmd($command, $outputCallback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
     if (!$process->isSuccessful() || $process->getOutput()) {
       throw new AcquiaCliException('Unable to create a dump of the local database. {message}', ['message' => $process->getErrorOutput()]);
     }
 
-    return $local_filepath;
+    return $localFilepath;
   }
 
   protected function promptOpenBrowserToCreateToken(
     InputInterface $input
   ): void {
     if (!$input->getOption('key') || !$input->getOption('secret')) {
-      $token_url = 'https://cloud.acquia.com/a/profile/tokens';
-      $this->output->writeln("You will need a Cloud Platform API token from <href=$token_url>$token_url</>");
+      $tokenUrl = 'https://cloud.acquia.com/a/profile/tokens';
+      $this->output->writeln("You will need a Cloud Platform API token from <href=$tokenUrl>$tokenUrl</>");
 
       if (!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && $this->io->confirm('Do you want to open this page to generate a token now?')) {
-        $this->localMachineHelper->startBrowser($token_url);
+        $this->localMachineHelper->startBrowser($tokenUrl);
       }
     }
   }
@@ -1288,31 +1288,31 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    * explicitly or by default. In other words, we can't prompt for the value of
    * an option that already has a default value.
    *
-   * @param string $option_name
+   * @param string $optionName
    * @param bool $hidden
    * @param \Closure|null $validator
    * @param \Closure|null $normalizer
    * @param string|null $default
    * @return string|null
    */
-  protected function determineOption(string $option_name, bool $hidden = FALSE, ?Closure $validator = NULL, ?Closure $normalizer = NULL, ?string $default = NULL): ?string {
-    if ($option_value = $this->input->getOption($option_name)) {
+  protected function determineOption(string $optionName, bool $hidden = FALSE, ?Closure $validator = NULL, ?Closure $normalizer = NULL, ?string $default = NULL): ?string {
+    if ($optionValue = $this->input->getOption($optionName)) {
       if (isset($normalizer)) {
-        $option_value = $normalizer($option_value);
+        $optionValue = $normalizer($optionValue);
       }
       if (isset($validator)) {
-        $validator($option_value);
+        $validator($optionValue);
       }
-      return $option_value;
+      return $optionValue;
     }
-    $option = $this->getDefinition()->getOption($option_name);
-    $option_shortcut = $option->getShortcut();
+    $option = $this->getDefinition()->getOption($optionName);
+    $optionShortcut = $option->getShortcut();
     $description = lcfirst($option->getDescription());
-    if ($option_shortcut) {
-      $message = "Enter $description (option <options=bold>-$option_shortcut</>, <options=bold>--$option_name</>)";
+    if ($optionShortcut) {
+      $message = "Enter $description (option <options=bold>-$optionShortcut</>, <options=bold>--$optionName</>)";
     }
     else {
-      $message = "Enter $description (option <options=bold>--$option_name</>)";
+      $message = "Enter $description (option <options=bold>--$optionName</>)";
     }
     $optional = $option->isValueOptional();
     $message .= $optional ? ' (optional)' : '';
@@ -1326,31 +1326,31 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     if (isset($validator)) {
       $question->setValidator($validator);
     }
-    $option_value = $this->io->askQuestion($question);
+    $optionValue = $this->io->askQuestion($question);
     // Question bypasses validation if session is non-interactive.
-    if (!$optional && is_null($option_value)) {
+    if (!$optional && is_null($optionValue)) {
       throw new AcquiaCliException($message);
     }
-    return $option_value;
+    return $optionValue;
   }
 
   /**
    * Get the first environment for a given Cloud application matching a filter.
    */
-  private function getAnyAhEnvironment(string $cloud_app_uuid, callable $filter): ?EnvironmentResponse {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $environment_resource = new Environments($acquia_cloud_client);
-    /** @var EnvironmentResponse[] $application_environments */
-    $application_environments = iterator_to_array($environment_resource->getAll($cloud_app_uuid));
-    $candidates = array_filter($application_environments, $filter);
+  private function getAnyAhEnvironment(string $cloudAppUuid, callable $filter): ?EnvironmentResponse {
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $environmentResource = new Environments($acquiaCloudClient);
+    /** @var EnvironmentResponse[] $applicationEnvironments */
+    $applicationEnvironments = iterator_to_array($environmentResource->getAll($cloudAppUuid));
+    $candidates = array_filter($applicationEnvironments, $filter);
     return reset($candidates);
   }
 
   /**
    * Get the first non-prod environment for a given Cloud application.
    */
-  protected function getAnyNonProdAhEnvironment(string $cloud_app_uuid): ?EnvironmentResponse {
-    return $this->getAnyAhEnvironment($cloud_app_uuid, function ($environment) {
+  protected function getAnyNonProdAhEnvironment(string $cloudAppUuid): ?EnvironmentResponse {
+    return $this->getAnyAhEnvironment($cloudAppUuid, function ($environment) {
       return !$environment->flags->production;
     });
   }
@@ -1358,8 +1358,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * Get the first prod environment for a given Cloud application.
    */
-  protected function getAnyProdAhEnvironment(string $cloud_app_uuid): ?EnvironmentResponse {
-    return $this->getAnyAhEnvironment($cloud_app_uuid, function ($environment) {
+  protected function getAnyProdAhEnvironment(string $cloudAppUuid): ?EnvironmentResponse {
+    return $this->getAnyAhEnvironment($cloudAppUuid, function ($environment) {
       return $environment->flags->production;
     });
   }
@@ -1367,52 +1367,52 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   /**
    * Get the first VCS URL for a given Cloud application.
    */
-  protected function getAnyVcsUrl(string $cloud_app_uuid): string {
-    $environment = $this->getAnyAhEnvironment($cloud_app_uuid, function () {
+  protected function getAnyVcsUrl(string $cloudAppUuid): string {
+    $environment = $this->getAnyAhEnvironment($cloudAppUuid, function () {
       return TRUE;
     });
     return $environment->vcs->url;
   }
 
   /**
-   * @param $application_uuid_argument
+   * @param $applicationUuidArgument
    */
-  protected function validateApplicationUuid($application_uuid_argument): mixed {
+  protected function validateApplicationUuid($applicationUuidArgument): mixed {
     try {
-      self::validateUuid($application_uuid_argument);
+      self::validateUuid($applicationUuidArgument);
     }
     catch (ValidatorException) {
       // Since this isn't a valid UUID, let's see if it's a valid alias.
-      $alias = $this->normalizeAlias($application_uuid_argument);
+      $alias = $this->normalizeAlias($applicationUuidArgument);
       return $this->getApplicationFromAlias($alias)->uuid;
     }
-    return $application_uuid_argument;
+    return $applicationUuidArgument;
   }
 
-  protected function validateEnvironmentUuid($env_uuid_argument, $argument_name): string {
-    if (is_null($env_uuid_argument)) {
-      throw new AcquiaCliException("{{$argument_name}} must not be null");
+  protected function validateEnvironmentUuid($envUuidArgument, $argumentName): string {
+    if (is_null($envUuidArgument)) {
+      throw new AcquiaCliException("{{$argumentName}} must not be null");
     }
     try {
       // Environment IDs take the form of [env-num]-[app-uuid].
-      $uuid_parts = explode('-', $env_uuid_argument);
-      unset($uuid_parts[0]);
-      $application_uuid = implode('-', $uuid_parts);
-      self::validateUuid($application_uuid);
+      $uuidParts = explode('-', $envUuidArgument);
+      unset($uuidParts[0]);
+      $applicationUuid = implode('-', $uuidParts);
+      self::validateUuid($applicationUuid);
     }
     catch (ValidatorException) {
       try {
         // Since this isn't a valid environment ID, let's see if it's a valid alias.
-        $alias = $env_uuid_argument;
+        $alias = $envUuidArgument;
         $alias = $this->normalizeAlias($alias);
         $alias = self::validateEnvironmentAlias($alias);
         return $this->getEnvironmentFromAliasArg($alias)->uuid;
       }
       catch (AcquiaCliException) {
-        throw new AcquiaCliException("{{$argument_name}} must be a valid UUID or site alias.");
+        throw new AcquiaCliException("{{$argumentName}} must be a valid UUID or site alias.");
       }
     }
-    return $env_uuid_argument;
+    return $envUuidArgument;
   }
 
   protected function checkAuthentication(): void {
@@ -1421,11 +1421,11 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     }
   }
 
-  protected function waitForNotificationToComplete(Client $acquia_cloud_client, string $uuid, string $message, callable $success = NULL): void {
-    $notifications_resource = new Notifications($acquia_cloud_client);
+  protected function waitForNotificationToComplete(Client $acquiaCloudClient, string $uuid, string $message, callable $success = NULL): void {
+    $notificationsResource = new Notifications($acquiaCloudClient);
     $notification = NULL;
-    $checkNotificationStatus = static function () use ($notifications_resource, &$notification, $uuid) {
-      $notification = $notifications_resource->get($uuid);
+    $checkNotificationStatus = static function () use ($notificationsResource, &$notification, $uuid) {
+      $notification = $notificationsResource->get($uuid);
       return $notification->status !== 'in-progress';
     };
     if ($success === NULL) {
@@ -1447,9 +1447,9 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       throw new AcquiaCliException("Unknown task status: {$notification->status}");
     }
     $duration = strtotime($notification->completed_at) - strtotime($notification->created_at);
-    $completed_at = date("D M j G:i:s T Y", strtotime($notification->completed_at));
+    $completedAt = date("D M j G:i:s T Y", strtotime($notification->completed_at));
     $this->io->writeln("Progress: {$notification->progress}");
-    $this->io->writeln("Completed: $completed_at");
+    $this->io->writeln("Completed: $completedAt");
     $this->io->writeln("Task type: {$notification->label}");
     $this->io->writeln("Duration: $duration seconds");
   }
@@ -1461,22 +1461,22 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     else {
       $links = $response->_links;
     }
-    $notification_url = $links->notification->href;
-    $url_parts = explode('/', $notification_url);
-    return $url_parts[5];
+    $notificationUrl = $links->notification->href;
+    $urlParts = explode('/', $notificationUrl);
+    return $urlParts[5];
   }
 
   /**
-   * @param array $required_permissions
+   * @param array $requiredPermissions
    */
-  protected function validateRequiredCloudPermissions(Client $acquia_cloud_client, ?string $cloud_application_uuid, AccountResponse $account, array $required_permissions): void {
-    $permissions = $acquia_cloud_client->request('get', "/applications/{$cloud_application_uuid}/permissions");
-    $keyed_permissions = [];
+  protected function validateRequiredCloudPermissions(Client $acquiaCloudClient, ?string $cloudApplicationUuid, AccountResponse $account, array $requiredPermissions): void {
+    $permissions = $acquiaCloudClient->request('get', "/applications/{$cloudApplicationUuid}/permissions");
+    $keyedPermissions = [];
     foreach ($permissions as $permission) {
-      $keyed_permissions[$permission->name] = $permission;
+      $keyedPermissions[$permission->name] = $permission;
     }
-    foreach ($required_permissions as $name) {
-      if (!array_key_exists($name, $keyed_permissions)) {
+    foreach ($requiredPermissions as $name) {
+      if (!array_key_exists($name, $keyedPermissions)) {
         throw new AcquiaCliException("The Acquia Cloud Platform account {account} does not have the required '{name}' permission. Add the permissions to this user or use an API Token belonging to a different Acquia Cloud Platform user.", [
           'account' => $account->mail,
           'name' => $name,

--- a/src/Command/DocsCommand.php
+++ b/src/Command/DocsCommand.php
@@ -22,7 +22,7 @@ class DocsCommand extends CommandBase {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $acquia_products = [
+    $acquiaProducts = [
       'Acquia CLI' => [
         'alias' => ['cli', 'acli'],
         'url' => 'acquia-cli',
@@ -99,25 +99,25 @@ class DocsCommand extends CommandBase {
 
     // If user has provided any acquia product in command.
     if ($acquiaProductName = $input->getArgument('product')) {
-      $product_url = NULL;
-      foreach ($acquia_products as $acquia_product) {
+      $productUrl = NULL;
+      foreach ($acquiaProducts as $acquiaProduct) {
         // If product provided by the user exists in the alias
-        if (in_array(strtolower($acquiaProductName), $acquia_product['alias'], TRUE)) {
-          $product_url = $acquia_product['url'];
+        if (in_array(strtolower($acquiaProductName), $acquiaProduct['alias'], TRUE)) {
+          $productUrl = $acquiaProduct['url'];
           break;
         }
       }
 
-      if ($product_url) {
-        $this->localMachineHelper->startBrowser('https://docs.acquia.com/' . $product_url . '/');
+      if ($productUrl) {
+        $this->localMachineHelper->startBrowser('https://docs.acquia.com/' . $productUrl . '/');
         return 0;
       }
     }
 
-    $labels = array_keys($acquia_products);
+    $labels = array_keys($acquiaProducts);
     $question = new ChoiceQuestion('Select the Acquia Product', $labels, $labels[0]);
-    $choice_id = $this->io->askQuestion($question);
-    $this->localMachineHelper->startBrowser('https://docs.acquia.com/' . $acquia_products[$choice_id]['url'] . '/');
+    $choiceId = $this->io->askQuestion($question);
+    $this->localMachineHelper->startBrowser('https://docs.acquia.com/' . $acquiaProducts[$choiceId]['url'] . '/');
 
     return 0;
   }

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -46,25 +46,25 @@ class ConfigurePlatformEmailCommand extends CommandBase {
     $checklist->completePreviousItem();
     $checklist->addItem('the environment or environments for the above applications where Platform Email will be enabled');
     $checklist->completePreviousItem();
-    $base_domain = $this->determineDomain();
+    $baseDomain = $this->determineDomain();
     $client = $this->cloudApiClientService->getClient();
     $subscription = $this->determineCloudSubscription();
     $response = $client->request('post', "/subscriptions/{$subscription->uuid}/domains", [
       'form_params' => [
-        'domain' => $base_domain,
+        'domain' => $baseDomain,
       ],
     ]);
 
-    $domain_uuid = $this->fetchDomainUuid($client, $subscription, $base_domain);
+    $domainUuid = $this->fetchDomainUuid($client, $subscription, $baseDomain);
 
     $this->io->success([
-      "Great! You've registered the domain {$base_domain} to subscription {$subscription->name}.",
+      "Great! You've registered the domain {$baseDomain} to subscription {$subscription->name}.",
       "We will create a file with the DNS records for your newly registered domain",
       "Provide these records to your DNS provider",
       "After you've done this, continue to domain verification.",
     ]);
-    $file_format = $this->io->choice('Would you like your DNS records in BIND Zone File, JSON, or YAML format?', ['BIND Zone File', 'YAML', 'JSON'], 'BIND Zone File');
-    $this->createDnsText($client, $subscription, $base_domain, $domain_uuid, $file_format);
+    $fileFormat = $this->io->choice('Would you like your DNS records in BIND Zone File, JSON, or YAML format?', ['BIND Zone File', 'YAML', 'JSON'], 'BIND Zone File');
+    $this->createDnsText($client, $subscription, $baseDomain, $domainUuid, $fileFormat);
     $continue = $this->io->confirm('Have you finished providing the DNS records to your DNS provider?');
     if (!$continue) {
       $this->io->info("Make sure to give these records to your DNS provider, then rerun this script with the domain that you just registered.");
@@ -72,9 +72,9 @@ class ConfigurePlatformEmailCommand extends CommandBase {
     }
 
     // Allow for as many reverification tries as needed.
-    while (!$this->checkIfDomainVerified($subscription, $domain_uuid)) {
-      $retry_verification = $this->io->confirm('Would you like to re-check domain verification?');
-      if (!$retry_verification) {
+    while (!$this->checkIfDomainVerified($subscription, $domainUuid)) {
+      $retryVerification = $this->io->confirm('Would you like to re-check domain verification?');
+      if (!$retryVerification) {
         $this->io->writeln('Check your DNS records with your DNS provider and try again by rerunning this script with the domain that you just registered.');
         return 1;
       }
@@ -82,7 +82,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
 
     $this->io->success("The next step is associating your verified domain with an application (or applications) in the subscription where your domain has been registered.");
 
-    if (!$this->addDomainToSubscriptionApplications($client, $subscription, $base_domain, $domain_uuid)) {
+    if (!$this->addDomainToSubscriptionApplications($client, $subscription, $baseDomain, $domainUuid)) {
       $this->io->error('Something went wrong with associating your application(s) or enabling your environment(s). Try again.');
       return 1;
     }
@@ -97,24 +97,24 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    *
    * @param array $records
    */
-  private function generateZoneFile(string $base_domain, array $records): void {
+  private function generateZoneFile(string $baseDomain, array $records): void {
 
-    $zone = new Zone($base_domain . '.');
+    $zone = new Zone($baseDomain . '.');
 
     foreach ($records as $record) {
       unset($record->health);
-      $record_to_add = $zone->getNode($record->name . '.');
+      $recordToAdd = $zone->getNode($record->name . '.');
 
       switch ($record->type) {
         case 'MX':
-          $mx_priority_value_arr = explode(' ', $record->value);
-          $record_to_add->getRecordAppender()->appendMxRecord($mx_priority_value_arr[0], $mx_priority_value_arr[1] . '.', 3600);
+          $mxPriorityValueArr = explode(' ', $record->value);
+          $recordToAdd->getRecordAppender()->appendMxRecord($mxPriorityValueArr[0], $mxPriorityValueArr[1] . '.', 3600);
           break;
         case 'TXT':
-          $record_to_add->getRecordAppender()->appendTxtRecord($record->value, 3600);
+          $recordToAdd->getRecordAppender()->appendTxtRecord($record->value, 3600);
           break;
         case 'CNAME':
-          $record_to_add->getRecordAppender()->appendCNameRecord($record->value . '.', 3600);
+          $recordToAdd->getRecordAppender()->appendCNameRecord($record->value . '.', 3600);
           break;
       }
     }
@@ -131,32 +131,33 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    * @return array
    */
   private function determineApplications(Client $client, SubscriptionResponse $subscription): array {
-    $applications_resource = new Applications($client);
-    $applications = $applications_resource->getAll();
-    $subscription_applications = [];
+    $applicationsResource = new Applications($client);
+    $applications = $applicationsResource->getAll();
+    $subscriptionApplications = [];
     foreach ($applications as $application) {
       if ($application->subscription->uuid === $subscription->uuid) {
-        $subscription_applications[] = $application;
+        $subscriptionApplications[] = $application;
       }
     }
-    if (count($subscription_applications) === 0) {
+    if (count($subscriptionApplications) === 0) {
       throw new AcquiaCliException("You do not have access to any applications on the {$subscription->name} subscription");
     }
 
-    if (count($subscription_applications) === 1) {
-      $applications = $subscription_applications;
+    if (count($subscriptionApplications) === 1) {
+      $applications = $subscriptionApplications;
       $this->io->info("You have one application, {$applications[0]->name}, in this subscription.");
     }
     else {
-      $applications = $this->promptChooseFromObjectsOrArrays($subscription_applications, 'uuid', 'name', "What are the applications you'd like to associate this domain with? You may enter multiple separated by a comma.", TRUE);
+      $applications = $this->promptChooseFromObjectsOrArrays($subscriptionApplications, 'uuid', 'name', "What are the applications you'd like to associate this domain with? You may enter multiple separated by a comma.", TRUE);
     }
     return $applications;
   }
 
   /**
-   * Checks any error from Cloud API when associating a domain with an application.
-   * Shows a warning and allows user to continue if the domain has been associated already.
-   * For any other error from the API, the setup will exit.
+   * Checks any error from Cloud API when associating a domain with an
+   * application. Shows a warning and allows user to continue if the domain has
+   * been associated already. For any other error from the API, the setup will
+   * exit.
    */
   private function domainAlreadyAssociated(object $application, ApiErrorException $exception): ?bool {
     if (!str_contains($exception, 'is already associated with this application')) {
@@ -169,9 +170,10 @@ class ConfigurePlatformEmailCommand extends CommandBase {
   }
 
   /**
-   * Checks any error from Cloud API when enabling Platform Email for an environment.
-   * Shows a warning and allows user to continue if Platform Email has already been enabled for the environment.
-   * For any other error from the API, the setup will exit.
+   * Checks any error from Cloud API when enabling Platform Email for an
+   * environment. Shows a warning and allows user to continue if Platform Email
+   * has already been enabled for the environment. For any other error from the
+   * API, the setup will exit.
    */
   private function environmentAlreadyEnabled(object $environment, ApiErrorException $exception): ?bool {
     if (!str_contains($exception, 'is already enabled on this environment')) {
@@ -188,14 +190,14 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    * then enables Platform Email for an environment or environments
    * of the above applications.
    */
-  private function addDomainToSubscriptionApplications(Client $client, SubscriptionResponse $subscription, string $base_domain, string $domain_uuid): bool {
+  private function addDomainToSubscriptionApplications(Client $client, SubscriptionResponse $subscription, string $baseDomain, string $domainUuid): bool {
     $applications = $this->determineApplications($client, $subscription);
 
-    $environments_resource = new Environments($client);
+    $environmentsResource = new Environments($client);
     foreach ($applications as $application) {
       try {
-        $response = $client->request('post', "/applications/{$application->uuid}/email/domains/{$domain_uuid}/actions/associate");
-        $this->io->success("Domain $base_domain has been associated with Application {$application->name}");
+        $response = $client->request('post', "/applications/{$application->uuid}/email/domains/{$domainUuid}/actions/associate");
+        $this->io->success("Domain $baseDomain has been associated with Application {$application->name}");
       }
       catch (ApiErrorException $e) {
         if (!$this->domainAlreadyAssociated($application, $e)) {
@@ -203,9 +205,9 @@ class ConfigurePlatformEmailCommand extends CommandBase {
         }
       }
 
-      $application_environments = $environments_resource->getAll($application->uuid);
+      $applicationEnvironments = $environmentsResource->getAll($application->uuid);
       $envs = $this->promptChooseFromObjectsOrArrays(
-        $application_environments,
+        $applicationEnvironments,
         'uuid',
         'label',
         "What are the environments of {$application->name} that you'd like to enable email for? You may enter multiple separated by a comma.",
@@ -230,15 +232,15 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    * Validates the URL entered as the base domain name.
    */
   public static function validateUrl(string $url): string {
-    $constraints_list = [new NotBlank()];
-    $url_parts = parse_url($url);
-    if (array_key_exists('host', $url_parts)) {
-      $constraints_list[] = new Url();
+    $constraintsList = [new NotBlank()];
+    $urlParts = parse_url($url);
+    if (array_key_exists('host', $urlParts)) {
+      $constraintsList[] = new Url();
     }
     else {
-      $constraints_list[] = new Hostname();
+      $constraintsList[] = new Hostname();
     }
-    $violations = Validation::createValidator()->validate($url, $constraints_list);
+    $violations = Validation::createValidator()->validate($url, $constraintsList);
     if (count($violations)) {
       throw new ValidatorException($violations->get(0)->getMessage());
     }
@@ -248,31 +250,31 @@ class ConfigurePlatformEmailCommand extends CommandBase {
   /**
    * Retrieves a domain registration UUID given the domain name.
    */
-  private function fetchDomainUuid(Client $client, SubscriptionResponse $subscription, string $base_domain): mixed {
-    $domains_response = $client->request('get', "/subscriptions/{$subscription->uuid}/domains");
-    foreach ($domains_response as $domain) {
-      if ($domain->domain_name === $base_domain) {
+  private function fetchDomainUuid(Client $client, SubscriptionResponse $subscription, string $baseDomain): mixed {
+    $domainsResponse = $client->request('get', "/subscriptions/{$subscription->uuid}/domains");
+    foreach ($domainsResponse as $domain) {
+      if ($domain->domain_name === $baseDomain) {
         return $domain->uuid;
       }
     }
-    throw new AcquiaCliException("Could not find domain $base_domain");
+    throw new AcquiaCliException("Could not find domain $baseDomain");
   }
 
   /**
    * Creates a file, either in Bind Zone File, JSON or YAML format,
    * of the DNS records needed to complete Platform Email setup.
    */
-  private function createDnsText(Client $client, SubscriptionResponse $subscription, string $base_domain, string $domain_uuid, string $file_format): void {
-    $domain_registration_response = $client->request('get', "/subscriptions/{$subscription->uuid}/domains/{$domain_uuid}");
-    if (!isset($domain_registration_response->dns_records)) {
+  private function createDnsText(Client $client, SubscriptionResponse $subscription, string $baseDomain, string $domainUuid, string $fileFormat): void {
+    $domainRegistrationResponse = $client->request('get', "/subscriptions/{$subscription->uuid}/domains/{$domainUuid}");
+    if (!isset($domainRegistrationResponse->dns_records)) {
       throw new AcquiaCliException('Could not retrieve DNS records for this domain. Try again by rerunning this script with the domain that you just registered.');
     }
     $records = [];
     $this->localMachineHelper->getFilesystem()->remove('dns-records.json');
     $this->localMachineHelper->getFilesystem()->remove('dns-records.yaml');
     $this->localMachineHelper->getFilesystem()->remove('dns-records.zone');
-    if ($file_format === 'JSON') {
-      foreach ($domain_registration_response->dns_records as $record) {
+    if ($fileFormat === 'JSON') {
+      foreach ($domainRegistrationResponse->dns_records as $record) {
         unset($record->health);
         $records[] = $record;
       }
@@ -280,8 +282,8 @@ class ConfigurePlatformEmailCommand extends CommandBase {
       $this->localMachineHelper->getFilesystem()
             ->dumpFile('dns-records.json', json_encode($records, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
-    else if ($file_format === 'YAML') {
-      foreach ($domain_registration_response->dns_records as $record) {
+    else if ($fileFormat === 'YAML') {
+      foreach ($domainRegistrationResponse->dns_records as $record) {
         unset($record->health);
         $records[] = ['type' => $record->type, 'name' => $record->name, 'value' => $record->value];
       }
@@ -290,7 +292,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
             ->dumpFile('dns-records.yaml', Yaml::dump($records));
     }
     else {
-      $this->generateZoneFile($base_domain, $domain_registration_response->dns_records);
+      $this->generateZoneFile($baseDomain, $domainRegistrationResponse->dns_records);
     }
 
   }
@@ -300,11 +302,11 @@ class ConfigurePlatformEmailCommand extends CommandBase {
    */
   private function checkIfDomainVerified(
     SubscriptionResponse $subscription,
-    string $domain_uuid
+    string $domainUuid
   ): bool {
     $client = $this->cloudApiClientService->getClient();
     try {
-      $response = $client->request('get', "/subscriptions/{$subscription->uuid}/domains/{$domain_uuid}");
+      $response = $client->request('get', "/subscriptions/{$subscription->uuid}/domains/{$domainUuid}");
       if (isset($response->health) && $response->health->code === "200") {
         $this->io->success("Your domain is ready for use!");
         return TRUE;
@@ -314,7 +316,7 @@ class ConfigurePlatformEmailCommand extends CommandBase {
         $this->io->error($response->health->details);
         $reverify = $this->io->confirm('Would you like to refresh?');
         if ($reverify) {
-          $refresh_response = $client->request('post', "/subscriptions/{$subscription->uuid}/domains/{$domain_uuid}/actions/verify");
+          $refreshResponse = $client->request('post', "/subscriptions/{$subscription->uuid}/domains/{$domainUuid}/actions/verify");
           $this->io->info('Refreshing...');
         }
       }
@@ -339,9 +341,9 @@ class ConfigurePlatformEmailCommand extends CommandBase {
       'validateUrl',
     ]));
 
-    $domain_parts = parse_url($domain);
-    if (array_key_exists('host', $domain_parts)) {
-      $return = $domain_parts['host'];
+    $domainParts = parse_url($domain);
+    if (array_key_exists('host', $domainParts)) {
+      $return = $domainParts['host'];
     }
     else {
       $return = $domain;

--- a/src/Command/Env/EnvCreateCommand.php
+++ b/src/Command/Env/EnvCreateCommand.php
@@ -30,23 +30,23 @@ class EnvCreateCommand extends CommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->output = $output;
-    $cloud_app_uuid = $this->determineCloudApplication(TRUE);
+    $cloudAppUuid = $this->determineCloudApplication(TRUE);
     $label = $input->getArgument('label');
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $environments_resource = new Environments($acquia_cloud_client);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $environmentsResource = new Environments($acquiaCloudClient);
     $this->checklist = new Checklist($output);
 
-    $this->validateLabel($environments_resource, $cloud_app_uuid, $label);
-    $branch = $this->getBranch($acquia_cloud_client, $cloud_app_uuid, $input);
-    $database_names = $this->getDatabaseNames($acquia_cloud_client, $cloud_app_uuid);
+    $this->validateLabel($environmentsResource, $cloudAppUuid, $label);
+    $branch = $this->getBranch($acquiaCloudClient, $cloudAppUuid, $input);
+    $databaseNames = $this->getDatabaseNames($acquiaCloudClient, $cloudAppUuid);
 
     $this->checklist->addItem("Initiating environment creation");
-    $response = $environments_resource->create($cloud_app_uuid, $label, $branch, $database_names);
-    $notification_uuid = $this->getNotificationUuidFromResponse($response);
+    $response = $environmentsResource->create($cloudAppUuid, $label, $branch, $databaseNames);
+    $notificationUuid = $this->getNotificationUuidFromResponse($response);
     $this->checklist->completePreviousItem();
 
-    $success = function () use ($environments_resource, $cloud_app_uuid, $label): void {
-      $environments = $environments_resource->getAll($cloud_app_uuid);
+    $success = function () use ($environmentsResource, $cloudAppUuid, $label): void {
+      $environments = $environmentsResource->getAll($cloudAppUuid);
       foreach ($environments as $environment) {
         if ($environment->label === $label) {
           break;
@@ -59,15 +59,15 @@ class EnvCreateCommand extends CommandBase {
         ]);
       }
     };
-    $this->waitForNotificationToComplete($acquia_cloud_client, $notification_uuid, "Waiting for the environment to be ready. This usually takes 2 - 15 minutes.", $success);
+    $this->waitForNotificationToComplete($acquiaCloudClient, $notificationUuid, "Waiting for the environment to be ready. This usually takes 2 - 15 minutes.", $success);
 
     return 0;
   }
 
-  private function validateLabel(Environments $environments_resource, string $cloud_app_uuid, string $title): void {
+  private function validateLabel(Environments $environmentsResource, string $cloudAppUuid, string $title): void {
     $this->checklist->addItem("Checking to see that label is unique");
     /** @var \AcquiaCloudApi\Response\EnvironmentResponse[] $environments */
-    $environments = $environments_resource->getAll($cloud_app_uuid);
+    $environments = $environmentsResource->getAll($cloudAppUuid);
     foreach ($environments as $environment) {
       if ($environment->label === $title) {
         throw new AcquiaCliException("An environment named $title already exists.");
@@ -76,31 +76,31 @@ class EnvCreateCommand extends CommandBase {
     $this->checklist->completePreviousItem();
   }
 
-  private function getBranch(Client $acquia_cloud_client, ?string $cloud_app_uuid, InputInterface $input): string {
-    $branches_and_tags = $acquia_cloud_client->request('get', "/applications/$cloud_app_uuid/code");
+  private function getBranch(Client $acquiaCloudClient, ?string $cloudAppUuid, InputInterface $input): string {
+    $branchesAndTags = $acquiaCloudClient->request('get', "/applications/$cloudAppUuid/code");
     if ($input->getArgument('branch')) {
       $branch = $input->getArgument('branch');
-      if (!in_array($branch, array_column($branches_and_tags, 'name'), TRUE)) {
+      if (!in_array($branch, array_column($branchesAndTags, 'name'), TRUE)) {
         throw new AcquiaCliException("There is no branch or tag with the name $branch on the remote VCS.", );
       }
       return $branch;
     }
-    return $this->promptChooseFromObjectsOrArrays($branches_and_tags, 'name', 'name', "Choose a branch or tag to deploy to the new environment")->name;
+    return $this->promptChooseFromObjectsOrArrays($branchesAndTags, 'name', 'name', "Choose a branch or tag to deploy to the new environment")->name;
   }
 
   /**
    * @return array
    */
-  private function getDatabaseNames(Client $acquia_cloud_client, ?string $cloud_app_uuid): array {
+  private function getDatabaseNames(Client $acquiaCloudClient, ?string $cloudAppUuid): array {
     $this->checklist->addItem("Determining default database");
-    $databases_resource = new Databases($acquia_cloud_client);
-    $databases = $databases_resource->getNames($cloud_app_uuid);
-    $database_names = [];
+    $databasesResource = new Databases($acquiaCloudClient);
+    $databases = $databasesResource->getNames($cloudAppUuid);
+    $databaseNames = [];
     foreach ($databases as $database) {
-      $database_names[] = $database->name;
+      $databaseNames[] = $database->name;
     }
     $this->checklist->completePreviousItem();
-    return $database_names;
+    return $databaseNames;
   }
 
 }

--- a/src/Command/Env/EnvDeleteCommand.php
+++ b/src/Command/Env/EnvDeleteCommand.php
@@ -23,11 +23,11 @@ class EnvDeleteCommand extends CommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->output = $output;
-    $cloud_app_uuid = $this->determineCloudApplication(TRUE);
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $environments_resource = new Environments($acquia_cloud_client);
-    $environment = $this->determineEnvironment($environments_resource, $cloud_app_uuid);
-    $environments_resource->delete($environment->uuid);
+    $cloudAppUuid = $this->determineCloudApplication(TRUE);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $environmentsResource = new Environments($acquiaCloudClient);
+    $environment = $this->determineEnvironment($environmentsResource, $cloudAppUuid);
+    $environmentsResource->delete($environment->uuid);
 
     $this->io->success([
       "The {$environment->label} environment is being deleted",
@@ -36,13 +36,13 @@ class EnvDeleteCommand extends CommandBase {
     return 0;
   }
 
-  private function determineEnvironment(Environments $environments_resource, string $cloud_app_uuid): EnvironmentResponse {
+  private function determineEnvironment(Environments $environmentsResource, string $cloudAppUuid): EnvironmentResponse {
     if ($this->input->getArgument('environmentId')) {
       // @todo Validate.
-      $environment_id = $this->input->getArgument('environmentId');
-      return $environments_resource->get($environment_id);
+      $environmentId = $this->input->getArgument('environmentId');
+      return $environmentsResource->get($environmentId);
     }
-    $environments = $environments_resource->getAll($cloud_app_uuid);
+    $environments = $environmentsResource->getAll($cloudAppUuid);
     $cdes = [];
     foreach ($environments as $environment) {
       if ($environment->flags->cde) {
@@ -50,7 +50,7 @@ class EnvDeleteCommand extends CommandBase {
       }
     }
     if (!$cdes) {
-      throw new AcquiaCliException('There are no existing CDEs for Application ' . $cloud_app_uuid);
+      throw new AcquiaCliException('There are no existing CDEs for Application ' . $cloudAppUuid);
     }
     return $this->promptChooseFromObjectsOrArrays($cdes, 'uuid', 'label', "Which Continuous Delivery Environment (CDE) do you want to delete?");
   }

--- a/src/Command/Env/EnvMirrorCommand.php
+++ b/src/Command/Env/EnvMirrorCommand.php
@@ -40,58 +40,58 @@ class EnvMirrorCommand extends CommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->checklist = new Checklist($output);
-    $output_callback = $this->getOutputCallback($output, $this->checklist);
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $environments_resource = new Environments($acquia_cloud_client);
-    $source_environment_uuid = $input->getArgument('source-environment');
-    $destination_environment_uuid = $input->getArgument('destination-environment');
+    $outputCallback = $this->getOutputCallback($output, $this->checklist);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $environmentsResource = new Environments($acquiaCloudClient);
+    $sourceEnvironmentUuid = $input->getArgument('source-environment');
+    $destinationEnvironmentUuid = $input->getArgument('destination-environment');
 
     $this->checklist->addItem("Fetching information about source environment");
-    $source_environment = $environments_resource->get($source_environment_uuid);
+    $sourceEnvironment = $environmentsResource->get($sourceEnvironmentUuid);
     $this->checklist->completePreviousItem();
 
     $this->checklist->addItem("Fetching information about destination environment");
-    $destination_environment = $environments_resource->get($destination_environment_uuid);
+    $destinationEnvironment = $environmentsResource->get($destinationEnvironmentUuid);
     $this->checklist->completePreviousItem();
 
-    $answer = $this->io->confirm("Are you sure that you want to overwrite everything on {$destination_environment->label} ({$destination_environment->name}) and replace it with source data from {$source_environment->label} ({$source_environment->name})");
+    $answer = $this->io->confirm("Are you sure that you want to overwrite everything on {$destinationEnvironment->label} ({$destinationEnvironment->name}) and replace it with source data from {$sourceEnvironment->label} ({$sourceEnvironment->name})");
     if (!$answer) {
       return 1;
     }
 
     if (!$input->getOption('no-code')) {
-      $code_copy_response = $this->mirrorCode($acquia_cloud_client, $destination_environment_uuid, $source_environment, $output_callback);
+      $codeCopyResponse = $this->mirrorCode($acquiaCloudClient, $destinationEnvironmentUuid, $sourceEnvironment, $outputCallback);
     }
 
     if (!$input->getOption('no-databases')) {
-      $db_copy_response = $this->mirrorDatabase($acquia_cloud_client, $source_environment_uuid, $destination_environment_uuid, $output_callback);
+      $dbCopyResponse = $this->mirrorDatabase($acquiaCloudClient, $sourceEnvironmentUuid, $destinationEnvironmentUuid, $outputCallback);
     }
 
     if (!$input->getOption('no-files')) {
-      $files_copy_response = $this->mirrorFiles($environments_resource, $source_environment_uuid, $destination_environment_uuid);
+      $filesCopyResponse = $this->mirrorFiles($environmentsResource, $sourceEnvironmentUuid, $destinationEnvironmentUuid);
     }
 
     if (!$input->getOption('no-config')) {
-      $config_copy_response = $this->mirrorConfig($source_environment, $destination_environment, $environments_resource, $destination_environment_uuid, $output_callback);
+      $configCopyResponse = $this->mirrorConfig($sourceEnvironment, $destinationEnvironment, $environmentsResource, $destinationEnvironmentUuid, $outputCallback);
     }
 
-    if (isset($code_copy_response)) {
-      $this->waitForNotificationToComplete($acquia_cloud_client, $this->getNotificationUuidFromResponse($code_copy_response), 'Waiting for code copy to complete');
+    if (isset($codeCopyResponse)) {
+      $this->waitForNotificationToComplete($acquiaCloudClient, $this->getNotificationUuidFromResponse($codeCopyResponse), 'Waiting for code copy to complete');
     }
-    if (isset($db_copy_response)) {
-      $this->waitForNotificationToComplete($acquia_cloud_client, $this->getNotificationUuidFromResponse($db_copy_response), 'Waiting for database copy to complete');
+    if (isset($dbCopyResponse)) {
+      $this->waitForNotificationToComplete($acquiaCloudClient, $this->getNotificationUuidFromResponse($dbCopyResponse), 'Waiting for database copy to complete');
     }
-    if (isset($files_copy_response)) {
-      $this->waitForNotificationToComplete($acquia_cloud_client, $this->getNotificationUuidFromResponse($files_copy_response), 'Waiting for files copy to complete');
+    if (isset($filesCopyResponse)) {
+      $this->waitForNotificationToComplete($acquiaCloudClient, $this->getNotificationUuidFromResponse($filesCopyResponse), 'Waiting for files copy to complete');
     }
-    if (isset($config_copy_response)) {
-      $this->waitForNotificationToComplete($acquia_cloud_client, $this->getNotificationUuidFromResponse($config_copy_response), 'Waiting for config copy to complete');
+    if (isset($configCopyResponse)) {
+      $this->waitForNotificationToComplete($acquiaCloudClient, $this->getNotificationUuidFromResponse($configCopyResponse), 'Waiting for config copy to complete');
     }
 
     $this->io->success([
-      "Done! {$destination_environment->label} now matches {$source_environment->label}",
+      "Done! {$destinationEnvironment->label} now matches {$sourceEnvironment->label}",
       "You can visit it here:",
-      "https://" . $destination_environment->domains[0],
+      "https://" . $destinationEnvironment->domains[0],
     ]);
 
     return 0;
@@ -109,52 +109,52 @@ class EnvMirrorCommand extends CommandBase {
     return NULL;
   }
 
-  private function mirrorDatabase(Client $acquia_cloud_client, mixed $source_environment_uuid, mixed $destination_environment_uuid, callable $output_callback): OperationResponse {
+  private function mirrorDatabase(Client $acquiaCloudClient, mixed $sourceEnvironmentUuid, mixed $destinationEnvironmentUuid, callable $outputCallback): OperationResponse {
     $this->checklist->addItem("Initiating database copy");
-    $output_callback('out', "Getting a list of databases");
-    $databases_resource = new Databases($acquia_cloud_client);
-    $databases = $acquia_cloud_client->request('get', "/environments/$source_environment_uuid/databases");
-    $default_database = $this->getDefaultDatabase($databases);
-    $output_callback('out', "Copying {$default_database->name}");
+    $outputCallback('out', "Getting a list of databases");
+    $databasesResource = new Databases($acquiaCloudClient);
+    $databases = $acquiaCloudClient->request('get', "/environments/$sourceEnvironmentUuid/databases");
+    $defaultDatabase = $this->getDefaultDatabase($databases);
+    $outputCallback('out', "Copying {$defaultDatabase->name}");
 
     // @todo Create database if its missing.
-    $db_copy_response = $databases_resource->copy($source_environment_uuid, $default_database->name, $destination_environment_uuid);
+    $dbCopyResponse = $databasesResource->copy($sourceEnvironmentUuid, $defaultDatabase->name, $destinationEnvironmentUuid);
     $this->checklist->completePreviousItem();
-    return $db_copy_response;
+    return $dbCopyResponse;
   }
 
-  private function mirrorCode(Client $acquia_cloud_client, mixed $destination_environment_uuid, EnvironmentResponse $source_environment, callable $output_callback): mixed {
+  private function mirrorCode(Client $acquiaCloudClient, mixed $destinationEnvironmentUuid, EnvironmentResponse $sourceEnvironment, callable $outputCallback): mixed {
     $this->checklist->addItem("Initiating code switch");
-    $output_callback('out', "Switching to {$source_environment->vcs->path}");
-    $code_copy_response = $acquia_cloud_client->request('post', "/environments/$destination_environment_uuid/code/actions/switch", [
+    $outputCallback('out', "Switching to {$sourceEnvironment->vcs->path}");
+    $codeCopyResponse = $acquiaCloudClient->request('post', "/environments/$destinationEnvironmentUuid/code/actions/switch", [
       'form_params' => [
-        'branch' => $source_environment->vcs->path,
+        'branch' => $sourceEnvironment->vcs->path,
       ],
     ]);
-    $code_copy_response->links = $code_copy_response->_links;
+    $codeCopyResponse->links = $codeCopyResponse->_links;
     $this->checklist->completePreviousItem();
-    return $code_copy_response;
+    return $codeCopyResponse;
   }
 
-  private function mirrorFiles(Environments $environments_resource, mixed $source_environment_uuid, mixed $destination_environment_uuid): OperationResponse {
+  private function mirrorFiles(Environments $environmentsResource, mixed $sourceEnvironmentUuid, mixed $destinationEnvironmentUuid): OperationResponse {
     $this->checklist->addItem("Initiating files copy");
-    $files_copy_response = $environments_resource->copyFiles($source_environment_uuid, $destination_environment_uuid);
+    $filesCopyResponse = $environmentsResource->copyFiles($sourceEnvironmentUuid, $destinationEnvironmentUuid);
     $this->checklist->completePreviousItem();
-    return $files_copy_response;
+    return $filesCopyResponse;
   }
 
-  private function mirrorConfig(EnvironmentResponse $source_environment, EnvironmentResponse $destination_environment, Environments $environments_resource, mixed $destination_environment_uuid, callable $output_callback): OperationResponse {
+  private function mirrorConfig(EnvironmentResponse $sourceEnvironment, EnvironmentResponse $destinationEnvironment, Environments $environmentsResource, mixed $destinationEnvironmentUuid, callable $outputCallback): OperationResponse {
     $this->checklist->addItem("Initiating config copy");
-    $output_callback('out', "Copying PHP version, acpu memory limit, etc.");
-    $config = (array) $source_environment->configuration->php;
-    $config['apcu'] = max(32, $source_environment->configuration->php->apcu);
-    if ($config['version'] == $destination_environment->configuration->php->version) {
+    $outputCallback('out', "Copying PHP version, acpu memory limit, etc.");
+    $config = (array) $sourceEnvironment->configuration->php;
+    $config['apcu'] = max(32, $sourceEnvironment->configuration->php->apcu);
+    if ($config['version'] == $destinationEnvironment->configuration->php->version) {
       unset($config['version']);
     }
     unset($config['memcached_limit']);
-    $config_copy_response = $environments_resource->update($destination_environment_uuid, $config);
+    $configCopyResponse = $environmentsResource->update($destinationEnvironmentUuid, $config);
     $this->checklist->completePreviousItem();
-    return $config_copy_response;
+    return $configCopyResponse;
   }
 
 }

--- a/src/Command/Ide/IdeCommandBase.php
+++ b/src/Command/Ide/IdeCommandBase.php
@@ -15,14 +15,14 @@ abstract class IdeCommandBase extends CommandBase {
   private string $xdebugIniFilepath = '/home/ide/configs/php/xdebug.ini';
 
   /**
-   * @param $cloud_application_uuid
+   * @param $cloudApplicationUuid
    */
   protected function promptIdeChoice(
-    string $question_text,
-    Ides $ides_resource,
-    $cloud_application_uuid
+    string $questionText,
+    Ides $idesResource,
+    $cloudApplicationUuid
   ): ?IdeResponse {
-    $ides = iterator_to_array($ides_resource->getAll($cloud_application_uuid));
+    $ides = iterator_to_array($idesResource->getAll($cloudApplicationUuid));
     if (empty($ides)) {
       throw new AcquiaCliException('No IDEs exist for this application.');
     }
@@ -31,10 +31,10 @@ abstract class IdeCommandBase extends CommandBase {
     foreach ($ides as $ide) {
       $choices[] = "$ide->label ($ide->uuid)";
     }
-    $choice = $this->io->choice($question_text, $choices, $choices[0]);
-    $chosen_environment_index = array_search($choice, $choices, TRUE);
+    $choice = $this->io->choice($questionText, $choices, $choices[0]);
+    $chosenEnvironmentIndex = array_search($choice, $choices, TRUE);
 
-    return $ides[$chosen_environment_index];
+    return $ides[$chosenEnvironmentIndex];
   }
 
   /**
@@ -79,8 +79,8 @@ abstract class IdeCommandBase extends CommandBase {
     }
   }
 
-  public function setXdebugIniFilepath(string $file_path): void {
-    $this->xdebugIniFilepath = $file_path;
+  public function setXdebugIniFilepath(string $filePath): void {
+    $this->xdebugIniFilepath = $filePath;
   }
 
   protected function getXdebugIniFilePath(): string {

--- a/src/Command/Ide/IdeDeleteCommand.php
+++ b/src/Command/Ide/IdeDeleteCommand.php
@@ -23,27 +23,27 @@ class IdeDeleteCommand extends IdeCommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $ides_resource = new Ides($acquia_cloud_client);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $idesResource = new Ides($acquiaCloudClient);
 
-    $cloud_application_uuid = $this->determineCloudApplication();
-    $ide = $this->promptIdeChoice("Select the IDE you'd like to delete:", $ides_resource, $cloud_application_uuid);
+    $cloudApplicationUuid = $this->determineCloudApplication();
+    $ide = $this->promptIdeChoice("Select the IDE you'd like to delete:", $idesResource, $cloudApplicationUuid);
     $answer = $this->io->confirm("Are you sure you want to delete <options=bold>{$ide->label}</>");
     if (!$answer) {
       $this->io->writeln('Ok, nevermind.');
       return 1;
     }
-    $response = $ides_resource->delete($ide->uuid);
+    $response = $idesResource->delete($ide->uuid);
     $this->io->writeln($response->message);
     // @todo Remove after CXAPI-8261 is closed.
     $this->io->writeln("This process usually takes a few minutes.");
 
     // Check to see if an SSH key for this IDE exists on Cloud.
-    $cloud_key = $this->findIdeSshKeyOnCloud($ide->uuid);
-    if ($cloud_key) {
+    $cloudKey = $this->findIdeSshKeyOnCloud($ide->uuid);
+    if ($cloudKey) {
       $answer = $this->io->confirm('Would you like to delete the SSH key associated with this IDE from your Cloud Platform account?');
       if ($answer) {
-        $this->deleteSshKeyFromCloud($output, $cloud_key);
+        $this->deleteSshKeyFromCloud($output, $cloudKey);
       }
     }
 

--- a/src/Command/Ide/IdeInfoCommand.php
+++ b/src/Command/Ide/IdeInfoCommand.php
@@ -20,13 +20,13 @@ class IdeInfoCommand extends IdeCommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $application_uuid = $this->determineCloudApplication();
+    $applicationUuid = $this->determineCloudApplication();
 
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $ides_resource = new Ides($acquia_cloud_client);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $idesResource = new Ides($acquiaCloudClient);
 
-    $ide = $this->promptIdeChoice("Select an IDE to get more information:", $ides_resource, $application_uuid);
-    $response = $ides_resource->get($ide->uuid);
+    $ide = $this->promptIdeChoice("Select an IDE to get more information:", $idesResource, $applicationUuid);
+    $response = $idesResource->get($ide->uuid);
     $this->io->definitionList(
       ['IDE property' => 'IDE value'],
       new TableSeparator(),

--- a/src/Command/Ide/IdeListCommand.php
+++ b/src/Command/Ide/IdeListCommand.php
@@ -22,17 +22,17 @@ class IdeListCommand extends IdeCommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $application_uuid = $this->determineCloudApplication();
+    $applicationUuid = $this->determineCloudApplication();
 
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $ides_resource = new Ides($acquia_cloud_client);
-    $application_ides = $ides_resource->getAll($application_uuid);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $idesResource = new Ides($acquiaCloudClient);
+    $applicationIdes = $idesResource->getAll($applicationUuid);
 
-    if ($application_ides->count()) {
+    if ($applicationIdes->count()) {
       $table = new Table($output);
       $table->setStyle('borderless');
       $table->setHeaders(['IDEs']);
-      foreach ($application_ides as $ide) {
+      foreach ($applicationIdes as $ide) {
         $table->addRows([
           ["<comment>{$ide->label} ({$ide->owner->mail})</comment>"],
           ["IDE URL: <href={$ide->links->ide->href}>{$ide->links->ide->href}</>"],

--- a/src/Command/Ide/IdeListMineCommand.php
+++ b/src/Command/Ide/IdeListMineCommand.php
@@ -21,25 +21,25 @@ class IdeListMineCommand extends IdeCommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $ides = new Ides($acquia_cloud_client);
-    $account_ides = $ides->getMine();
-    $application_resource = new Applications($acquia_cloud_client);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $ides = new Ides($acquiaCloudClient);
+    $accountIdes = $ides->getMine();
+    $applicationResource = new Applications($acquiaCloudClient);
 
-    if (count($account_ides)) {
+    if (count($accountIdes)) {
       $table = new Table($output);
       $table->setStyle('borderless');
       $table->setHeaders(['IDEs']);
-      foreach ($account_ides as $ide) {
-        $app_url_parts = explode('/', $ide->links->application->href);
-        $app_uuid = end($app_url_parts);
-        $application = $application_resource->get($app_uuid);
-        $application_url = str_replace('/api', '/a', $application->links->self->href);
+      foreach ($accountIdes as $ide) {
+        $appUrlParts = explode('/', $ide->links->application->href);
+        $appUuid = end($appUrlParts);
+        $application = $applicationResource->get($appUuid);
+        $applicationUrl = str_replace('/api', '/a', $application->links->self->href);
 
         $table->addRows([
           ["<comment>$ide->label</comment>"],
           ["UUID: $ide->uuid"],
-          ["Application: <href=$application_url>$application->name</>"],
+          ["Application: <href=$applicationUrl>$application->name</>"],
           ["Subscription: {$application->subscription->name}"],
           ["IDE URL: <href={$ide->links->ide->href}>{$ide->links->ide->href}</>"],
           ["Web URL: <href={$ide->links->web->href}>{$ide->links->web->href}</>"],

--- a/src/Command/Ide/IdeOpenCommand.php
+++ b/src/Command/Ide/IdeOpenCommand.php
@@ -22,10 +22,10 @@ class IdeOpenCommand extends IdeCommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $cloud_application_uuid = $this->determineCloudApplication();
-    $ides_resource = new Ides($acquia_cloud_client);
-    $ide = $this->promptIdeChoice("Select the IDE you'd like to open:", $ides_resource, $cloud_application_uuid);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $cloudApplicationUuid = $this->determineCloudApplication();
+    $idesResource = new Ides($acquiaCloudClient);
+    $ide = $this->promptIdeChoice("Select the IDE you'd like to open:", $idesResource, $cloudApplicationUuid);
 
     $this->output->writeln('');
     $this->output->writeln("<comment>Your IDE URL:</comment> <href={$ide->links->ide->href}>{$ide->links->ide->href}</>");

--- a/src/Command/Ide/IdePhpVersionCommand.php
+++ b/src/Command/Ide/IdePhpVersionCommand.php
@@ -55,8 +55,8 @@ class IdePhpVersionCommand extends IdeCommandBase {
 
   protected function validatePhpVersion(string $version): string {
     parent::validatePhpVersion($version);
-    $php_filepath = $this->getIdePhpFilePathPrefix() . $version;
-    if (!$this->localMachineHelper->getFilesystem()->exists($php_filepath)) {
+    $phpFilepath = $this->getIdePhpFilePathPrefix() . $version;
+    if (!$this->localMachineHelper->getFilesystem()->exists($phpFilepath)) {
       throw new AcquiaCliException('The specified PHP version does not exist on this machine.');
     }
 

--- a/src/Command/Ide/IdeServiceRestartCommand.php
+++ b/src/Command/Ide/IdeServiceRestartCommand.php
@@ -35,7 +35,7 @@ class IdeServiceRestartCommand extends IdeCommandBase {
     $service = $input->getArgument('service');
     $this->validateService($service);
 
-    $service_name_map = [
+    $serviceNameMap = [
       'apache' => 'apache2',
       'apache2' => 'apache2',
       'mysql' => 'mysqld',
@@ -44,8 +44,8 @@ class IdeServiceRestartCommand extends IdeCommandBase {
       'php-fpm' => 'php-fpm',
     ];
     $output->writeln("Restarting <options=bold>$service</>...");
-    $service_name = $service_name_map[$service];
-    $this->restartService($service_name);
+    $serviceName = $serviceNameMap[$service];
+    $this->restartService($serviceName);
     $output->writeln("<info>Restarted <options=bold>$service</></info>");
 
     return 0;

--- a/src/Command/Ide/IdeServiceStartCommand.php
+++ b/src/Command/Ide/IdeServiceStartCommand.php
@@ -35,7 +35,7 @@ class IdeServiceStartCommand extends IdeCommandBase {
     $service = $input->getArgument('service');
     $this->validateService($service);
 
-    $service_name_map = [
+    $serviceNameMap = [
       'apache' => 'apache2',
       'apache2' => 'apache2',
       'mysql' => 'mysqld',
@@ -44,8 +44,8 @@ class IdeServiceStartCommand extends IdeCommandBase {
       'php-fpm' => 'php-fpm',
     ];
     $output->writeln("Starting <options=bold>$service</>...");
-    $service_name = $service_name_map[$service];
-    $this->startService($service_name);
+    $serviceName = $serviceNameMap[$service];
+    $this->startService($serviceName);
     $output->writeln("<info>Started <options=bold>$service</></info>");
 
     return 0;

--- a/src/Command/Ide/IdeServiceStopCommand.php
+++ b/src/Command/Ide/IdeServiceStopCommand.php
@@ -35,7 +35,7 @@ class IdeServiceStopCommand extends IdeCommandBase {
     $service = $input->getArgument('service');
     $this->validateService($service);
 
-    $service_name_map = [
+    $serviceNameMap = [
       'apache' => 'apache2',
       'apache2' => 'apache2',
       'mysql' => 'mysqld',
@@ -44,8 +44,8 @@ class IdeServiceStopCommand extends IdeCommandBase {
       'php-fpm' => 'php-fpm',
     ];
     $output->writeln("Stopping <options=bold>$service</>...");
-    $service_name = $service_name_map[$service];
-    $this->stopService($service_name);
+    $serviceName = $serviceNameMap[$service];
+    $this->stopService($serviceName);
     $output->writeln("<info>Stopped <options=bold>$service</></info>");
 
     return 0;

--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -39,22 +39,22 @@ class IdeShareCommand extends CommandBase {
       $this->regenerateShareCode();
     }
 
-    $share_uuid = $this->localMachineHelper->readFile($this->getShareCodeFilepaths()[0]);
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $ides_resource = new Ides($acquia_cloud_client);
-    $ide = $ides_resource->get($this::getThisCloudIdeUuid());
+    $shareUuid = $this->localMachineHelper->readFile($this->getShareCodeFilepaths()[0]);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $idesResource = new Ides($acquiaCloudClient);
+    $ide = $idesResource->get($this::getThisCloudIdeUuid());
 
     $this->output->writeln('');
-    $this->output->writeln("<comment>Your IDE Share URL:</comment> <href={$ide->links->web->href}>{$ide->links->web->href}?share=$share_uuid</>");
+    $this->output->writeln("<comment>Your IDE Share URL:</comment> <href={$ide->links->web->href}>{$ide->links->web->href}?share=$shareUuid</>");
 
     return 0;
   }
 
   /**
-   * @param array $file_path
+   * @param array $filePath
    */
-  public function setShareCodeFilepaths(array $file_path): void {
-    $this->shareCodeFilepaths = $file_path;
+  public function setShareCodeFilepaths(array $filePath): void {
+    $this->shareCodeFilepaths = $filePath;
   }
 
   /**
@@ -71,9 +71,9 @@ class IdeShareCommand extends CommandBase {
   }
 
   private function regenerateShareCode(): void {
-    $new_share_code = Uuid::uuid4();
+    $newShareCode = Uuid::uuid4();
     foreach ($this->getShareCodeFilepaths() as $path) {
-      $this->localMachineHelper->writeFile($path, $new_share_code);
+      $this->localMachineHelper->writeFile($path, $newShareCode);
     }
   }
 

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -28,18 +28,18 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->requireCloudIdeEnvironment();
-    $ini_file = $this->getXdebugIniFilePath();
-    $contents = file_get_contents($ini_file);
+    $iniFile = $this->getXdebugIniFilePath();
+    $contents = file_get_contents($iniFile);
     $this->setXDebugStatus($contents);
 
     if ($this->getXDebugStatus() === FALSE) {
-      $this->enableXDebug($ini_file, $contents);
+      $this->enableXDebug($iniFile, $contents);
     }
     elseif ($this->getXDebugStatus() === TRUE) {
-      $this->disableXDebug($ini_file, $contents);
+      $this->disableXDebug($iniFile, $contents);
     }
     else {
-      throw new AcquiaCliException("Could not find xdebug zend extension in $ini_file!");
+      throw new AcquiaCliException("Could not find xdebug zend extension in $iniFile!");
     }
     $this->restartService('php-fpm');
 
@@ -80,12 +80,12 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    * @param string $contents
    *   The contents of php.ini.
    */
-  private function enableXDebug(string $destination_file, string $contents): void {
-    $this->logger->notice("Enabling Xdebug PHP extension in $destination_file...");
+  private function enableXDebug(string $destinationFile, string $contents): void {
+    $this->logger->notice("Enabling Xdebug PHP extension in $destinationFile...");
 
     // Note that this replaces 1 or more ";" characters.
-    $new_contents = preg_replace('/(;)+(zend_extension=xdebug\.so)/', '$2', $contents);
-    file_put_contents($destination_file, $new_contents);
+    $newContents = preg_replace('/(;)+(zend_extension=xdebug\.so)/', '$2', $contents);
+    file_put_contents($destinationFile, $newContents);
     $this->output->writeln("<info>Xdebug PHP extension enabled.</info>");
     $this->output->writeln("You must also enable Xdebug listening in your code editor to begin a debugging session.");
   }
@@ -96,10 +96,10 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
    * @param string $contents
    *   The contents of php.ini.
    */
-  private function disableXDebug(string $destination_file, string $contents): void {
-    $this->logger->notice("Disabling Xdebug PHP extension in $destination_file...");
-    $new_contents = preg_replace('/(;)*(zend_extension=xdebug\.so)/', ';$2', $contents);
-    file_put_contents($destination_file, $new_contents);
+  private function disableXDebug(string $destinationFile, string $contents): void {
+    $this->logger->notice("Disabling Xdebug PHP extension in $destinationFile...");
+    $newContents = preg_replace('/(;)*(zend_extension=xdebug\.so)/', ';$2', $contents);
+    file_put_contents($destinationFile, $newContents);
     $this->output->writeln("<info>Xdebug PHP extension disabled.</info>");
   }
 

--- a/src/Command/Ide/Wizard/IdeWizardCommandBase.php
+++ b/src/Command/Ide/Wizard/IdeWizardCommandBase.php
@@ -31,16 +31,16 @@ abstract class IdeWizardCommandBase extends WizardCommandBase {
     $this->ideUuid = $this::getThisCloudIdeUuid();
     $this->setSshKeyFilepath(self::getSshKeyFilename($this->ideUuid));
     $this->passphraseFilepath = $this->localMachineHelper->getLocalFilepath('~/.passphrase');
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $ides_resource = new Ides($acquia_cloud_client);
-    $this->ide = $ides_resource->get($this->ideUuid);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $idesResource = new Ides($acquiaCloudClient);
+    $this->ide = $idesResource->get($this->ideUuid);
   }
 
   /**
-   * @param $ide_uuid
+   * @param $ideUuid
    */
-  public static function getSshKeyFilename($ide_uuid): string {
-    return 'id_rsa_acquia_ide_' . $ide_uuid;
+  public static function getSshKeyFilename($ideUuid): string {
+    return 'id_rsa_acquia_ide_' . $ideUuid;
   }
 
   protected function validateEnvironment(): void {
@@ -52,8 +52,8 @@ abstract class IdeWizardCommandBase extends WizardCommandBase {
   }
 
   protected function deleteThisSshKeyFromCloud($output): void {
-    if ($cloud_key = $this->findIdeSshKeyOnCloud($this::getThisCloudIdeUuid())) {
-      $this->deleteSshKeyFromCloud($output, $cloud_key);
+    if ($cloudKey = $this->findIdeSshKeyOnCloud($this::getThisCloudIdeUuid())) {
+      $this->deleteSshKeyFromCloud($output, $cloudKey);
     }
   }
 

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -25,11 +25,11 @@ class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
     $checklist = new Checklist($output);
 
     // Get Cloud account.
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $account_adapter = new Account($acquia_cloud_client);
-    $account = $account_adapter->get();
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $accountAdapter = new Account($acquiaCloudClient);
+    $account = $accountAdapter->get();
     $this->validateRequiredCloudPermissions(
-      $acquia_cloud_client,
+      $acquiaCloudClient,
       self::getThisCloudIdeCloudAppUuid(),
       $account,
       [
@@ -40,7 +40,7 @@ class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
       ]
     );
 
-    $key_was_uploaded = FALSE;
+    $keyWasUploaded = FALSE;
     // Create local SSH key.
     if (!$this->localSshKeyExists() || !$this->passPhraseFileExists()) {
       // Just in case the public key exists and the private doesn't, remove the public key.
@@ -56,7 +56,7 @@ class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
       $this->createSshKey($this->privateSshKeyFilename, $password);
 
       $checklist->completePreviousItem();
-      $key_was_uploaded = TRUE;
+      $keyWasUploaded = TRUE;
     }
     else {
       $checklist->addItem('Already created a local key');
@@ -70,12 +70,12 @@ class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
       // Just in case there is an uploaded key,  but it doesn't actually match
       // the local key, delete remote key!
       $this->deleteThisSshKeyFromCloud($output);
-      $public_key = $this->localMachineHelper->readFile($this->publicSshKeyFilepath);
-      $chosen_local_key = basename($this->publicSshKeyFilepath);
-      $this->uploadSshKey($this->getSshKeyLabel(), $public_key);
+      $publicKey = $this->localMachineHelper->readFile($this->publicSshKeyFilepath);
+      $chosenLocalKey = basename($this->publicSshKeyFilepath);
+      $this->uploadSshKey($this->getSshKeyLabel(), $publicKey);
 
       $checklist->completePreviousItem();
-      $key_was_uploaded = TRUE;
+      $keyWasUploaded = TRUE;
     }
     else {
       $checklist->addItem('Already uploaded the local key to the Cloud Platform');
@@ -93,7 +93,7 @@ class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
     $checklist->completePreviousItem();
 
     // Wait for the key to register on the Cloud Platform.
-    if ($key_was_uploaded) {
+    if ($keyWasUploaded) {
       if ($this->input->isInteractive() && !$this->promptWaitForSsh($this->io)) {
         $this->io->success('Your SSH key has been successfully uploaded to the Cloud Platform.');
         return 0;

--- a/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
@@ -25,12 +25,12 @@ class IdeWizardDeleteSshKeyCommand extends IdeWizardCommandBase {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->requireCloudIdeEnvironment();
 
-    $cloud_key = $this->findIdeSshKeyOnCloud($this::getThisCloudIdeUuid());
-    if (!$cloud_key) {
+    $cloudKey = $this->findIdeSshKeyOnCloud($this::getThisCloudIdeUuid());
+    if (!$cloudKey) {
       throw new AcquiaCliException('Could not find an SSH key on the Cloud Platform matching any local key in this IDE.');
     }
 
-    $this->deleteSshKeyFromCloud($output, $cloud_key);
+    $this->deleteSshKeyFromCloud($output, $cloudKey);
     $this->deleteLocalSshKey();
 
     $this->output->writeln("<info>Deleted local files <options=bold>{$this->publicSshKeyFilepath}</> and <options=bold>{$this->privateSshKeyFilepath}</>");

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -29,9 +29,9 @@ class PullCodeCommand extends PullCommandBase {
     $this->checkEnvironmentPhpVersions($this->sourceEnvironment);
     $this->matchIdePhpVersion($output, $this->sourceEnvironment);
     if (!$input->getOption('no-scripts')) {
-      $output_callback = $this->getOutputCallback($output, $this->checklist);
-      $this->runComposerScripts($output_callback);
-      $this->runDrushCacheClear($output_callback);
+      $outputCallback = $this->getOutputCallback($output, $this->checklist);
+      $this->runComposerScripts($outputCallback);
+      $this->runDrushCacheClear($outputCallback);
     }
 
     return 0;

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -46,10 +46,10 @@ abstract class PullCommandBase extends CommandBase {
   /**
    * @param $environment
    * @param \AcquiaCloudApi\Response\DatabaseResponse $database
-   * @param $backup_response
+   * @param $backupResponse
    * @return string
    */
-  public static function getBackupPath($environment, DatabaseResponse $database, $backup_response): string {
+  public static function getBackupPath($environment, DatabaseResponse $database, $backupResponse): string {
     // Databases have a machine name not exposed via the API; we can only
     // approximately reconstruct it and match the filename you'd get downloading
     // a backup from Cloud UI.
@@ -63,7 +63,7 @@ abstract class PullCommandBase extends CommandBase {
         $environment->name,
         $database->name,
         $dbMachineName,
-        $backup_response->completedAt,
+        $backupResponse->completedAt,
       ]) . '.sql.gz';
     return Path::join(sys_get_temp_dir(), $filename);
   }
@@ -83,54 +83,54 @@ abstract class PullCommandBase extends CommandBase {
   protected function pullCode(InputInterface $input, OutputInterface $output): void {
     $this->setDirAndRequireProjectCwd($input);
     $clone = $this->determineCloneProject($output);
-    $source_environment = $this->determineEnvironment($input, $output, TRUE);
+    $sourceEnvironment = $this->determineEnvironment($input, $output, TRUE);
 
     if ($clone) {
       $this->checklist->addItem('Cloning git repository from the Cloud Platform');
-      $this->cloneFromCloud($source_environment, $this->getOutputCallback($output, $this->checklist));
+      $this->cloneFromCloud($sourceEnvironment, $this->getOutputCallback($output, $this->checklist));
     }
     else {
       $this->checklist->addItem('Pulling code from the Cloud Platform');
-      $this->pullCodeFromCloud($source_environment, $this->getOutputCallback($output, $this->checklist));
+      $this->pullCodeFromCloud($sourceEnvironment, $this->getOutputCallback($output, $this->checklist));
     }
     $this->checklist->completePreviousItem();
   }
 
   /**
-   * @param bool $on_demand Force on-demand backup.
-   * @param bool $no_import Skip import.
+   * @param bool $onDemand Force on-demand backup.
+   * @param bool $noImport Skip import.
    */
-  protected function pullDatabase(InputInterface $input, OutputInterface $output, bool $on_demand = FALSE, bool $no_import = FALSE, bool $multiple_dbs = FALSE): void {
-    if (!$no_import) {
+  protected function pullDatabase(InputInterface $input, OutputInterface $output, bool $onDemand = FALSE, bool $noImport = FALSE, bool $multipleDbs = FALSE): void {
+    if (!$noImport) {
       // Verify database connection.
       $this->connectToLocalDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $this->getOutputCallback($output, $this->checklist));
     }
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $source_environment = $this->determineEnvironment($input, $output, TRUE);
-    $site = $this->determineSite($source_environment, $input);
-    $databases = $this->determineCloudDatabases($acquia_cloud_client, $source_environment, $site, $multiple_dbs);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $sourceEnvironment = $this->determineEnvironment($input, $output, TRUE);
+    $site = $this->determineSite($sourceEnvironment, $input);
+    $databases = $this->determineCloudDatabases($acquiaCloudClient, $sourceEnvironment, $site, $multipleDbs);
 
     foreach ($databases as $database) {
-      if ($on_demand) {
+      if ($onDemand) {
         $this->checklist->addItem("Creating an on-demand database(s) backup on Cloud Platform");
-        $this->createBackup($source_environment, $database, $acquia_cloud_client);
+        $this->createBackup($sourceEnvironment, $database, $acquiaCloudClient);
         $this->checklist->completePreviousItem();
       }
-      $backup_response = $this->getDatabaseBackup($acquia_cloud_client, $source_environment, $database);
-      if (!$on_demand) {
-        $this->printDatabaseBackupInfo($backup_response, $source_environment);
+      $backupResponse = $this->getDatabaseBackup($acquiaCloudClient, $sourceEnvironment, $database);
+      if (!$onDemand) {
+        $this->printDatabaseBackupInfo($backupResponse, $sourceEnvironment);
       }
 
       $this->checklist->addItem("Downloading {$database->name} database copy from the Cloud Platform");
-      $local_filepath = $this->downloadDatabaseBackup($source_environment, $database, $backup_response, $this->getOutputCallback($output, $this->checklist));
+      $localFilepath = $this->downloadDatabaseBackup($sourceEnvironment, $database, $backupResponse, $this->getOutputCallback($output, $this->checklist));
       $this->checklist->completePreviousItem();
 
-      if ($no_import) {
-        $this->io->success("{$database->name} database backup downloaded to $local_filepath");
+      if ($noImport) {
+        $this->io->success("{$database->name} database backup downloaded to $localFilepath");
       }
       else {
         $this->checklist->addItem("Importing {$database->name} database download");
-        $this->importRemoteDatabase($database, $local_filepath, $this->getOutputCallback($output, $this->checklist));
+        $this->importRemoteDatabase($database, $localFilepath, $this->getOutputCallback($output, $this->checklist));
         $this->checklist->completePreviousItem();
       }
     }
@@ -138,16 +138,16 @@ abstract class PullCommandBase extends CommandBase {
 
   protected function pullFiles(InputInterface $input, OutputInterface $output): void {
     $this->setDirAndRequireProjectCwd($input);
-    $source_environment = $this->determineEnvironment($input, $output, TRUE);
+    $sourceEnvironment = $this->determineEnvironment($input, $output, TRUE);
     $this->checklist->addItem('Copying Drupal\'s public files from the Cloud Platform');
-    $site = $this->determineSite($source_environment, $input);
-    $this->rsyncFilesFromCloud($source_environment, $this->getOutputCallback($output, $this->checklist), $site);
+    $site = $this->determineSite($sourceEnvironment, $input);
+    $this->rsyncFilesFromCloud($sourceEnvironment, $this->getOutputCallback($output, $this->checklist), $site);
     $this->checklist->completePreviousItem();
   }
 
-  private function pullCodeFromCloud(EnvironmentResponse $chosen_environment, Closure $output_callback = NULL): void {
-    $is_dirty = $this->isLocalGitRepoDirty();
-    if ($is_dirty) {
+  private function pullCodeFromCloud(EnvironmentResponse $chosenEnvironment, Closure $outputCallback = NULL): void {
+    $isDirty = $this->isLocalGitRepoDirty();
+    if ($isDirty) {
       throw new AcquiaCliException('Pulling code from your Cloud Platform environment was aborted because your local Git repository has uncommitted changes. Either commit, reset, or stash your changes via git.');
     }
     // @todo Validate that an Acquia remote is configured for this repository.
@@ -156,46 +156,46 @@ abstract class PullCommandBase extends CommandBase {
       'git',
       'fetch',
       '--all',
-    ], $output_callback, $this->dir, FALSE);
-    $this->checkoutBranchFromEnv($chosen_environment, $output_callback);
+    ], $outputCallback, $this->dir, FALSE);
+    $this->checkoutBranchFromEnv($chosenEnvironment, $outputCallback);
   }
 
   /**
    * Checks out the matching branch from a source environment.
    */
-  private function checkoutBranchFromEnv(EnvironmentResponse $environment, Closure $output_callback = NULL): void {
+  private function checkoutBranchFromEnv(EnvironmentResponse $environment, Closure $outputCallback = NULL): void {
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
     $this->localMachineHelper->execute([
       'git',
       'checkout',
       $environment->vcs->path,
-    ], $output_callback, $this->dir, FALSE);
+    ], $outputCallback, $this->dir, FALSE);
   }
 
   private function doImportRemoteDatabase(
-    string $database_host,
-    string $database_user,
-    string $database_name,
-    string $database_password,
-    string $local_filepath,
-    Closure $output_callback = NULL
+    string $databaseHost,
+    string $databaseUser,
+    string $databaseName,
+    string $databasePassword,
+    string $localFilepath,
+    Closure $outputCallback = NULL
   ): void {
-    $this->dropLocalDatabase($database_host, $database_user, $database_name, $database_password, $output_callback);
-    $this->createLocalDatabase($database_host, $database_user, $database_name, $database_password, $output_callback);
-    $this->importDatabaseDump($local_filepath, $database_host, $database_user, $database_name, $database_password, $output_callback);
-    $this->localMachineHelper->getFilesystem()->remove($local_filepath);
+    $this->dropLocalDatabase($databaseHost, $databaseUser, $databaseName, $databasePassword, $outputCallback);
+    $this->createLocalDatabase($databaseHost, $databaseUser, $databaseName, $databasePassword, $outputCallback);
+    $this->importDatabaseDump($localFilepath, $databaseHost, $databaseUser, $databaseName, $databasePassword, $outputCallback);
+    $this->localMachineHelper->getFilesystem()->remove($localFilepath);
   }
 
   private function downloadDatabaseBackup(
     EnvironmentResponse $environment,
     DatabaseResponse $database,
-    BackupResponse $backup_response,
-    callable $output_callback = NULL
+    BackupResponse $backupResponse,
+    callable $outputCallback = NULL
   ): string {
-    if ($output_callback) {
-      $output_callback('out', "Downloading backup $backup_response->id");
+    if ($outputCallback) {
+      $outputCallback('out', "Downloading backup $backupResponse->id");
     }
-    $local_filepath = self::getBackupPath($environment, $database, $backup_response);
+    $localFilepath = self::getBackupPath($environment, $database, $backupResponse);
     if ($this->output instanceof ConsoleOutput) {
       $output = $this->output->section();
     }
@@ -203,43 +203,43 @@ abstract class PullCommandBase extends CommandBase {
       $output = $this->output;
     }
     // These options tell curl to stream the file to disk rather than loading it into memory.
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $acquia_cloud_client->addOption('sink', $local_filepath);
-    $acquia_cloud_client->addOption('curl.options', [
-      'CURLOPT_FILE' => $local_filepath,
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $acquiaCloudClient->addOption('sink', $localFilepath);
+    $acquiaCloudClient->addOption('curl.options', [
+      'CURLOPT_FILE' => $localFilepath,
       'CURLOPT_RETURNTRANSFER' => FALSE,
 ]);
-    $acquia_cloud_client->addOption('progress', static function ($total_bytes, $downloaded_bytes) use (&$progress, $output): void {
-      self::displayDownloadProgress($total_bytes, $downloaded_bytes, $progress, $output);
+    $acquiaCloudClient->addOption('progress', static function ($totalBytes, $downloadedBytes) use (&$progress, $output): void {
+      self::displayDownloadProgress($totalBytes, $downloadedBytes, $progress, $output);
     });
     // This is really just used to allow us to inject values for $url during testing.
     // It should be empty during normal operations.
     $url = $this->getBackupDownloadUrl();
-    $acquia_cloud_client->addOption('on_stats', function (TransferStats $stats) use (&$url): void {
+    $acquiaCloudClient->addOption('on_stats', function (TransferStats $stats) use (&$url): void {
       $url = $stats->getEffectiveUri();
     });
 
     try {
-      $acquia_cloud_client->stream("get", "/environments/$environment->uuid/databases/$database->name/backups/$backup_response->id/actions/download", $acquia_cloud_client->getOptions());
-      return $local_filepath;
+      $acquiaCloudClient->stream("get", "/environments/$environment->uuid/databases/$database->name/backups/$backupResponse->id/actions/download", $acquiaCloudClient->getOptions());
+      return $localFilepath;
     }
     catch (RequestException $exception) {
       // Deal with broken SSL certificates.
       // @see https://timi.eu/docs/anatella/5_1_9_1_list_of_curl_error_codes.html
       if (in_array($exception->getHandlerContext()['errno'], [51, 60], TRUE)) {
-        $output_callback('out', '<comment>The certificate for ' . $url->getHost() . ' is invalid.</comment>');
+        $outputCallback('out', '<comment>The certificate for ' . $url->getHost() . ' is invalid.</comment>');
         assert($url !== NULL);
-        $domains_resource = new Domains($this->cloudApiClientService->getClient());
-        $domains = $domains_resource->getAll($environment->uuid);
+        $domainsResource = new Domains($this->cloudApiClientService->getClient());
+        $domains = $domainsResource->getAll($environment->uuid);
         foreach ($domains as $domain) {
           if ($domain->hostname === $url->getHost()) {
             continue;
           }
-          $output_callback('out', '<comment>Trying alternative host ' . $domain->hostname . ' </comment>');
-          $download_url = $url->withHost($domain->hostname);
+          $outputCallback('out', '<comment>Trying alternative host ' . $domain->hostname . ' </comment>');
+          $downloadUrl = $url->withHost($domain->hostname);
           try {
-            $this->httpClient->request('GET', $download_url, ['sink' => $local_filepath]);
-            return $local_filepath;
+            $this->httpClient->request('GET', $downloadUrl, ['sink' => $localFilepath]);
+            return $localFilepath;
           }
           catch (Exception) {
             // Continue in the foreach() loop.
@@ -261,13 +261,13 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   /**
-   * @param $total_bytes
-   * @param $downloaded_bytes
+   * @param $totalBytes
+   * @param $downloadedBytes
    * @param $progress
    */
-  public static function displayDownloadProgress($total_bytes, $downloaded_bytes, &$progress, OutputInterface $output): void {
-    if ($total_bytes > 0 && is_null($progress)) {
-      $progress = new ProgressBar($output, $total_bytes);
+  public static function displayDownloadProgress($totalBytes, $downloadedBytes, &$progress, OutputInterface $output): void {
+    if ($totalBytes > 0 && is_null($progress)) {
+      $progress = new ProgressBar($output, $totalBytes);
       $progress->setFormat('        %current%/%max% [%bar%] %percent:3s%%');
       $progress->setProgressCharacter('💧');
       $progress->setOverwrite(TRUE);
@@ -275,26 +275,26 @@ abstract class PullCommandBase extends CommandBase {
     }
 
     if (!is_null($progress)) {
-      if ($total_bytes === $downloaded_bytes && $progress->getProgressPercent() !== 1.0) {
+      if ($totalBytes === $downloadedBytes && $progress->getProgressPercent() !== 1.0) {
         $progress->finish();
         if ($output instanceof ConsoleSectionOutput) {
           $output->clear();
         }
         return;
       }
-      $progress->setProgress($downloaded_bytes);
+      $progress->setProgress($downloadedBytes);
     }
   }
 
   /**
    * Create an on-demand backup and wait for it to become available.
    */
-  private function createBackup(EnvironmentResponse $environment, DatabaseResponse $database, Client $acquia_cloud_client): void {
-    $backups = new DatabaseBackups($acquia_cloud_client);
+  private function createBackup(EnvironmentResponse $environment, DatabaseResponse $database, Client $acquiaCloudClient): void {
+    $backups = new DatabaseBackups($acquiaCloudClient);
     $response = $backups->create($environment->uuid, $database->name);
-    $url_parts = explode('/', $response->links->notification->href);
-    $notification_uuid = end($url_parts);
-    $this->waitForBackup($notification_uuid, $acquia_cloud_client);
+    $urlParts = explode('/', $response->links->notification->href);
+    $notificationUuid = end($urlParts);
+    $this->waitForBackup($notificationUuid, $acquiaCloudClient);
   }
 
   /**
@@ -302,102 +302,102 @@ abstract class PullCommandBase extends CommandBase {
    *
    * @infection-ignore-all
    */
-  protected function waitForBackup(string $notification_uuid, Client $acquia_cloud_client): void {
+  protected function waitForBackup(string $notificationUuid, Client $acquiaCloudClient): void {
     $spinnerMessage = 'Waiting for database backup to complete...';
     $successCallback = function (): void {
       $this->output->writeln('');
       $this->output->writeln('<info>Database backup is ready!</info>');
     };
-    $this->waitForNotificationToComplete($acquia_cloud_client, $notification_uuid, $spinnerMessage, $successCallback);
+    $this->waitForNotificationToComplete($acquiaCloudClient, $notificationUuid, $spinnerMessage, $successCallback);
     Loop::run();
   }
 
-  private function connectToLocalDatabase(string $db_host, string $db_user, string $db_name, string $db_password, callable $output_callback = NULL): void {
-    if ($output_callback) {
-      $output_callback('out', "Connecting to database $db_name");
+  private function connectToLocalDatabase(string $dbHost, string $dbUser, string $dbName, string $dbPassword, callable $outputCallback = NULL): void {
+    if ($outputCallback) {
+      $outputCallback('out', "Connecting to database $dbName");
     }
     $this->localMachineHelper->checkRequiredBinariesExist(['mysql']);
     $command = [
       'mysql',
       '--host',
-      $db_host,
+      $dbHost,
       '--user',
-      $db_user,
-      $db_name,
+      $dbUser,
+      $dbName,
     ];
-    $process = $this->localMachineHelper->execute($command, $output_callback, NULL, FALSE, NULL, ['MYSQL_PWD' => $db_password]);
+    $process = $this->localMachineHelper->execute($command, $outputCallback, NULL, FALSE, NULL, ['MYSQL_PWD' => $dbPassword]);
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Unable to connect to local database using credentials mysql:://{user}:{password}@{host}/{database}. {message}', [
-        'database' => $db_name,
-        'host' => $db_host,
+        'database' => $dbName,
+        'host' => $dbHost,
         'message' => $process->getErrorOutput(),
-        'password' => $db_password,
-        'user' => $db_user,
+        'password' => $dbPassword,
+        'user' => $dbUser,
       ]);
     }
   }
 
   /**
-   * @param callable|null $output_callback
+   * @param callable|null $outputCallback
    */
-  private function dropLocalDatabase(string $db_host, string $db_user, string $db_name, string $db_password, callable $output_callback = NULL): void {
-    if ($output_callback) {
-      $output_callback('out', "Dropping database $db_name");
+  private function dropLocalDatabase(string $dbHost, string $dbUser, string $dbName, string $dbPassword, callable $outputCallback = NULL): void {
+    if ($outputCallback) {
+      $outputCallback('out', "Dropping database $dbName");
     }
     $this->localMachineHelper->checkRequiredBinariesExist(['mysql']);
     $command = [
       'mysql',
       '--host',
-      $db_host,
+      $dbHost,
       '--user',
-      $db_user,
+      $dbUser,
       '-e',
-      'DROP DATABASE IF EXISTS ' . $db_name,
+      'DROP DATABASE IF EXISTS ' . $dbName,
     ];
-    $process = $this->localMachineHelper->execute($command, $output_callback, NULL, FALSE, NULL, ['MYSQL_PWD' => $db_password]);
+    $process = $this->localMachineHelper->execute($command, $outputCallback, NULL, FALSE, NULL, ['MYSQL_PWD' => $dbPassword]);
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Unable to drop a local database. {message}', ['message' => $process->getErrorOutput()]);
     }
   }
 
   /**
-   * @param callable|null $output_callback
+   * @param callable|null $outputCallback
    */
-  private function createLocalDatabase(string $db_host, string $db_user, string $db_name, string $db_password, callable $output_callback = NULL): void {
-    if ($output_callback) {
-      $output_callback('out', "Creating new empty database $db_name");
+  private function createLocalDatabase(string $dbHost, string $dbUser, string $dbName, string $dbPassword, callable $outputCallback = NULL): void {
+    if ($outputCallback) {
+      $outputCallback('out', "Creating new empty database $dbName");
     }
     $this->localMachineHelper->checkRequiredBinariesExist(['mysql']);
     $command = [
       'mysql',
       '--host',
-      $db_host,
+      $dbHost,
       '--user',
-      $db_user,
+      $dbUser,
       '-e',
-      'create database ' . $db_name,
+      'create database ' . $dbName,
     ];
-    $process = $this->localMachineHelper->execute($command, $output_callback, NULL, FALSE, NULL, ['MYSQL_PWD' => $db_password]);
+    $process = $this->localMachineHelper->execute($command, $outputCallback, NULL, FALSE, NULL, ['MYSQL_PWD' => $dbPassword]);
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Unable to create a local database. {message}', ['message' => $process->getErrorOutput()]);
     }
   }
 
-  private function importDatabaseDump(string $local_dump_filepath, string $db_host, string $db_user, string $db_name, string $db_password, Closure $output_callback = NULL): void {
-    if ($output_callback) {
-      $output_callback('out', "Importing downloaded file to database $db_name");
+  private function importDatabaseDump(string $localDumpFilepath, string $dbHost, string $dbUser, string $dbName, string $dbPassword, Closure $outputCallback = NULL): void {
+    if ($outputCallback) {
+      $outputCallback('out', "Importing downloaded file to database $dbName");
     }
-    $this->logger->debug("Importing $local_dump_filepath to MySQL on local machine");
+    $this->logger->debug("Importing $localDumpFilepath to MySQL on local machine");
     $this->localMachineHelper->checkRequiredBinariesExist(['gunzip', 'mysql']);
     if ($this->localMachineHelper->commandExists('pv')) {
-      $command = "pv $local_dump_filepath --bytes --rate | gunzip | MYSQL_PWD=$db_password mysql --host=$db_host --user=$db_user $db_name";
+      $command = "pv $localDumpFilepath --bytes --rate | gunzip | MYSQL_PWD=$dbPassword mysql --host=$dbHost --user=$dbUser $dbName";
     }
     else {
       $this->io->warning('Install `pv` to see progress bar');
-      $command = "gunzip $local_dump_filepath | MYSQL_PWD=$db_password mysql --host=$db_host --user=$db_user $db_name";
+      $command = "gunzip $localDumpFilepath | MYSQL_PWD=$dbPassword mysql --host=$dbHost --user=$dbUser $dbName";
     }
 
-    $process = $this->localMachineHelper->executeFromCmd($command, $output_callback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
+    $process = $this->localMachineHelper->executeFromCmd($command, $outputCallback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Unable to import local database. {message}', ['message' => $process->getErrorOutput()]);
     }
@@ -430,97 +430,97 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   /**
-   * @param $acquia_cloud_client
+   * @param $acquiaCloudClient
    */
-  private function promptChooseEnvironment($acquia_cloud_client, string $application_uuid, bool $allow_production = FALSE): EnvironmentResponse {
-    $environment_resource = new Environments($acquia_cloud_client);
-    $application_environments = iterator_to_array($environment_resource->getAll($application_uuid));
+  private function promptChooseEnvironment($acquiaCloudClient, string $applicationUuid, bool $allowProduction = FALSE): EnvironmentResponse {
+    $environmentResource = new Environments($acquiaCloudClient);
+    $applicationEnvironments = iterator_to_array($environmentResource->getAll($applicationUuid));
     $choices = [];
-    foreach ($application_environments as $key => $environment) {
-      if (!$allow_production && $environment->flags->production) {
-        unset($application_environments[$key]);
+    foreach ($applicationEnvironments as $key => $environment) {
+      if (!$allowProduction && $environment->flags->production) {
+        unset($applicationEnvironments[$key]);
         // Re-index array so keys match those in $choices.
-        $application_environments = array_values($application_environments);
+        $applicationEnvironments = array_values($applicationEnvironments);
         continue;
       }
       $choices[] = "{$environment->label}, {$environment->name} (vcs: {$environment->vcs->path})";
     }
-    $chosen_environment_label = $this->io->choice('Choose a Cloud Platform environment', $choices, $choices[0]);
-    $chosen_environment_index = array_search($chosen_environment_label, $choices, TRUE);
+    $chosenEnvironmentLabel = $this->io->choice('Choose a Cloud Platform environment', $choices, $choices[0]);
+    $chosenEnvironmentIndex = array_search($chosenEnvironmentLabel, $choices, TRUE);
 
-    return $application_environments[$chosen_environment_index];
+    return $applicationEnvironments[$chosenEnvironmentIndex];
   }
 
   /**
-   * @param \AcquiaCloudApi\Response\EnvironmentResponse $cloud_environment
-   * @param \AcquiaCloudApi\Response\DatabasesResponse $environment_databases
-   * @param bool $multiple_dbs
+   * @param \AcquiaCloudApi\Response\EnvironmentResponse $cloudEnvironment
+   * @param \AcquiaCloudApi\Response\DatabasesResponse $environmentDatabases
+   * @param bool $multipleDbs
    * @return DatabaseResponse[]
    */
   private function promptChooseDatabases(
-    EnvironmentResponse $cloud_environment,
-    DatabasesResponse $environment_databases,
-    bool $multiple_dbs
+    EnvironmentResponse $cloudEnvironment,
+    DatabasesResponse $environmentDatabases,
+    bool $multipleDbs
   ): array {
     $choices = [];
-    if ($multiple_dbs) {
+    if ($multipleDbs) {
       $choices['all'] = 'All';
     }
-    $default_database_index = 0;
-    if ($this->isAcsfEnv($cloud_environment)) {
-      $acsf_sites = $this->getAcsfSites($cloud_environment);
+    $defaultDatabaseIndex = 0;
+    if ($this->isAcsfEnv($cloudEnvironment)) {
+      $acsfSites = $this->getAcsfSites($cloudEnvironment);
     }
-    foreach ($environment_databases as $index => $database) {
+    foreach ($environmentDatabases as $index => $database) {
       $suffix = '';
-      if (isset($acsf_sites)) {
-        foreach ($acsf_sites['sites'] as $domain => $acsf_site) {
-          if ($acsf_site['conf']['gardens_db_name'] === $database->name) {
+      if (isset($acsfSites)) {
+        foreach ($acsfSites['sites'] as $domain => $acsfSite) {
+          if ($acsfSite['conf']['gardens_db_name'] === $database->name) {
             $suffix .= ' (' . $domain . ')';
             break;
           }
         }
       }
       if ($database->flags->default) {
-        $default_database_index = $index;
+        $defaultDatabaseIndex = $index;
         $suffix .= ' (default)';
       }
       $choices[] = $database->name . $suffix;
     }
 
     $question = new ChoiceQuestion(
-      $multiple_dbs ? 'Choose databases. You may choose multiple. Use commas to separate choices.' : 'Choose a database.',
+      $multipleDbs ? 'Choose databases. You may choose multiple. Use commas to separate choices.' : 'Choose a database.',
       $choices,
-      $default_database_index
+      $defaultDatabaseIndex
     );
-    $question->setMultiselect($multiple_dbs);
-    if ($multiple_dbs) {
-      $chosen_database_keys = $this->io->askQuestion($question);
-      $chosen_databases = [];
-      if (count($chosen_database_keys) === 1 && $chosen_database_keys[0] === 'all') {
-        if (count($environment_databases) > 10) {
+    $question->setMultiselect($multipleDbs);
+    if ($multipleDbs) {
+      $chosenDatabaseKeys = $this->io->askQuestion($question);
+      $chosenDatabases = [];
+      if (count($chosenDatabaseKeys) === 1 && $chosenDatabaseKeys[0] === 'all') {
+        if (count($environmentDatabases) > 10) {
           $this->io->warning('You have chosen to pull down more than 10 databases. This could exhaust your disk space.');
         }
-        return (array) $environment_databases;
+        return (array) $environmentDatabases;
       }
-      foreach ($chosen_database_keys as $chosen_database_key) {
-        $chosen_databases[] = $environment_databases[$chosen_database_key];
+      foreach ($chosenDatabaseKeys as $chosenDatabaseKey) {
+        $chosenDatabases[] = $environmentDatabases[$chosenDatabaseKey];
       }
 
-      return $chosen_databases;
+      return $chosenDatabases;
     }
 
-    $chosen_database_label = $this->io->choice('Choose a database', $choices, $default_database_index);
-    $chosen_database_index = array_search($chosen_database_label, $choices, TRUE);
-    return [$environment_databases[$chosen_database_index]];
+    $chosenDatabaseLabel = $this->io->choice('Choose a database', $choices, $defaultDatabaseIndex);
+    $chosenDatabaseIndex = array_search($chosenDatabaseLabel, $choices, TRUE);
+    return [$environmentDatabases[$chosenDatabaseIndex]];
   }
 
   /**
-   * @param callable|null $output_callback
+   * @param callable|null $outputCallback
    */
-  protected function runComposerScripts(callable $output_callback = NULL): void {
+  protected function runComposerScripts(callable $outputCallback = NULL): void {
     if (file_exists($this->dir . '/composer.json') && $this->localMachineHelper->commandExists('composer')) {
       $this->checklist->addItem("Installing Composer dependencies");
-      $this->composerInstall($output_callback);
+      $this->composerInstall($outputCallback);
       $this->checklist->completePreviousItem();
     }
     else {
@@ -552,17 +552,17 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   /**
-   * @param $chosen_environment
-   * @param \Closure|null $output_callback
+   * @param $chosenEnvironment
+   * @param \Closure|null $outputCallback
    */
-  private function rsyncFilesFromCloud($chosen_environment, Closure $output_callback = NULL, string $site): void {
-    $sitegroup = self::getSiteGroupFromSshUrl($chosen_environment->sshUrl);
-    if ($this->isAcsfEnv($chosen_environment)) {
-      $source_dir = '/mnt/files/' . $sitegroup . '.' . $chosen_environment->name . '/sites/g/files/' . $site . '/files';
+  private function rsyncFilesFromCloud($chosenEnvironment, Closure $outputCallback = NULL, string $site): void {
+    $sitegroup = self::getSiteGroupFromSshUrl($chosenEnvironment->sshUrl);
+    if ($this->isAcsfEnv($chosenEnvironment)) {
+      $sourceDir = '/mnt/files/' . $sitegroup . '.' . $chosenEnvironment->name . '/sites/g/files/' . $site . '/files';
       $destination = $this->dir . '/docroot/sites/' . $site . '/';
     }
     else {
-      $source_dir = $this->getCloudSitesPath($chosen_environment, $sitegroup) . "/$site/files/";
+      $sourceDir = $this->getCloudSitesPath($chosenEnvironment, $sitegroup) . "/$site/files/";
       $destination = $this->dir . '/docroot/sites/' . $site . '/files';
     }
     $this->localMachineHelper->checkRequiredBinariesExist(['rsync']);
@@ -577,43 +577,43 @@ abstract class PullCommandBase extends CommandBase {
       // -e specify the remote shell to use.
       '-avPhze',
       'ssh -o StrictHostKeyChecking=no',
-      $chosen_environment->sshUrl . ':' . $source_dir,
+      $chosenEnvironment->sshUrl . ':' . $sourceDir,
       $destination,
     ];
-    $process = $this->localMachineHelper->execute($command, $output_callback, NULL, FALSE, 60 * 60);
+    $process = $this->localMachineHelper->execute($command, $outputCallback, NULL, FALSE, 60 * 60);
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Unable to sync files from Cloud. {message}', ['message' => $process->getErrorOutput()]);
     }
   }
 
   /**
-   * @param \AcquiaCloudApi\Connector\Client $acquia_cloud_client
-   * @param \AcquiaCloudApi\Response\EnvironmentResponse $chosen_environment
+   * @param \AcquiaCloudApi\Connector\Client $acquiaCloudClient
+   * @param \AcquiaCloudApi\Response\EnvironmentResponse $chosenEnvironment
    * @param string|null $site
-   * @param bool $multiple_dbs
+   * @param bool $multipleDbs
    * @return DatabaseResponse[]
    */
-  protected function determineCloudDatabases(Client $acquia_cloud_client, EnvironmentResponse $chosen_environment, string $site = NULL, bool $multiple_dbs = FALSE): array {
-    $databases_request = new Databases($acquia_cloud_client);
-    $databases = $databases_request->getAll($chosen_environment->uuid);
+  protected function determineCloudDatabases(Client $acquiaCloudClient, EnvironmentResponse $chosenEnvironment, string $site = NULL, bool $multipleDbs = FALSE): array {
+    $databasesRequest = new Databases($acquiaCloudClient);
+    $databases = $databasesRequest->getAll($chosenEnvironment->uuid);
 
     if (count($databases) === 1) {
       $this->logger->debug('Only a single database detected on Cloud');
       return [$databases[0]];
     }
     $this->logger->debug('Multiple databases detected on Cloud');
-    if ($site && !$multiple_dbs) {
+    if ($site && !$multipleDbs) {
       if ($site === 'default') {
         $this->logger->debug('Site is set to default. Assuming default database');
-        $site = self::getSiteGroupFromSshUrl($chosen_environment->sshUrl);
+        $site = self::getSiteGroupFromSshUrl($chosenEnvironment->sshUrl);
       }
-      $database_names = array_column((array) $databases, 'name');
-      $database_key = array_search($site, $database_names, TRUE);
-      if ($database_key !== FALSE) {
-        return [$databases[$database_key]];
+      $databaseNames = array_column((array) $databases, 'name');
+      $databaseKey = array_search($site, $databaseNames, TRUE);
+      if ($databaseKey !== FALSE) {
+        return [$databases[$databaseKey]];
       }
     }
-    return $this->promptChooseDatabases($chosen_environment, $databases, $multiple_dbs);
+    return $this->promptChooseDatabases($chosenEnvironment, $databases, $multipleDbs);
   }
 
   private function determineCloneProject(OutputInterface $output): bool {
@@ -645,41 +645,41 @@ abstract class PullCommandBase extends CommandBase {
     throw new AcquiaCliException('Execute this command from within a Drupal project directory or an empty directory');
   }
 
-  private function cloneFromCloud(EnvironmentResponse $chosen_environment, Closure $output_callback): void {
+  private function cloneFromCloud(EnvironmentResponse $chosenEnvironment, Closure $outputCallback): void {
     $this->localMachineHelper->checkRequiredBinariesExist(['git']);
     $command = [
       'git',
       'clone',
-      $chosen_environment->vcs->url,
+      $chosenEnvironment->vcs->url,
       $this->dir,
     ];
-    $process = $this->localMachineHelper->execute($command, $output_callback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL), NULL, ['GIT_SSH_COMMAND' => 'ssh -o StrictHostKeyChecking=no']);
-    $this->checkoutBranchFromEnv($chosen_environment, $output_callback);
+    $process = $this->localMachineHelper->execute($command, $outputCallback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL), NULL, ['GIT_SSH_COMMAND' => 'ssh -o StrictHostKeyChecking=no']);
+    $this->checkoutBranchFromEnv($chosenEnvironment, $outputCallback);
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Failed to clone repository from the Cloud Platform: {message}', ['message' => $process->getErrorOutput()]);
     }
     $this->projectDir = $this->dir;
   }
 
-  protected function determineEnvironment(InputInterface $input, OutputInterface $output, bool $allow_production = FALSE): array|string|EnvironmentResponse {
+  protected function determineEnvironment(InputInterface $input, OutputInterface $output, bool $allowProduction = FALSE): array|string|EnvironmentResponse {
     if (isset($this->sourceEnvironment)) {
       return $this->sourceEnvironment;
     }
 
     if ($input->getArgument('environmentId')) {
-      $environment_id = $input->getArgument('environmentId');
-      $chosen_environment = $this->getCloudEnvironment($environment_id);
+      $environmentId = $input->getArgument('environmentId');
+      $chosenEnvironment = $this->getCloudEnvironment($environmentId);
     }
     else {
-      $cloud_application_uuid = $this->determineCloudApplication();
-      $cloud_application = $this->getCloudApplication($cloud_application_uuid);
-      $output->writeln('Using Cloud Application <options=bold>' . $cloud_application->name . '</>');
-      $acquia_cloud_client = $this->cloudApiClientService->getClient();
-      $chosen_environment = $this->promptChooseEnvironment($acquia_cloud_client, $cloud_application_uuid, $allow_production);
+      $cloudApplicationUuid = $this->determineCloudApplication();
+      $cloudApplication = $this->getCloudApplication($cloudApplicationUuid);
+      $output->writeln('Using Cloud Application <options=bold>' . $cloudApplication->name . '</>');
+      $acquiaCloudClient = $this->cloudApiClientService->getClient();
+      $chosenEnvironment = $this->promptChooseEnvironment($acquiaCloudClient, $cloudApplicationUuid, $allowProduction);
     }
-    $this->logger->debug("Using environment {$chosen_environment->label} {$chosen_environment->uuid}");
+    $this->logger->debug("Using environment {$chosenEnvironment->label} {$chosenEnvironment->uuid}");
 
-    $this->sourceEnvironment = $chosen_environment;
+    $this->sourceEnvironment = $chosenEnvironment;
 
     return $this->sourceEnvironment;
   }
@@ -696,13 +696,13 @@ abstract class PullCommandBase extends CommandBase {
 
   protected function matchIdePhpVersion(
     OutputInterface $output,
-    EnvironmentResponse $chosen_environment
+    EnvironmentResponse $chosenEnvironment
   ): void {
-    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !$this->environmentPhpVersionMatches($chosen_environment)) {
-      $answer = $this->io->confirm("Would you like to change the PHP version on this IDE to match the PHP version on the <bg=cyan;options=bold>{$chosen_environment->label} ({$chosen_environment->configuration->php->version})</> environment?", FALSE);
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !$this->environmentPhpVersionMatches($chosenEnvironment)) {
+      $answer = $this->io->confirm("Would you like to change the PHP version on this IDE to match the PHP version on the <bg=cyan;options=bold>{$chosenEnvironment->label} ({$chosenEnvironment->configuration->php->version})</> environment?", FALSE);
       if ($answer) {
         $command = $this->getApplication()->find('ide:php-version');
-        $command->run(new ArrayInput(['command' => 'ide:php-version', 'version' => $chosen_environment->configuration->php->version]),
+        $command->run(new ArrayInput(['command' => 'ide:php-version', 'version' => $chosenEnvironment->configuration->php->version]),
           $output);
       }
     }
@@ -712,21 +712,21 @@ abstract class PullCommandBase extends CommandBase {
    * @param $environment
    */
   private function environmentPhpVersionMatches($environment): bool {
-    $current_php_version = $this->getIdePhpVersion();
-    return $environment->configuration->php->version === $current_php_version;
+    $currentPhpVersion = $this->getIdePhpVersion();
+    return $environment->configuration->php->version === $currentPhpVersion;
   }
 
   /**
    * @param $input
    */
-  protected function executeAllScripts($input, Closure $output_callback): void {
+  protected function executeAllScripts($input, Closure $outputCallback): void {
     $this->setDirAndRequireProjectCwd($input);
-    $this->runComposerScripts($output_callback);
-    $this->runDrushCacheClear($output_callback);
-    $this->runDrushSqlSanitize($output_callback);
+    $this->runComposerScripts($outputCallback);
+    $this->runDrushCacheClear($outputCallback);
+    $this->runDrushSqlSanitize($outputCallback);
   }
 
-  protected function runDrushCacheClear(Closure $output_callback): void {
+  protected function runDrushCacheClear(Closure $outputCallback): void {
     if ($this->getDrushDatabaseConnectionStatus()) {
       $this->checklist->addItem('Clearing Drupal caches via Drush');
       // @todo Add support for Drush 8.
@@ -736,7 +736,7 @@ abstract class PullCommandBase extends CommandBase {
         '--yes',
         '--no-interaction',
         '--verbose',
-      ], $output_callback, $this->dir, FALSE);
+      ], $outputCallback, $this->dir, FALSE);
       if (!$process->isSuccessful()) {
         throw new AcquiaCliException('Unable to rebuild Drupal caches via Drush. {message}', ['message' => $process->getErrorOutput()]);
       }
@@ -747,7 +747,7 @@ abstract class PullCommandBase extends CommandBase {
     }
   }
 
-  protected function runDrushSqlSanitize(Closure $output_callback): void {
+  protected function runDrushSqlSanitize(Closure $outputCallback): void {
     if ($this->getDrushDatabaseConnectionStatus()) {
       $this->checklist->addItem('Sanitizing database via Drush');
       $process = $this->localMachineHelper->execute([
@@ -756,7 +756,7 @@ abstract class PullCommandBase extends CommandBase {
         '--yes',
         '--no-interaction',
         '--verbose',
-      ], $output_callback, $this->dir, FALSE);
+      ], $outputCallback, $this->dir, FALSE);
       if (!$process->isSuccessful()) {
         throw new AcquiaCliException('Unable to sanitize Drupal database via Drush. {message}', ['message' => $process->getErrorOutput()]);
       }
@@ -770,25 +770,21 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   /**
-   * @param $output_callback
+   * @param $outputCallback
    */
-  private function composerInstall($output_callback): void {
+  private function composerInstall($outputCallback): void {
     $process = $this->localMachineHelper->execute([
       'composer',
       'install',
       '--no-interaction',
-    ], $output_callback, $this->dir, FALSE);
+    ], $outputCallback, $this->dir, FALSE);
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Unable to install Drupal dependencies via Composer. {message}',
         ['message' => $process->getErrorOutput()]);
     }
   }
 
-  /**
-   * @param $environment
-   * @param $database
-   */
-  protected function getHostFromDatabaseResponse($environment, $database): string {
+  protected function getHostFromDatabaseResponse($environment, DatabaseResponse $database): string {
     if ($this->isAcsfEnv($environment)) {
       return $database->db_host . '.enterprise-g1.hosting.acquia.com';
     }
@@ -797,65 +793,47 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   /**
-   * @param $environment
-   * @param $database
-   */
-  protected function getRemoteTempFilepath($environment, $database): string {
-    if ($this->isAcsfEnv($environment)) {
-      $ssh_url_parts = explode('.', $database->ssh_host);
-      $temp_prefix = reset($ssh_url_parts);
-    }
-    else {
-      $vcs_url_parts = explode('@', $environment->vcs->url);
-      $sitegroup = $vcs_url_parts[0];
-      $temp_prefix = $sitegroup . '.' . $database->environment->name;
-    }
-
-    return '/mnt/tmp/' . $temp_prefix;
-  }
-
-  /**
-   * @param \AcquiaCloudApi\Connector\Client $acquia_cloud_client
+   * @param \AcquiaCloudApi\Connector\Client $acquiaCloudClient
    * @param $environment
    * @param \AcquiaCloudApi\Response\DatabaseResponse $database
    * @return mixed
    */
   private function getDatabaseBackup(
-    Client $acquia_cloud_client,
+    Client $acquiaCloudClient,
     $environment,
     DatabaseResponse $database
   ): mixed {
-    $database_backups = new DatabaseBackups($acquia_cloud_client);
-    $backups_response = $database_backups->getAll($environment->uuid, $database->name);
-    if (!count($backups_response)) {
+    $databaseBackups = new DatabaseBackups($acquiaCloudClient);
+    $backupsResponse = $databaseBackups->getAll($environment->uuid, $database->name);
+    if (!count($backupsResponse)) {
       $this->logger->warning('No existing backups found, creating an on-demand backup now. This will take some time depending on the size of the database.');
-      $this->createBackup($environment, $database, $acquia_cloud_client);
-      $backups_response = $database_backups->getAll($environment->uuid,
+      $this->createBackup($environment, $database, $acquiaCloudClient);
+      $backupsResponse = $databaseBackups->getAll($environment->uuid,
         $database->name);
     }
-    $backup_response = $backups_response[0];
-    $this->logger->debug('Using database backup (id #' . $backup_response->id . ') generated at ' . $backup_response->completedAt);
+    $backupResponse = $backupsResponse[0];
+    $this->logger->debug('Using database backup (id #' . $backupResponse->id . ') generated at ' . $backupResponse->completedAt);
 
-    return $backup_response;
+    return $backupResponse;
   }
 
   /**
    * Print information to the console about the selected database backup.
    */
   private function printDatabaseBackupInfo(
-    BackupResponse $backup_response,
-    EnvironmentResponse $source_environment
+    BackupResponse $backupResponse,
+    EnvironmentResponse $sourceEnvironment
   ): void {
-    $interval = time() - strtotime($backup_response->completedAt);
-    $hours_interval = floor($interval / 60 / 60);
-    $date_formatted = date("D M j G:i:s T Y", strtotime($backup_response->completedAt));
-    $web_link = "https://cloud.acquia.com/a/environments/{$source_environment->uuid}/databases";
+    $interval = time() - strtotime($backupResponse->completedAt);
+    $hoursInterval = floor($interval / 60 / 60);
+    $dateFormatted = date("D M j G:i:s T Y", strtotime($backupResponse->completedAt));
+    $webLink = "https://cloud.acquia.com/a/environments/{$sourceEnvironment->uuid}/databases";
     $messages = [
-      "Using a database backup that is $hours_interval hours old. Backup #{$backup_response->id} was created at {$date_formatted}.",
-      "You can view your backups here: {$web_link}",
+      "Using a database backup that is $hoursInterval hours old. Backup #{$backupResponse->id} was created at {$dateFormatted}.",
+      "You can view your backups here: {$webLink}",
       "To generate a new backup, re-run this command with the --on-demand option.",
     ];
-    if ($hours_interval > 24) {
+    if ($hoursInterval > 24) {
       $this->io->warning($messages);
     }
     else {
@@ -864,27 +842,27 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   /**
-   * @param callable|null $output_callback
+   * @param callable|null $outputCallback
    */
-  private function importRemoteDatabase(DatabaseResponse $database, string $local_filepath, Closure $output_callback = NULL): void {
+  private function importRemoteDatabase(DatabaseResponse $database, string $localFilepath, Closure $outputCallback = NULL): void {
     if ($database->flags->default) {
       // Easy case, import the default db into the default db.
-      $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);
+      $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $localFilepath, $outputCallback);
     }
     else if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !getenv('IDE_ENABLE_MULTISITE')) {
       // Import non-default db into default db. Needed on legacy IDE without multiple dbs.
       // @todo remove this case once all IDEs support multiple dbs.
       $this->io->note("Cloud IDE only supports importing into the default Drupal database. Acquia CLI will import the NON-DEFAULT database {$database->name} into the DEFAULT database {$this->getDefaultLocalDbName()}");
-      $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);
+      $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $localFilepath, $outputCallback);
     }
     else {
       // Import non-default db into non-default db.
       $this->io->note("Acquia CLI assumes that the local name for the {$database->name} database is also {$database->name}");
       if (AcquiaDrupalEnvironmentDetector::isLandoEnv() || AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
-        $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), 'root', $database->name, '', $local_filepath, $output_callback);
+        $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), 'root', $database->name, '', $localFilepath, $outputCallback);
       }
       else {
-        $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $database->name, $this->getDefaultLocalDbPassword(), $local_filepath, $output_callback);
+        $this->doImportRemoteDatabase($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $database->name, $this->getDefaultLocalDbPassword(), $localFilepath, $outputCallback);
 
       }
     }

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -33,14 +33,14 @@ class PullDatabaseCommand extends PullCommandBase {
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
     parent::execute($input, $output);
-    $no_scripts = $input->hasOption('no-scripts') && $input->getOption('no-scripts');
-    $on_demand = $input->hasOption('on-demand') && $input->getOption('on-demand');
-    $no_import = $input->hasOption('no-import') && $input->getOption('no-import');
-    $multiple_dbs = $input->hasOption('multiple-dbs') && $input->getOption('multiple-dbs');
-    // $no_import implies $no_scripts.
-    $no_scripts = $no_import || $no_scripts;
-    $this->pullDatabase($input, $output, $on_demand, $no_import, $multiple_dbs);
-    if (!$no_scripts) {
+    $noScripts = $input->hasOption('no-scripts') && $input->getOption('no-scripts');
+    $onDemand = $input->hasOption('on-demand') && $input->getOption('on-demand');
+    $noImport = $input->hasOption('no-import') && $input->getOption('no-import');
+    $multipleDbs = $input->hasOption('multiple-dbs') && $input->getOption('multiple-dbs');
+    // $noImport implies $noScripts.
+    $noScripts = $noImport || $noScripts;
+    $this->pullDatabase($input, $output, $onDemand, $noImport, $multipleDbs);
+    if (!$noScripts) {
       $this->runDrushCacheClear($this->getOutputCallback($output, $this->checklist));
       $this->runDrushSqlSanitize($this->getOutputCallback($output, $this->checklist));
     }

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -27,29 +27,29 @@ class PushDatabaseCommand extends PullCommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $destination_environment = $this->determineEnvironment($input, $output);
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $databases = $this->determineCloudDatabases($acquia_cloud_client, $destination_environment, $input->getArgument('site'));
+    $destinationEnvironment = $this->determineEnvironment($input, $output);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $databases = $this->determineCloudDatabases($acquiaCloudClient, $destinationEnvironment, $input->getArgument('site'));
     // We only support pushing a single database.
     $database = $databases[0];
-    $answer = $this->io->confirm("Overwrite the <bg=cyan;options=bold>{$database->name}</> database on <bg=cyan;options=bold>{$destination_environment->name}</> with a copy of the database from the current machine?");
+    $answer = $this->io->confirm("Overwrite the <bg=cyan;options=bold>{$database->name}</> database on <bg=cyan;options=bold>{$destinationEnvironment->name}</> with a copy of the database from the current machine?");
     if (!$answer) {
       return 0;
     }
 
     $this->checklist = new Checklist($output);
-    $output_callback = $this->getOutputCallback($output, $this->checklist);
+    $outputCallback = $this->getOutputCallback($output, $this->checklist);
 
     $this->checklist->addItem('Creating local database dump');
-    $local_dump_filepath = $this->createMySqlDumpOnLocal($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $output_callback);
+    $localDumpFilepath = $this->createMySqlDumpOnLocal($this->getDefaultLocalDbHost(), $this->getDefaultLocalDbUser(), $this->getDefaultLocalDbName(), $this->getDefaultLocalDbPassword(), $outputCallback);
     $this->checklist->completePreviousItem();
 
     $this->checklist->addItem('Uploading database dump to remote machine');
-    $remote_dump_filepath = $this->uploadDatabaseDump($destination_environment, $local_dump_filepath, $output_callback);
+    $remoteDumpFilepath = $this->uploadDatabaseDump($destinationEnvironment, $localDumpFilepath, $outputCallback);
     $this->checklist->completePreviousItem();
 
     $this->checklist->addItem('Importing database dump into MySQL on remote machine');
-    $this->importDatabaseDumpOnRemote($destination_environment, $remote_dump_filepath, $database);
+    $this->importDatabaseDumpOnRemote($destinationEnvironment, $remoteDumpFilepath, $database);
     $this->checklist->completePreviousItem();
 
     return 0;
@@ -57,32 +57,32 @@ class PushDatabaseCommand extends PullCommandBase {
 
   private function uploadDatabaseDump(
     EnvironmentResponse $environment,
-    string $local_filepath,
-    callable $output_callback
+    string $localFilepath,
+    callable $outputCallback
   ): string {
     $sitegroup = self::getSiteGroupFromSshUrl($environment->sshUrl);
-    $remote_filepath = "/mnt/tmp/{$sitegroup}.{$environment->name}/" . basename($local_filepath);
-    $this->logger->debug("Uploading database dump to $remote_filepath on remote machine");
+    $remoteFilepath = "/mnt/tmp/{$sitegroup}.{$environment->name}/" . basename($localFilepath);
+    $this->logger->debug("Uploading database dump to $remoteFilepath on remote machine");
     $this->localMachineHelper->checkRequiredBinariesExist(['rsync']);
     $command = [
       'rsync',
       '-tDvPhe',
       'ssh -o StrictHostKeyChecking=no',
-      $local_filepath,
-      $environment->sshUrl . ':' . $remote_filepath,
+      $localFilepath,
+      $environment->sshUrl . ':' . $remoteFilepath,
     ];
-    $process = $this->localMachineHelper->execute($command, $output_callback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
+    $process = $this->localMachineHelper->execute($command, $outputCallback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Could not upload local database dump: {message}',
         ['message' => $process->getOutput()]);
     }
 
-    return $remote_filepath;
+    return $remoteFilepath;
   }
 
-  private function importDatabaseDumpOnRemote(EnvironmentResponse $environment, string $remote_dump_filepath, DatabaseResponse $database): void {
-    $this->logger->debug("Importing $remote_dump_filepath to MySQL on remote machine");
-    $command = "pv $remote_dump_filepath --bytes --rate | gunzip | MYSQL_PWD={$database->password} mysql --host={$this->getHostFromDatabaseResponse($environment, $database)} --user={$database->user_name} {$this->getNameFromDatabaseResponse($database)}";
+  private function importDatabaseDumpOnRemote(EnvironmentResponse $environment, string $remoteDumpFilepath, DatabaseResponse $database): void {
+    $this->logger->debug("Importing $remoteDumpFilepath to MySQL on remote machine");
+    $command = "pv $remoteDumpFilepath --bytes --rate | gunzip | MYSQL_PWD={$database->password} mysql --host={$this->getHostFromDatabaseResponse($environment, $database)} --user={$database->user_name} {$this->getNameFromDatabaseResponse($database)}";
     $process = $this->sshHelper->executeCommand($environment, [$command], ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Unable to import database on remote machine. {message}', ['message' => $process->getErrorOutput()]);
@@ -90,8 +90,8 @@ class PushDatabaseCommand extends PullCommandBase {
   }
 
   private function getNameFromDatabaseResponse(DatabaseResponse $database): string {
-    $db_url_parts = explode('/', $database->url);
-    return end($db_url_parts);
+    $dbUrlParts = explode('/', $database->url);
+    return end($dbUrlParts);
   }
 
 }

--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -20,22 +20,22 @@ class AliasListCommand extends CommandBase {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $applications_resource = new Applications($acquia_cloud_client);
-    $cloud_application_uuid = $this->determineCloudApplication();
-    $customer_application = $applications_resource->get($cloud_application_uuid);
-    $environments_resource = new Environments($acquia_cloud_client);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $applicationsResource = new Applications($acquiaCloudClient);
+    $cloudApplicationUuid = $this->determineCloudApplication();
+    $customerApplication = $applicationsResource->get($cloudApplicationUuid);
+    $environmentsResource = new Environments($acquiaCloudClient);
 
     $table = new Table($this->output);
     $table->setHeaders(['Application', 'Environment Alias', 'Environment UUID']);
 
-    $site_id = $customer_application->hosting->id;
-    $parts = explode(':', $site_id);
-    $site_prefix = $parts[1];
-    $environments = $environments_resource->getAll($customer_application->uuid);
+    $siteId = $customerApplication->hosting->id;
+    $parts = explode(':', $siteId);
+    $sitePrefix = $parts[1];
+    $environments = $environmentsResource->getAll($customerApplication->uuid);
     foreach ($environments as $environment) {
-      $alias = $site_prefix . '.' . $environment->name;
-      $table->addRow([$customer_application->name, $alias, $environment->uuid]);
+      $alias = $sitePrefix . '.' . $environment->name;
+      $table->addRow([$customerApplication->name, $alias, $environment->uuid]);
     }
 
     $table->render();

--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -30,24 +30,24 @@ class AliasesDownloadCommand extends SshCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $alias_version = $this->promptChooseDrushAliasVersion();
-    $drush_archive_temp_filepath = $this->getDrushArchiveTempFilepath();
-    $drush_aliases_dir = $this->getDrushAliasesDir($alias_version);
-    $this->localMachineHelper->getFilesystem()->mkdir($drush_aliases_dir);
-    $this->localMachineHelper->getFilesystem()->chmod($drush_aliases_dir, 0700);
+    $aliasVersion = $this->promptChooseDrushAliasVersion();
+    $drushArchiveTempFilepath = $this->getDrushArchiveTempFilepath();
+    $drushAliasesDir = $this->getDrushAliasesDir($aliasVersion);
+    $this->localMachineHelper->getFilesystem()->mkdir($drushAliasesDir);
+    $this->localMachineHelper->getFilesystem()->chmod($drushAliasesDir, 0700);
 
-    if ($alias_version === '9') {
-      $this->downloadDrush9Aliases($input, $alias_version, $drush_archive_temp_filepath, $drush_aliases_dir);
+    if ($aliasVersion === '9') {
+      $this->downloadDrush9Aliases($input, $aliasVersion, $drushArchiveTempFilepath, $drushAliasesDir);
     }
     else {
-      $this->downloadDrush8Aliases($alias_version, $drush_archive_temp_filepath, $drush_aliases_dir);
+      $this->downloadDrush8Aliases($aliasVersion, $drushArchiveTempFilepath, $drushAliasesDir);
     }
 
     $this->output->writeln(sprintf(
       'Cloud Platform Drush aliases installed into <options=bold>%s</>',
-      $drush_aliases_dir
+      $drushAliasesDir
     ));
-    unlink($drush_archive_temp_filepath);
+    unlink($drushArchiveTempFilepath);
 
     return 0;
   }
@@ -85,73 +85,73 @@ class AliasesDownloadCommand extends SshCommand {
     };
   }
 
-  protected function getAliasesFromCloud(Client $acquia_cloud_client, int $alias_version): StreamInterface {
-    $acquia_cloud_client->addQuery('version', $alias_version);
-    return (new Account($acquia_cloud_client))->getDrushAliases();
+  protected function getAliasesFromCloud(Client $acquiaCloudClient, int $aliasVersion): StreamInterface {
+    $acquiaCloudClient->addQuery('version', $aliasVersion);
+    return (new Account($acquiaCloudClient))->getDrushAliases();
   }
 
-  protected function getSitePrefix(bool $single_application): string {
-    $site_prefix = '';
-    if ($single_application) {
-      $cloud_application_uuid = $this->determineCloudApplication();
-      $cloud_application = $this->getCloudApplication($cloud_application_uuid);
-      $parts = explode(':', $cloud_application->hosting->id);
-      $site_prefix = $parts[1];
+  protected function getSitePrefix(bool $singleApplication): string {
+    $sitePrefix = '';
+    if ($singleApplication) {
+      $cloudApplicationUuid = $this->determineCloudApplication();
+      $cloudApplication = $this->getCloudApplication($cloudApplicationUuid);
+      $parts = explode(':', $cloudApplication->hosting->id);
+      $sitePrefix = $parts[1];
     }
-    return $site_prefix;
+    return $sitePrefix;
   }
 
-  protected function downloadArchive(int $alias_version, string $drush_archive_temp_filepath, string $base_dir): PharData {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $aliases = $this->getAliasesFromCloud($acquia_cloud_client, $alias_version);
-    $this->localMachineHelper->writeFile($drush_archive_temp_filepath, $aliases);
-    return new PharData($drush_archive_temp_filepath . '/' . $base_dir);
+  protected function downloadArchive(int $aliasVersion, string $drushArchiveTempFilepath, string $baseDir): PharData {
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $aliases = $this->getAliasesFromCloud($acquiaCloudClient, $aliasVersion);
+    $this->localMachineHelper->writeFile($drushArchiveTempFilepath, $aliases);
+    return new PharData($drushArchiveTempFilepath . '/' . $baseDir);
   }
 
-  protected function downloadDrush9Aliases(InputInterface $input, int $alias_version, string $drush_archive_temp_filepath, string $drush_aliases_dir): void {
+  protected function downloadDrush9Aliases(InputInterface $input, int $aliasVersion, string $drushArchiveTempFilepath, string $drushAliasesDir): void {
     $this->setDirAndRequireProjectCwd($input);
     $all = $input->getOption('all');
-    $application_uuid_argument = $input->getArgument('applicationUuid');
-    $single_application = !$all || $application_uuid_argument;
-    $site_prefix = $this->getSitePrefix($single_application);
-    $base_dir = 'sites';
-    $archive = $this->downloadArchive($alias_version, $drush_archive_temp_filepath, $base_dir);
-    if ($single_application) {
-      $drushFiles = $this->getSingleAliasForSite($archive, $site_prefix, $base_dir);
+    $applicationUuidArgument = $input->getArgument('applicationUuid');
+    $singleApplication = !$all || $applicationUuidArgument;
+    $sitePrefix = $this->getSitePrefix($singleApplication);
+    $baseDir = 'sites';
+    $archive = $this->downloadArchive($aliasVersion, $drushArchiveTempFilepath, $baseDir);
+    if ($singleApplication) {
+      $drushFiles = $this->getSingleAliasForSite($archive, $sitePrefix, $baseDir);
     }
     else {
       $drushFiles = [];
       foreach (new RecursiveIteratorIterator($archive, RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
-        $drushFiles[] = $base_dir . '/' . $file->getFileName();
+        $drushFiles[] = $baseDir . '/' . $file->getFileName();
       }
     }
-    $archive->extractTo($drush_aliases_dir, $drushFiles, TRUE);
+    $archive->extractTo($drushAliasesDir, $drushFiles, TRUE);
   }
 
-  protected function downloadDrush8Aliases(int $alias_version, string $drush_archive_temp_filepath, string $drush_aliases_dir): void {
-    $base_dir = '.drush';
-    $archive = $this->downloadArchive($alias_version, $drush_archive_temp_filepath, $base_dir);
+  protected function downloadDrush8Aliases(int $aliasVersion, string $drushArchiveTempFilepath, string $drushAliasesDir): void {
+    $baseDir = '.drush';
+    $archive = $this->downloadArchive($aliasVersion, $drushArchiveTempFilepath, $baseDir);
     $drushFiles = [];
     foreach (new RecursiveIteratorIterator($archive, RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
-      $drushFiles[] = $base_dir . '/' . $file->getFileName();
+      $drushFiles[] = $baseDir . '/' . $file->getFileName();
     }
-    $archive->extractTo($drush_aliases_dir, $drushFiles, TRUE);
+    $archive->extractTo($drushAliasesDir, $drushFiles, TRUE);
   }
 
   /**
    * @return array
    */
-  protected function getSingleAliasForSite(PharData $archive, string $site_prefix, string $base_dir): array {
+  protected function getSingleAliasForSite(PharData $archive, string $sitePrefix, string $baseDir): array {
     $drushFiles = [];
     foreach (new RecursiveIteratorIterator($archive, RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
       // Just get the single alias for this single application.
-      if ($file->getFileName() === $site_prefix . '.site.yml') {
-        $drushFiles[] = $base_dir . '/' . $file->getFileName();
+      if ($file->getFileName() === $sitePrefix . '.site.yml') {
+        $drushFiles[] = $baseDir . '/' . $file->getFileName();
         break;
       }
     }
     if (empty($drushFiles)) {
-      throw new AcquiaCliException("Could not locate any aliases matching the current site ($site_prefix)");
+      throw new AcquiaCliException("Could not locate any aliases matching the current site ($sitePrefix)");
     }
     return $drushFiles;
   }

--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -30,14 +30,14 @@ class DrushCommand extends SshBaseCommand {
     $alias = self::validateEnvironmentAlias($alias);
     $environment = $this->getEnvironmentFromAliasArg($alias);
 
-    $acli_arguments = $input->getArguments();
-    $drush_command_arguments = [
+    $acliArguments = $input->getArguments();
+    $drushCommandArguments = [
       "cd /var/www/html/{$alias}/docroot; ",
       'drush',
-      implode(' ', (array) $acli_arguments['drush_command']),
+      implode(' ', (array) $acliArguments['drush_command']),
     ];
 
-    return $this->sshHelper->executeCommand($environment, $drush_command_arguments)->getExitCode();
+    return $this->sshHelper->executeCommand($environment, $drushCommandArguments)->getExitCode();
   }
 
 }

--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -27,18 +27,18 @@ class SshCommand extends SshBaseCommand {
     $alias = $this->normalizeAlias($alias);
     $alias = self::validateEnvironmentAlias($alias);
     $environment = $this->getEnvironmentFromAliasArg($alias);
-    $ssh_command = [
+    $sshCommand = [
       'cd /var/www/html/' . $alias,
     ];
     $arguments = $input->getArguments();
     if (empty($arguments['ssh_command'])) {
-      $ssh_command[] = 'exec $SHELL -l';
+      $sshCommand[] = 'exec $sHELL -l';
     }
     else {
-      $ssh_command[] = implode(' ', $arguments['ssh_command']);
+      $sshCommand[] = implode(' ', $arguments['ssh_command']);
     }
-    $ssh_command = (array) implode('; ', $ssh_command);
-    return $this->sshHelper->executeCommand($environment, $ssh_command)->getExitCode();
+    $sshCommand = (array) implode('; ', $sshCommand);
+    return $this->sshHelper->executeCommand($environment, $sshCommand)->getExitCode();
   }
 
 }

--- a/src/Command/Self/ClearCacheCommand.php
+++ b/src/Command/Self/ClearCacheCommand.php
@@ -30,9 +30,9 @@ class ClearCacheCommand extends CommandBase {
   public static function clearCaches(): void {
     $cache = self::getAliasCache();
     $cache->clear();
-    $system_cache_dir = Path::join(sys_get_temp_dir(), 'symphony-cache');
+    $systemCacheDir = Path::join(sys_get_temp_dir(), 'symphony-cache');
     $fs = new Filesystem();
-    $fs->remove([$system_cache_dir]);
+    $fs->remove([$systemCacheDir]);
   }
 
 }

--- a/src/Command/Self/ListCommand.php
+++ b/src/Command/Self/ListCommand.php
@@ -19,8 +19,8 @@ class ListCommand extends \Symfony\Component\Console\Command\ListCommand {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     foreach (['api', 'acsf'] as $prefix) {
       if ($input->getArgument('namespace') !== $prefix) {
-        $all_commands = $this->getApplication()->all();
-        foreach ($all_commands as $command) {
+        $allCommands = $this->getApplication()->all();
+        foreach ($allCommands as $command) {
           if (
             !is_a($command, ApiListCommandBase::class)
             && !is_a($command, AcsfListCommandBase::class)

--- a/src/Command/Self/TelemetryCommand.php
+++ b/src/Command/Self/TelemetryCommand.php
@@ -33,8 +33,8 @@ class TelemetryCommand extends CommandBase {
       $datastore->set(DataStoreContract::SEND_TELEMETRY, TRUE);
       $this->io->success('Telemetry has been enabled.');
     }
-    $opposite_verb = $datastore->get(DataStoreContract::SEND_TELEMETRY) ? 'disable' : 'enable';
-    $this->io->writeln("Run this command again to $opposite_verb telemetry");
+    $oppositeVerb = $datastore->get(DataStoreContract::SEND_TELEMETRY) ? 'disable' : 'enable';
+    $this->io->writeln("Run this command again to $oppositeVerb telemetry");
 
     return 0;
   }

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -33,8 +33,8 @@ abstract class SshKeyCommandBase extends CommandBase {
 
   protected string $publicSshKeyFilepath;
 
-  protected function setSshKeyFilepath(string $private_ssh_key_filename): void {
-    $this->privateSshKeyFilename = $private_ssh_key_filename;
+  protected function setSshKeyFilepath(string $privateSshKeyFilename): void {
+    $this->privateSshKeyFilename = $privateSshKeyFilename;
     $this->privateSshKeyFilepath = $this->sshDir . '/' . $this->privateSshKeyFilename;
     $this->publicSshKeyFilepath = $this->privateSshKeyFilepath . '.pub';
   }
@@ -59,8 +59,8 @@ abstract class SshKeyCommandBase extends CommandBase {
   /**
    * Normalizes public SSH key by trimming and removing user and machine suffix.
    */
-  protected function normalizePublicSshKey(string $public_key): string {
-    $parts = explode('== ', $public_key);
+  protected function normalizePublicSshKey(string $publicKey): string {
+    $parts = explode('== ', $publicKey);
     $key = $parts[0];
 
     return trim($key);
@@ -76,8 +76,8 @@ abstract class SshKeyCommandBase extends CommandBase {
     ], NULL, NULL, FALSE);
 
     if ($process->isSuccessful()) {
-      $key_contents = $this->normalizePublicSshKey($this->localMachineHelper->readFile($this->publicSshKeyFilepath));
-      return str_contains($process->getOutput(), $key_contents);
+      $keyContents = $this->normalizePublicSshKey($this->localMachineHelper->readFile($this->publicSshKeyFilepath));
+      return str_contains($process->getOutput(), $keyContents);
     }
     return FALSE;
   }
@@ -91,16 +91,16 @@ abstract class SshKeyCommandBase extends CommandBase {
   protected function addSshKeyToAgent(string $filepath, string $password): void {
     // We must use a separate script to mimic user input due to the limitations of the `ssh-add` command.
     // @see https://www.linux.com/topic/networking/manage-ssh-key-file-passphrase/
-    $temp_filepath = $this->localMachineHelper->getFilesystem()->tempnam(sys_get_temp_dir(), 'acli');
-    $this->localMachineHelper->writeFile($temp_filepath, <<<'EOT'
+    $tempFilepath = $this->localMachineHelper->getFilesystem()->tempnam(sys_get_temp_dir(), 'acli');
+    $this->localMachineHelper->writeFile($tempFilepath, <<<'EOT'
 #!/usr/bin/env bash
-echo $SSH_PASS
+echo $sSHPASS
 EOT
     );
-    $this->localMachineHelper->getFilesystem()->chmod($temp_filepath, 0755);
-    $private_key_filepath = str_replace('.pub', '', $filepath);
-    $process = $this->localMachineHelper->executeFromCmd('SSH_PASS=' . $password . ' DISPLAY=1 SSH_ASKPASS=' . $temp_filepath . ' ssh-add ' . $private_key_filepath, NULL, NULL, FALSE);
-    $this->localMachineHelper->getFilesystem()->remove($temp_filepath);
+    $this->localMachineHelper->getFilesystem()->chmod($tempFilepath, 0755);
+    $privateKeyFilepath = str_replace('.pub', '', $filepath);
+    $process = $this->localMachineHelper->executeFromCmd('SSH_PASS=' . $password . ' DISPLAY=1 SSH_ASKPASS=' . $tempFilepath . ' ssh-add ' . $privateKeyFilepath, NULL, NULL, FALSE);
+    $this->localMachineHelper->getFilesystem()->remove($tempFilepath);
     if (!$process->isSuccessful()) {
       throw new AcquiaCliException('Unable to add the SSH key to local SSH agent:' . $process->getOutput() . $process->getErrorOutput());
     }
@@ -119,29 +119,29 @@ EOT
     $loop = Loop::get();
     $timers = [];
     $startTime = time();
-    $cloud_app_uuid = $this->determineCloudApplication(TRUE);
-    $permissions = $this->cloudApiClientService->getClient()->request('get', "/applications/{$cloud_app_uuid}/permissions");
+    $cloudAppUuid = $this->determineCloudApplication(TRUE);
+    $permissions = $this->cloudApiClientService->getClient()->request('get', "/applications/{$cloudAppUuid}/permissions");
     $perms = array_column($permissions, 'name');
-    $mappings = $this->checkPermissions($perms, $cloud_app_uuid, $output);
-    foreach ($mappings as $env_name => $config) {
+    $mappings = $this->checkPermissions($perms, $cloudAppUuid, $output);
+    foreach ($mappings as $envName => $config) {
       $spinner = new Spinner($output, 4);
-      $spinner->setMessage("Waiting for the key to become available in Cloud Platform $env_name environments");
+      $spinner->setMessage("Waiting for the key to become available in Cloud Platform $envName environments");
       $spinner->start();
-      $mappings[$env_name]['timer'] = $loop->addPeriodicTimer($spinner->interval(),
+      $mappings[$envName]['timer'] = $loop->addPeriodicTimer($spinner->interval(),
         static function () use ($spinner): void {
           $spinner->advance();
         });
-      $mappings[$env_name]['spinner'] = $spinner;
+      $mappings[$envName]['spinner'] = $spinner;
     }
     $callback = function () use ($output, $loop, &$mappings, &$timers, $startTime): void {
-      foreach ($mappings as $env_name => $config) {
+      foreach ($mappings as $envName => $config) {
         try {
           $process = $this->sshHelper->executeCommand($config['ssh_target'], ['ls'], FALSE);
-          if (($process->getExitCode() === 128 && $env_name === 'git') || $process->isSuccessful()) {
+          if (($process->getExitCode() === 128 && $envName === 'git') || $process->isSuccessful()) {
             // SSH key is available on this host, but may be pending on others.
             $config['spinner']->finish();
             $loop->cancelTimer($config['timer']);
-            unset($mappings[$env_name]);
+            unset($mappings[$envName]);
           }
           else {
             // SSH key isn't available on this host... yet.
@@ -177,42 +177,42 @@ EOT
     $loop->run();
   }
 
-  private function checkPermissions(array $perms, string $cloud_app_uuid, OutputInterface $output): array {
+  private function checkPermissions(array $perms, string $cloudAppUuid, OutputInterface $output): array {
     $mappings = [];
-    $needed_perms = ['add ssh key to git', 'add ssh key to non-prod', 'add ssh key to prod'];
-    foreach ($needed_perms as $index => $perm) {
+    $neededPerms = ['add ssh key to git', 'add ssh key to non-prod', 'add ssh key to prod'];
+    foreach ($neededPerms as $index => $perm) {
       if (in_array($perm, $perms, TRUE)) {
         switch ($perm) {
           case 'add ssh key to git':
-            $full_url = $this->getAnyVcsUrl($cloud_app_uuid);
-            $url_parts = explode(':', $full_url);
-            $mappings['git']['ssh_target'] = $url_parts[0];
+            $fullUrl = $this->getAnyVcsUrl($cloudAppUuid);
+            $urlParts = explode(':', $fullUrl);
+            $mappings['git']['ssh_target'] = $urlParts[0];
             break;
           case 'add ssh key to non-prod':
-            $mappings['nonprod']['ssh_target'] = $this->getAnyNonProdAhEnvironment($cloud_app_uuid);
+            $mappings['nonprod']['ssh_target'] = $this->getAnyNonProdAhEnvironment($cloudAppUuid);
             break;
           case 'add ssh key to prod':
-            $mappings['prod']['ssh_target'] = $this->getAnyProdAhEnvironment($cloud_app_uuid);
+            $mappings['prod']['ssh_target'] = $this->getAnyProdAhEnvironment($cloudAppUuid);
             break;
         }
-        unset($needed_perms[$index]);
+        unset($neededPerms[$index]);
       }
     }
-    if (!empty($needed_perms)) {
-      $perm_string = implode(", ", $needed_perms);
+    if (!empty($neededPerms)) {
+      $permString = implode(", ", $neededPerms);
       $output->writeln('<comment>You do not have access to some environments on this application.</comment>');
-      $output->writeln("<comment>Check that you have the following permissions: <options=bold>$perm_string</></comment>");
+      $output->writeln("<comment>Check that you have the following permissions: <options=bold>$permString</></comment>");
     }
     return $mappings;
   }
 
   protected function createSshKey(string $filename, string $password): string {
-    $key_file_path = $this->doCreateSshKey($filename, $password);
-    $this->setSshKeyFilepath(basename($key_file_path));
+    $keyFilePath = $this->doCreateSshKey($filename, $password);
+    $this->setSshKeyFilepath(basename($keyFilePath));
     if (!$this->sshKeyIsAddedToKeychain()) {
       $this->addSshKeyToAgent($this->publicSshKeyFilepath, $password);
     }
-    return $key_file_path;
+    return $keyFilePath;
   }
 
   private function doCreateSshKey(string $filename, string $password): string {
@@ -287,19 +287,16 @@ EOT
     return $password;
   }
 
-  private function keyHasUploaded(Client $acquia_cloud_client, string $public_key): bool {
-    $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
-    foreach ($cloud_keys as $cloud_key) {
-      if (trim($cloud_key->public_key) === trim($public_key)) {
+  private function keyHasUploaded(Client $acquiaCloudClient, string $publicKey): bool {
+    $sshKeys = new SshKeys($acquiaCloudClient);
+    foreach ($sshKeys->getAll() as $cloudKey) {
+      if (trim($cloudKey->public_key) === trim($publicKey)) {
         return TRUE;
       }
     }
     return FALSE;
   }
 
-  /**
-   * @return array
-   */
   protected function determinePublicSshKey(string $filepath = NULL): array {
     if ($filepath) {
       $filepath = $this->localMachineHelper->getLocalFilepath($filepath);
@@ -315,26 +312,26 @@ EOT
       if (!str_contains($filepath, '.pub')) {
         throw new AcquiaCliException('The filepath {filepath} does not have the .pub extension', ['filepath' => $filepath]);
       }
-      $public_key = $this->localMachineHelper->readFile($filepath);
-      $chosen_local_key = basename($filepath);
+      $publicKey = $this->localMachineHelper->readFile($filepath);
+      $chosenLocalKey = basename($filepath);
     }
     else {
       // Get local key and contents.
-      $local_keys = $this->findLocalSshKeys();
-      $chosen_local_key = $this->promptChooseLocalSshKey($local_keys);
-      $public_key = $this->getLocalSshKeyContents($local_keys, $chosen_local_key);
+      $localKeys = $this->findLocalSshKeys();
+      $chosenLocalKey = $this->promptChooseLocalSshKey($localKeys);
+      $publicKey = $this->getLocalSshKeyContents($localKeys, $chosenLocalKey);
     }
 
-    return [$chosen_local_key, $public_key];
+    return [$chosenLocalKey, $publicKey];
   }
 
   /**
-   * @param \Symfony\Component\Finder\SplFileInfo[] $local_keys
+   * @param \Symfony\Component\Finder\SplFileInfo[] $localKeys
    */
-  private function promptChooseLocalSshKey(array $local_keys): string {
+  private function promptChooseLocalSshKey(array $localKeys): string {
     $labels = [];
-    foreach ($local_keys as $local_key) {
-      $labels[] = $local_key->getFilename();
+    foreach ($localKeys as $localKey) {
+      $labels[] = $localKey->getFilename();
     }
     $question = new ChoiceQuestion(
       'Choose a local SSH key to upload to the Cloud Platform',
@@ -359,23 +356,23 @@ EOT
   }
 
   /**
-   * @param \Symfony\Component\Finder\SplFileInfo[] $local_keys
+   * @param \Symfony\Component\Finder\SplFileInfo[] $localKeys
    */
-  private function getLocalSshKeyContents(array $local_keys, string $chosen_local_key): string {
+  private function getLocalSshKeyContents(array $localKeys, string $chosenLocalKey): string {
     $filepath = '';
-    foreach ($local_keys as $local_key) {
-      if ($local_key->getFilename() === $chosen_local_key) {
-        $filepath = $local_key->getRealPath();
+    foreach ($localKeys as $localKey) {
+      if ($localKey->getFilename() === $chosenLocalKey) {
+        $filepath = $localKey->getRealPath();
         break;
       }
     }
     return $this->localMachineHelper->readFile($filepath);
   }
 
-  protected function uploadSshKey(string $label, string $public_key): void {
+  protected function uploadSshKey(string $label, string $publicKey): void {
     // @todo If a key with this label already exists, let the user try again.
     $sshKeys = new SshKeys($this->cloudApiClientService->getClient());
-    $sshKeys->create($label, $public_key);
+    $sshKeys->create($label, $publicKey);
 
     // Wait for the key to register on the Cloud Platform.
     if ($this->input->hasOption('no-wait') && $this->input->getOption('no-wait') === FALSE) {
@@ -384,7 +381,7 @@ EOT
         return;
       }
 
-      if ($this->keyHasUploaded($this->cloudApiClientService->getClient(), $public_key)) {
+      if ($this->keyHasUploaded($this->cloudApiClientService->getClient(), $publicKey)) {
         $this->pollAcquiaCloudUntilSshSuccess($this->output);
       }
     }

--- a/src/Command/Ssh/SshKeyCreateUploadCommand.php
+++ b/src/Command/Ssh/SshKeyCreateUploadCommand.php
@@ -25,11 +25,11 @@ class SshKeyCreateUploadCommand extends SshKeyCreateCommand {
     $filename = $this->determineFilename();
     $password = $this->determinePassword();
     $this->createSshKey($filename, $password);
-    $public_key = $this->localMachineHelper->readFile($this->publicSshKeyFilepath);
-    $chosen_local_key = basename($this->privateSshKeyFilepath);
+    $publicKey = $this->localMachineHelper->readFile($this->publicSshKeyFilepath);
+    $chosenLocalKey = basename($this->privateSshKeyFilepath);
     $label = $this->determineSshKeyLabel();
-    $this->uploadSshKey($label, $public_key);
-    $this->io->success("Uploaded $chosen_local_key to the Cloud Platform with label $label");
+    $this->uploadSshKey($label, $publicKey);
+    $this->io->success("Uploaded $chosenLocalKey to the Cloud Platform with label $label");
 
     return 0;
   }

--- a/src/Command/Ssh/SshKeyInfoCommand.php
+++ b/src/Command/Ssh/SshKeyInfoCommand.php
@@ -22,8 +22,8 @@ class SshKeyInfoCommand extends SshKeyCommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $key = $this->determineSshKey($acquia_cloud_client);
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $key = $this->determineSshKey($acquiaCloudClient);
 
     $location = 'Local';
     if (array_key_exists('cloud', $key)) {
@@ -47,11 +47,12 @@ class SshKeyInfoCommand extends SshKeyCommandBase {
     return 0;
   }
 
-  private function determineSshKey($acquia_cloud_client): array {
-    $cloudKeysResponse = new SshKeys($acquia_cloud_client);
-    $cloudKeys = (array) $cloudKeysResponse->getAll();
+  private function determineSshKey($acquiaCloudClient): array {
+    $cloudKeysResponse = new SshKeys($acquiaCloudClient);
+    $cloudKeys = $cloudKeysResponse->getAll();
     $localKeys = $this->findLocalSshKeys();
     $keys = [];
+    /** @var SshKeyResponse $key */
     foreach ($cloudKeys as $key) {
       $fingerprint = FingerprintGenerator::getFingerprint($key->public_key, 'sha256');
       $keys[$fingerprint]['fingerprint'] = $fingerprint;

--- a/src/Command/Ssh/SshKeyUploadCommand.php
+++ b/src/Command/Ssh/SshKeyUploadCommand.php
@@ -21,10 +21,10 @@ class SshKeyUploadCommand extends SshKeyCommandBase {
    * @return int 0 if everything went fine, or an exit code
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    [$chosen_local_key, $public_key] = $this->determinePublicSshKey();
+    [$chosenLocalKey, $publicKey] = $this->determinePublicSshKey();
     $label = $this->determineSshKeyLabel();
-    $this->uploadSshKey($label, $public_key);
-    $this->io->success("Uploaded $chosen_local_key to the Cloud Platform with label $label");
+    $this->uploadSshKey($label, $publicKey);
+    $this->io->success("Uploaded $chosenLocalKey to the Cloud Platform with label $label");
 
     return 0;
   }

--- a/src/Command/WizardCommandBase.php
+++ b/src/Command/WizardCommandBase.php
@@ -4,6 +4,7 @@ namespace Acquia\Cli\Command;
 
 use Acquia\Cli\Command\Ssh\SshKeyCommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
+use AcquiaCloudApi\Endpoints\SshKeys;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,12 +15,12 @@ abstract class WizardCommandBase extends SshKeyCommandBase {
 
   protected function initialize(InputInterface $input, OutputInterface $output): void {
     if ($this->commandRequiresAuthentication() && !$this->cloudApiClientService->isMachineAuthenticated()) {
-      $command_name = 'auth:login';
-      $command = $this->getApplication()->find($command_name);
-      $arguments = ['command' => $command_name];
-      $create_input = new ArrayInput($arguments);
-      $exit_code = $command->run($create_input, $output);
-      if ($exit_code !== 0) {
+      $commandName = 'auth:login';
+      $command = $this->getApplication()->find($commandName);
+      $arguments = ['command' => $commandName];
+      $createInput = new ArrayInput($arguments);
+      $exitCode = $command->run($createInput, $output);
+      if ($exitCode !== 0) {
         throw new AcquiaCliException("Unable to authenticate with the Cloud Platform.");
       }
     }
@@ -52,15 +53,17 @@ abstract class WizardCommandBase extends SshKeyCommandBase {
    * Cloud Platform.
    */
   protected function userHasUploadedThisKeyToCloud(string $label): bool {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
-    foreach ($cloud_keys as $index => $cloud_key) {
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    $sshKeys = new SshKeys($acquiaCloudClient);
+    $cloudKeys = $sshKeys->getAll();
+    /** @var \AcquiaCloudApi\Response\SshKeyResponse $cloudKey */
+    foreach ($cloudKeys as $index => $cloudKey) {
       if (
-        $cloud_key->label === $label
+        $cloudKey->label === $label
         // Assert that a corresponding local key exists.
         && $this->localSshKeyExists()
         // Assert local public key contents match Cloud public key contents.
-        && $this->normalizePublicSshKey($cloud_key->public_key) === $this->normalizePublicSshKey(file_get_contents($this->publicSshKeyFilepath))
+        && $this->normalizePublicSshKey($cloudKey->public_key) === $this->normalizePublicSshKey(file_get_contents($this->publicSshKeyFilepath))
       ) {
         return TRUE;
       }

--- a/src/Config/CloudDataConfig.php
+++ b/src/Config/CloudDataConfig.php
@@ -13,8 +13,8 @@ class CloudDataConfig implements ConfigurationInterface {
 
   public function getConfigTreeBuilder(): TreeBuilder {
     $treeBuilder = new TreeBuilder('cloud_api');
-    $root_node = $treeBuilder->getRootNode();
-    $root_node
+    $rootNode = $treeBuilder->getRootNode();
+    $rootNode
       ->children()
 
         // I can't find a better node type that accepts TRUE, FALSE, and NULL.

--- a/src/DataStore/AcquiaCliDatastore.php
+++ b/src/DataStore/AcquiaCliDatastore.php
@@ -7,21 +7,15 @@ use Acquia\Cli\Helpers\LocalMachineHelper;
 
 class AcquiaCliDatastore extends YamlStore {
 
-  protected LocalMachineHelper $localMachineHelper;
-
-  /**
-   * @var array
-   */
   protected array $config;
 
   public function __construct(
-    LocalMachineHelper $local_machine_helper,
-    AcquiaCliConfig $config_definition,
+    protected LocalMachineHelper $localMachineHelper,
+    AcquiaCliConfig $configDefinition,
     string $acliConfigFilepath
   ) {
-    $this->localMachineHelper = $local_machine_helper;
-    $file_path = $local_machine_helper->getLocalFilepath($acliConfigFilepath);
-    parent::__construct($file_path, $config_definition);
+    $filePath = $localMachineHelper->getLocalFilepath($acliConfigFilepath);
+    parent::__construct($filePath, $configDefinition);
   }
 
 }

--- a/src/DataStore/CloudDataStore.php
+++ b/src/DataStore/CloudDataStore.php
@@ -7,20 +7,14 @@ use Acquia\Cli\Helpers\LocalMachineHelper;
 
 class CloudDataStore extends JsonDataStore {
 
-  protected LocalMachineHelper $localMachineHelper;
-
-  /**
-   * @var array
-   */
   protected array $config;
 
   public function __construct(
-    LocalMachineHelper $local_machine_helper,
-    CloudDataConfig $cloud_data_config,
+    protected LocalMachineHelper $localMachineHelper,
+    CloudDataConfig $cloudDataConfig,
     string $cloudConfigFilepath
   ) {
-    $this->localMachineHelper = $local_machine_helper;
-    parent::__construct($cloudConfigFilepath, $cloud_data_config);
+    parent::__construct($cloudConfigFilepath, $cloudDataConfig);
   }
 
 }

--- a/src/DataStore/JsonDataStore.php
+++ b/src/DataStore/JsonDataStore.php
@@ -9,17 +9,17 @@ class JsonDataStore extends Datastore {
   /**
    * Creates a new store.
    *
-   * @param \Symfony\Component\Config\Definition\ConfigurationInterface|null $config_definition
+   * @param \Symfony\Component\Config\Definition\ConfigurationInterface|null $configDefinition
    */
-  public function __construct(string $path, ConfigurationInterface $config_definition = NULL) {
+  public function __construct(string $path, ConfigurationInterface $configDefinition = NULL) {
     parent::__construct($path);
     if ($this->fileSystem->exists($path)) {
       $array = json_decode(file_get_contents($path), TRUE, 512, JSON_THROW_ON_ERROR);
       $array = $this->expander->expandArrayProperties($array);
       $cleaned = $this->cleanLegacyConfig($array);
 
-      if ($config_definition) {
-        $array = $this->processConfig($array, $config_definition, $path);
+      if ($configDefinition) {
+        $array = $this->processConfig($array, $configDefinition, $path);
       }
       $this->data->import($array);
 

--- a/src/DataStore/YamlStore.php
+++ b/src/DataStore/YamlStore.php
@@ -10,15 +10,15 @@ class YamlStore extends Datastore {
   /**
    * Creates a new store.
    *
-   * @param \Symfony\Component\Config\Definition\ConfigurationInterface|null $config_definition
+   * @param \Symfony\Component\Config\Definition\ConfigurationInterface|null $configDefinition
    */
-  public function __construct(string $path, ConfigurationInterface $config_definition = NULL) {
+  public function __construct(string $path, ConfigurationInterface $configDefinition = NULL) {
     parent::__construct($path);
     if ($this->fileSystem->exists($path)) {
       $array = Yaml::parseFile($path);
       $array = $this->expander->expandArrayProperties($array);
-      if ($config_definition) {
-        $array = $this->processConfig($array, $config_definition, $path);
+      if ($configDefinition) {
+        $array = $this->processConfig($array, $configDefinition, $path);
       }
       $this->data->import($array);
     }

--- a/src/EventListener/ComposerScriptsListener.php
+++ b/src/EventListener/ComposerScriptsListener.php
@@ -41,21 +41,21 @@ class ComposerScriptsListener {
     }
     // Only successful commands should be executed.
     if (is_a($command, CommandBase::class)) {
-      $composer_json_filepath = Path::join($command->getProjectDir(), 'composer.json');
-      if (file_exists($composer_json_filepath)) {
-        $composer_json = json_decode($command->localMachineHelper->readFile($composer_json_filepath), TRUE, 512, JSON_THROW_ON_ERROR);
+      $composerJsonFilepath = Path::join($command->getProjectDir(), 'composer.json');
+      if (file_exists($composerJsonFilepath)) {
+        $composerJson = json_decode($command->localMachineHelper->readFile($composerJsonFilepath), TRUE, 512, JSON_THROW_ON_ERROR);
         // Protect against invalid JSON.
-        if ($composer_json) {
-          $command_name = $command->getName();
+        if ($composerJson) {
+          $commandName = $command->getName();
           // Replace colons with hyphens. E.g., pull:db becomes pull-db.
-          $script_name = $prefix . '-acli-' . str_replace(':', '-', $command_name);
-          if (array_key_exists('scripts', $composer_json) && array_key_exists($script_name, $composer_json['scripts'])) {
-            $event->getOutput()->writeln("Executing composer script `$script_name` defined in `$composer_json_filepath`", OutputInterface::VERBOSITY_VERBOSE);
-            $event->getOutput()->writeln($script_name);
-            $command->localMachineHelper->execute(['composer', 'run-script', $script_name]);
+          $scriptName = $prefix . '-acli-' . str_replace(':', '-', $commandName);
+          if (array_key_exists('scripts', $composerJson) && array_key_exists($scriptName, $composerJson['scripts'])) {
+            $event->getOutput()->writeln("Executing composer script `$scriptName` defined in `$composerJsonFilepath`", OutputInterface::VERBOSITY_VERBOSE);
+            $event->getOutput()->writeln($scriptName);
+            $command->localMachineHelper->execute(['composer', 'run-script', $scriptName]);
           }
           else {
-            $event->getOutput()->writeln("Notice: Composer script `$script_name` does not exist in `$composer_json_filepath`, skipping. This is not an error.", OutputInterface::VERBOSITY_VERBOSE);
+            $event->getOutput()->writeln("Notice: Composer script `$scriptName` does not exist in `$composerJsonFilepath`, skipping. This is not an error.", OutputInterface::VERBOSITY_VERBOSE);
           }
         }
       }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -32,7 +32,7 @@ class ExceptionListener {
     $errorMessage = $error->getMessage();
 
     if ($error instanceof IdentityProviderException && $error->getMessage() === 'invalid_client') {
-      $new_error_message = 'Your Cloud Platform API credentials are invalid.';
+      $newErrorMessage = 'Your Cloud Platform API credentials are invalid.';
       $this->helpMessages[] = "Run <bg=$this->messagesBgColor;fg=$this->messagesFgColor;options=bold>acli auth:login</> to reset your API credentials.";
     }
 
@@ -72,7 +72,7 @@ class ExceptionListener {
           $this->helpMessages[] = "Run `acli login` to authenticate via API token and then try again.";
           break;
         default:
-          $new_error_message = 'Cloud Platform API returned an error: ' . $errorMessage;
+          $newErrorMessage = 'Cloud Platform API returned an error: ' . $errorMessage;
           $this->helpMessages[] = "You can learn more about Cloud Platform API at https://docs.acquia.com/cloud-platform/develop/api/";
       }
     }
@@ -87,8 +87,8 @@ class ExceptionListener {
       $application->setHelpMessages($this->helpMessages);
     }
 
-    if (isset($new_error_message)) {
-      $event->setError(new AcquiaCliException($new_error_message, [], $exitCode));
+    if (isset($newErrorMessage)) {
+      $event->setError(new AcquiaCliException($newErrorMessage, [], $exitCode));
     }
   }
 

--- a/src/Exception/AcquiaCliException.php
+++ b/src/Exception/AcquiaCliException.php
@@ -10,24 +10,24 @@ class AcquiaCliException extends Exception {
   /**
    * Object constructor. Sets context array as replacements property.
    *
-   * @param string|null $raw_message
+   * @param string|null $rawMessage
    * @param array $replacements
    *   Context array to interpolate into message.
    * @param int $code
    *   Exit code.
    */
   public function __construct(
-    private ?string $raw_message = NULL,
+    private ?string $rawMessage = NULL,
     array $replacements = [],
     int $code = 0
     ) {
-    $event_properties = [
+    $eventProperties = [
       'code' => $code,
-      'message' => $raw_message,
+      'message' => $rawMessage,
 ];
-    Amplitude::getInstance()->queueEvent('Threw exception', $event_properties);
+    Amplitude::getInstance()->queueEvent('Threw exception', $eventProperties);
 
-    parent::__construct($this->interpolateString($raw_message, $replacements), $code);
+    parent::__construct($this->interpolateString($rawMessage, $replacements), $code);
   }
 
   /**
@@ -36,7 +36,7 @@ class AcquiaCliException extends Exception {
    * @return string $this->replacements
    */
   public function getRawMessage(): string {
-    return $this->raw_message;
+    return $this->rawMessage;
   }
 
   /**

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -14,7 +14,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
-use function Safe\file_get_contents;
+use function safe\file_get_contents;
 
 /**
  * A helper for executing commands on the local client. A wrapper for 'exec' and 'passthru'.
@@ -48,8 +48,8 @@ class LocalMachineHelper {
     if (array_key_exists($command, $this->installedBinaries)) {
       return (bool) $this->installedBinaries[$command];
     }
-    $os_command = OsInfo::isWindows() ? ['where', $command] : ['which', $command];
-    $exists = $this->execute($os_command, NULL, NULL, FALSE)->isSuccessful();
+    $osCommand = OsInfo::isWindows() ? ['where', $command] : ['which', $command];
+    $exists = $this->execute($osCommand, NULL, NULL, FALSE)->isSuccessful();
     $this->installedBinaries[$command] = $exists;
     return $exists;
   }
@@ -60,7 +60,7 @@ class LocalMachineHelper {
   public function checkRequiredBinariesExist(array $binaries = []): void {
     foreach ($binaries as $binary) {
       if (!$this->commandExists($binary)) {
-        throw new AcquiaCliException("The required binary `$binary` does not exist. Install it and ensure it exists in a location listed in your system \$PATH");
+        throw new AcquiaCliException("The required binary `$binary` does not exist. Install it and ensure it exists in a location listed in your system \$pATH");
       }
     }
   }
@@ -73,10 +73,10 @@ class LocalMachineHelper {
    * @param null $callback
    *   A function to run while waiting for the process to complete.
    */
-  public function execute(array $cmd, callable $callback = NULL, string $cwd = NULL, ?bool $print_output = TRUE, float $timeout = NULL, array $env = NULL): Process {
+  public function execute(array $cmd, callable $callback = NULL, string $cwd = NULL, ?bool $printOutput = TRUE, float $timeout = NULL, array $env = NULL): Process {
     $process = new Process($cmd);
-    $process = $this->configureProcess($process, $cwd, $print_output, $timeout, $env);
-    return $this->executeProcess($process, $callback, $print_output);
+    $process = $this->configureProcess($process, $cwd, $printOutput, $timeout, $env);
+    return $this->executeProcess($process, $callback, $printOutput);
   }
 
   /**
@@ -93,25 +93,25 @@ class LocalMachineHelper {
    * @param int|null $timeout
    * @param array|null $env
    */
-  public function executeFromCmd(string $cmd, callable $callback = NULL, string $cwd = NULL, ?bool $print_output = TRUE, int $timeout = NULL, array $env = NULL): Process {
+  public function executeFromCmd(string $cmd, callable $callback = NULL, string $cwd = NULL, ?bool $printOutput = TRUE, int $timeout = NULL, array $env = NULL): Process {
     $process = Process::fromShellCommandline($cmd);
-    $process = $this->configureProcess($process, $cwd, $print_output, $timeout, $env);
+    $process = $this->configureProcess($process, $cwd, $printOutput, $timeout, $env);
 
-    return $this->executeProcess($process, $callback, $print_output);
+    return $this->executeProcess($process, $callback, $printOutput);
   }
 
   /**
    * @param string|null $cwd
    * @param array|null $env
    */
-  private function configureProcess(Process $process, string $cwd = NULL, ?bool $print_output = TRUE, float $timeout = NULL, array $env = NULL): Process {
+  private function configureProcess(Process $process, string $cwd = NULL, ?bool $printOutput = TRUE, float $timeout = NULL, array $env = NULL): Process {
     if (function_exists('posix_isatty') && !@posix_isatty(STDIN)) {
       $process->setInput(STDIN);
     }
     if ($cwd) {
       $process->setWorkingDirectory($cwd);
     }
-    if ($print_output) {
+    if ($printOutput) {
       $process->setTty($this->useTty());
     }
     if ($env) {
@@ -125,8 +125,8 @@ class LocalMachineHelper {
   /**
    * @param callable|null $callback
    */
-  private function executeProcess(Process $process, callable $callback = NULL, ?bool $print_output = TRUE): Process {
-    if ($callback === NULL && $print_output !== FALSE) {
+  private function executeProcess(Process $process, callable $callback = NULL, ?bool $printOutput = TRUE): Process {
+    if ($callback === NULL && $printOutput !== FALSE) {
       $callback = function ($type, $buffer): void {
         $this->output->write($buffer);
       };
@@ -220,7 +220,7 @@ class LocalMachineHelper {
    * Accepts a filename/full path and localizes it to the user's system.
    */
   private function fixFilename(string $filename): string {
-    // '~' is only an alias for $HOME if it's at the start of the path.
+    // '~' is only an alias for $hOME if it's at the start of the path.
     // On Windows, '~' (not as an alias) can appear other places in the path.
     return preg_replace('/^~/', self::getHomeDir(), $filename);
   }
@@ -245,7 +245,7 @@ class LocalMachineHelper {
     }
 
     if (!$home) {
-      throw new AcquiaCliException('Could not determine $HOME directory. Ensure $HOME is set in your shell.');
+      throw new AcquiaCliException('Could not determine $hOME directory. Ensure $hOME is set in your shell.');
     }
 
     return $home;
@@ -265,16 +265,16 @@ class LocalMachineHelper {
    *   Root.
    */
   public static function getProjectDir(): ?string {
-    $possible_project_roots = [
+    $possibleProjectRoots = [
       getcwd(),
     ];
     // Check for PWD - some local environments will not have this key.
-    if (getenv('PWD') && !in_array(getenv('PWD'), $possible_project_roots, TRUE)) {
-      array_unshift($possible_project_roots, getenv('PWD'));
+    if (getenv('PWD') && !in_array(getenv('PWD'), $possibleProjectRoots, TRUE)) {
+      array_unshift($possibleProjectRoots, getenv('PWD'));
     }
-    foreach ($possible_project_roots as $possible_project_root) {
-      if ($project_root = self::find_directory_containing_files($possible_project_root, ['docroot'])) {
-        return realpath($project_root);
+    foreach ($possibleProjectRoots as $possibleProjectRoot) {
+      if ($projectRoot = self::findDirectoryContainingFiles($possibleProjectRoot, ['docroot'])) {
+        return realpath($projectRoot);
       }
     }
 
@@ -284,27 +284,27 @@ class LocalMachineHelper {
   /**
    * Traverses file system upwards in search of a given file.
    *
-   * Begins searching for $file in $working_directory and climbs up directories
-   * $max_height times, repeating search.
+   * Begins searching for $file in $workingDirectory and climbs up directories
+   * $maxHeight times, repeating search.
    *
-   * @param string $working_directory
+   * @param string $workingDirectory
    *   Working directory.
    * @param array $files
    *   Files.
-   * @param int $max_height
+   * @param int $maxHeight
    *   Max Height.
    * @return bool|string
    *   FALSE if file was not found. Otherwise, the directory path containing the
    *   file.
    */
-  private static function find_directory_containing_files(string $working_directory, array $files, int $max_height = 10): bool|string {
-    $file_path = $working_directory;
-    for ($i = 0; $i <= $max_height; $i++) {
-      if (self::files_exist($file_path, $files)) {
-        return $file_path;
+  private static function findDirectoryContainingFiles(string $workingDirectory, array $files, int $maxHeight = 10): bool|string {
+    $filePath = $workingDirectory;
+    for ($i = 0; $i <= $maxHeight; $i++) {
+      if (self::filesExist($filePath, $files)) {
+        return $filePath;
       }
 
-      $file_path = dirname($file_path);
+      $filePath = dirname($filePath);
     }
 
     return FALSE;
@@ -320,7 +320,7 @@ class LocalMachineHelper {
    * @return bool
    *   Exists.
    */
-  private static function files_exist(string $dir, array $files): bool {
+  private static function filesExist(string $dir, array $files): bool {
     foreach ($files as $file) {
       if (file_exists(Path::join($dir, $file))) {
         return TRUE;

--- a/src/Helpers/SshCommandTrait.php
+++ b/src/Helpers/SshCommandTrait.php
@@ -9,27 +9,27 @@ use Zumba\Amplitude\Amplitude;
 
 trait SshCommandTrait {
 
-  private function deleteSshKeyFromCloud($output, $cloud_key = NULL): int {
-    $acquia_cloud_client = $this->cloudApiClientService->getClient();
-    if (!$cloud_key) {
-      $cloud_key = $this->determineCloudKey($acquia_cloud_client);
+  private function deleteSshKeyFromCloud($output, $cloudKey = NULL): int {
+    $acquiaCloudClient = $this->cloudApiClientService->getClient();
+    if (!$cloudKey) {
+      $cloudKey = $this->determineCloudKey($acquiaCloudClient);
     }
 
-    $response = $acquia_cloud_client->makeRequest('delete', '/account/ssh-keys/' . $cloud_key->uuid);
+    $response = $acquiaCloudClient->makeRequest('delete', '/account/ssh-keys/' . $cloudKey->uuid);
     if ($response->getStatusCode() === 202) {
-      $output->writeln("<info>Successfully deleted SSH key <options=bold>$cloud_key->label</> from the Cloud Platform.</info>");
-      $local_keys = $this->findLocalSshKeys();
-      foreach ($local_keys as $local_file) {
-        if (trim($local_file->getContents()) === trim($cloud_key->public_key)) {
-          $private_key_path = str_replace('.pub', '', $local_file->getRealPath());
-          $public_key_path = $local_file->getRealPath();
-          $answer = $this->io->confirm("Do you also want to delete the corresponding local key files {$local_file->getRealPath()} and $private_key_path ?", FALSE);
+      $output->writeln("<info>Successfully deleted SSH key <options=bold>$cloudKey->label</> from the Cloud Platform.</info>");
+      $localKeys = $this->findLocalSshKeys();
+      foreach ($localKeys as $localFile) {
+        if (trim($localFile->getContents()) === trim($cloudKey->public_key)) {
+          $privateKeyPath = str_replace('.pub', '', $localFile->getRealPath());
+          $publicKeyPath = $localFile->getRealPath();
+          $answer = $this->io->confirm("Do you also want to delete the corresponding local key files {$localFile->getRealPath()} and $privateKeyPath ?", FALSE);
           if ($answer) {
             $this->localMachineHelper->getFilesystem()->remove([
-              $local_file->getRealPath(),
-              $private_key_path,
+              $localFile->getRealPath(),
+              $privateKeyPath,
             ]);
-            $this->io->success("Deleted $public_key_path and $private_key_path");
+            $this->io->success("Deleted $publicKeyPath and $privateKeyPath");
             return 0;
           }
         }
@@ -40,10 +40,10 @@ trait SshCommandTrait {
     throw new AcquiaCliException($response->getBody()->getContents());
   }
 
-  private function determineCloudKey(Client $acquia_cloud_client): object|array|null {
-    $cloud_keys = $acquia_cloud_client->request('get', '/account/ssh-keys');
+  private function determineCloudKey(Client $acquiaCloudClient): object|array|null {
+    $cloudKeys = $acquiaCloudClient->request('get', '/account/ssh-keys');
     return $this->promptChooseFromObjectsOrArrays(
-      $cloud_keys,
+      $cloudKeys,
       'uuid',
       'label',
       'Choose an SSH key to delete from the Cloud Platform'

--- a/src/Helpers/SshHelper.php
+++ b/src/Helpers/SshHelper.php
@@ -28,22 +28,22 @@ class SshHelper implements LoggerAwareInterface {
   /**
    * Execute the command in a remote environment.
    *
-   * @param array $command_args
+   * @param array $commandArgs
    * @param int|null $timeout
    */
-  public function executeCommand(EnvironmentResponse|string $target, array $command_args, bool $print_output = TRUE, int $timeout = NULL): Process {
-    $command_summary = $this->getCommandSummary($command_args);
+  public function executeCommand(EnvironmentResponse|string $target, array $commandArgs, bool $printOutput = TRUE, int $timeout = NULL): Process {
+    $commandSummary = $this->getCommandSummary($commandArgs);
 
     if (is_a($target, EnvironmentResponse::class)) {
       $target = $target->sshUrl;
     }
 
     // Remove site_env arg.
-    unset($command_args['alias']);
-    $process = $this->sendCommand($target, $command_args, $print_output, $timeout);
+    unset($commandArgs['alias']);
+    $process = $this->sendCommand($target, $commandArgs, $printOutput, $timeout);
 
     $this->logger->debug('Command: {command} [Exit: {exit}]', [
-      'command' => $command_summary,
+      'command' => $commandSummary,
       'env' => $target,
       'exit' => $process->getExitCode(),
     ]);
@@ -55,22 +55,22 @@ class SshHelper implements LoggerAwareInterface {
     return $process;
   }
 
-  private function sendCommand($url, $command, $print_output, $timeout = NULL): Process {
+  private function sendCommand($url, $command, $printOutput, $timeout = NULL): Process {
     $command = array_values($this->getSshCommand($url, $command));
     $this->localMachineHelper->checkRequiredBinariesExist(['ssh']);
 
-    return $this->localMachineHelper->execute($command, $this->getOutputCallback(), NULL, $print_output, $timeout);
+    return $this->localMachineHelper->execute($command, $this->getOutputCallback(), NULL, $printOutput, $timeout);
   }
 
   /**
-   * Return the first item of the $command_args that is not an option.
+   * Return the first item of the $commandArgs that is not an option.
    *
-   * @param array $command_args
+   * @param array $commandArgs
    */
-  private function firstArguments(array $command_args): string {
+  private function firstArguments(array $commandArgs): string {
     $result = '';
-    while (!empty($command_args)) {
-      $first = array_shift($command_args);
+    while (!empty($commandArgs)) {
+      $first = array_shift($commandArgs);
       if ($first != '' && $first[0] == '-') {
         return $result;
       }
@@ -100,10 +100,10 @@ class SshHelper implements LoggerAwareInterface {
    * arguments. This avoids potential information disclosure in
    * CI scripts.
    *
-   * @param array $command_args
+   * @param array $commandArgs
    */
-  private function getCommandSummary(array $command_args): string {
-    return $this->firstArguments($command_args);
+  private function getCommandSummary(array $commandArgs): string {
+    return $this->firstArguments($commandArgs);
   }
 
   /**

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -34,8 +34,8 @@ class TelemetryHelper {
     if (empty($this->bugSnagKey)) {
       return;
     }
-    $send_telemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
-    if ($send_telemetry === FALSE) {
+    $sendTelemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
+    if ($sendTelemetry === FALSE) {
       return;
     }
     // It's safe-ish to make this key public.
@@ -44,10 +44,10 @@ class TelemetryHelper {
     $bugsnag->setAppVersion($this->application->getVersion());
     $bugsnag->setProjectRoot(Path::join(__DIR__, '..'));
     $bugsnag->registerCallback(function ($report) {
-      $user_id = $this->getUserId();
-      if (isset($user_id)) {
+      $userId = $this->getUserId();
+      if (isset($userId)) {
         $report->setUser([
-          'id' => $user_id,
+          'id' => $userId,
         ]);
       }
     });
@@ -73,11 +73,11 @@ class TelemetryHelper {
     if (empty($this->amplitudeKey)) {
       return;
     }
-    $send_telemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
+    $sendTelemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
     $amplitude = Amplitude::getInstance();
-    $amplitude->setOptOut($send_telemetry === FALSE);
+    $amplitude->setOptOut($sendTelemetry === FALSE);
 
-    if ($send_telemetry === FALSE) {
+    if ($sendTelemetry === FALSE) {
       return;
     }
     try {

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -61,8 +61,8 @@ class Kernel extends BaseKernel {
     return new DelegatingLoader($resolver);
   }
 
-  protected function build(ContainerBuilder $container_builder): void {
-    $container_builder->addCompilerPass($this->createCollectingCompilerPass());
+  protected function build(ContainerBuilder $containerBuilder): void {
+    $containerBuilder->addCompilerPass($this->createCollectingCompilerPass());
   }
 
   /**
@@ -71,15 +71,15 @@ class Kernel extends BaseKernel {
   private function createCollectingCompilerPass(): CompilerPassInterface {
     return new class implements CompilerPassInterface {
 
-      public function process(ContainerBuilder $container_builder) {
-        $app_definition = $container_builder->findDefinition(Application::class);
-        $dispatcher_definition = $container_builder->findDefinition(EventDispatcher::class);
+      public function process(ContainerBuilder $containerBuilder) {
+        $appDefinition = $containerBuilder->findDefinition(Application::class);
+        $dispatcherDefinition = $containerBuilder->findDefinition(EventDispatcher::class);
 
-        foreach ($container_builder->getDefinitions() as $definition) {
+        foreach ($containerBuilder->getDefinitions() as $definition) {
           // Handle event listeners.
           if ($definition->hasTag('kernel.event_listener')) {
             foreach ($definition->getTag('kernel.event_listener') as $tag) {
-              $dispatcher_definition->addMethodCall('addListener', [
+              $dispatcherDefinition->addMethodCall('addListener', [
                 $tag['event'],
                 [
                   new ServiceClosureArgument(new Reference($definition->getClass())),
@@ -99,13 +99,13 @@ class Kernel extends BaseKernel {
             continue;
           }
 
-          $app_definition->addMethodCall('add', [
+          $appDefinition->addMethodCall('add', [
             new Reference($definition->getClass()),
           ]);
         }
 
-        $app_definition->addMethodCall('setDispatcher', [
-          $dispatcher_definition,
+        $appDefinition->addMethodCall('setDispatcher', [
+          $dispatcherDefinition,
         ]);
       }
 

--- a/src/Output/Checklist.php
+++ b/src/Output/Checklist.php
@@ -49,9 +49,9 @@ class Checklist {
   }
 
   /**
-   * @param $update_message
+   * @param $updateMessage
    */
-  public function updateProgressBar($update_message): void {
+  public function updateProgressBar($updateMessage): void {
     $item = $this->getLastItem();
     if (!$item) {
       return;
@@ -61,8 +61,8 @@ class Checklist {
       $spinner = $item['spinner'];
     }
 
-    $message_lines = explode(PHP_EOL, $update_message);
-    foreach ($message_lines as $line) {
+    $messageLines = explode(PHP_EOL, $updateMessage);
+    foreach ($messageLines as $line) {
       if (isset($spinner) && $item['spinner']) {
         if (trim($line)) {
           $spinner->setMessage(str_repeat(' ', $this->indentLength * 2) . $line, 'detail');

--- a/src/Output/Spinner/Spinner.php
+++ b/src/Output/Spinner/Spinner.php
@@ -137,12 +137,12 @@ class Spinner {
       return;
     }
     if ($name === 'detail') {
-      $terminal_width = (new Terminal())->getWidth();
-      $message_length = Helper::length($message) + ($this->indentLength * 2);
-      if ($message_length > $terminal_width) {
+      $terminalWidth = (new Terminal())->getWidth();
+      $messageLength = Helper::length($message) + ($this->indentLength * 2);
+      if ($messageLength > $terminalWidth) {
         $suffix = '...';
-        $new_message_len = ($terminal_width - ($this->indentLength * 2) - strlen($suffix));
-        $message = Helper::substr($message, 0, $new_message_len);
+        $newMessageLen = ($terminalWidth - ($this->indentLength * 2) - strlen($suffix));
+        $message = Helper::substr($message, 0, $newMessageLen);
         $message .= $suffix;
       }
     }

--- a/test.php
+++ b/test.php
@@ -1,0 +1,37 @@
+<?php
+
+function snakeToCamel($val) {
+  preg_match('#^_*#', $val, $underscores);
+  $underscores = current($underscores);
+  $camel = str_replace(' ', '', ucwords(str_replace('_', ' ', $val)));
+  $camel = strtolower(substr($camel, 0, 1)) . substr($camel, 1);
+
+  return $underscores . $camel;
+}
+
+function convert($str) {
+  $name = '[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*';
+  $snake_regexps = [
+        "#->($name)#i",
+        '#\$(' . $name . ')#i',
+        "#function ($name)#i",
+    ];
+  foreach ($snake_regexps as $regexp)
+        $str = preg_replace_callback($regexp, function ($matches) {
+            //print_r($matches);
+            $camel = snakeToCamel($matches[1]);
+            return str_replace($matches[1], $camel, $matches[0]);
+        }, $str);
+  return $str;
+
+}
+
+$path = $argv[1];
+$Iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
+foreach ($Iterator as $file) {
+  if (substr($file, -4) !== '.php')
+        continue;
+  echo($file);
+  $out = convert(file_get_contents($file));
+  file_put_contents($file, $out);
+}

--- a/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
+++ b/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
@@ -43,13 +43,13 @@ class AcsfServiceTest extends TestBase {
 
   /**
    * @dataProvider providerTestIsMachineAuthenticated
-   * @param array $env_vars
+   * @param array $envVars
    */
-  public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated): void {
-    self::setEnvVars($env_vars);
-    $client_service = new AcsfClientService(new AcsfConnectorFactory(['key' => NULL, 'secret' => NULL]), $this->prophet->prophesize(Application::class)->reveal(), $this->cloudCredentials);
-    $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated());
-    self::unsetEnvVars($env_vars);
+  public function testIsMachineAuthenticated(array $envVars, bool $isAuthenticated): void {
+    self::setEnvVars($envVars);
+    $clientService = new AcsfClientService(new AcsfConnectorFactory(['key' => NULL, 'secret' => NULL]), $this->prophet->prophesize(Application::class)->reveal(), $this->cloudCredentials);
+    $this->assertEquals($isAuthenticated, $clientService->isMachineAuthenticated());
+    self::unsetEnvVars($envVars);
   }
 
 }

--- a/tests/phpunit/src/ApplicationTestBase.php
+++ b/tests/phpunit/src/ApplicationTestBase.php
@@ -42,10 +42,10 @@ class ApplicationTestBase extends TestBase {
   protected function setInput(array $args): void {
     // ArrayInput requires command to be the first parameter.
     if (array_key_exists('command', $args)) {
-      $new_args = [];
-      $new_args['command'] = $args['command'];
+      $newArgs = [];
+      $newArgs['command'] = $args['command'];
       unset($args['command']);
-      $args = array_merge($new_args, $args);
+      $args = array_merge($newArgs, $args);
     }
     $input = new ArrayInput($args);
     $input->setInteractive(FALSE);

--- a/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
+++ b/tests/phpunit/src/CloudApi/AccessTokenConnectorTest.php
@@ -48,14 +48,14 @@ class AccessTokenConnectorTest extends TestBase {
     self::setAccessTokenEnvVars();
     // Ensure that ACLI_ACCESS_TOKEN was used to populate the refresh token.
     self::assertEquals(self::$accessToken, $this->cloudCredentials->getCloudAccessToken());
-    $connector_factory = new ConnectorFactory(
+    $connectorFactory = new ConnectorFactory(
       [
         'accessToken' => $this->cloudCredentials->getCloudAccessToken(),
         'accessTokenExpiry' => $this->cloudCredentials->getCloudAccessTokenExpiry(),
         'key' => NULL,
         'secret' => NULL,
       ]);
-    $connector = $connector_factory->createConnector();
+    $connector = $connectorFactory->createConnector();
     self::assertInstanceOf(AccessTokenConnector::class, $connector);
     self::assertEquals(self::$accessToken, $connector->getAccessToken()->getToken());
 
@@ -63,11 +63,11 @@ class AccessTokenConnectorTest extends TestBase {
     $path = 'api';
 
     // Make sure that new access tokens are fetched using the refresh token.
-    $mock_provider = $this->prophet->prophesize(GenericProvider::class);
-    $mock_provider->getAuthenticatedRequest($verb, ConnectorInterface::BASE_URI . $path, Argument::type(AccessTokenInterface::class))
+    $mockProvider = $this->prophet->prophesize(GenericProvider::class);
+    $mockProvider->getAuthenticatedRequest($verb, ConnectorInterface::BASE_URI . $path, Argument::type(AccessTokenInterface::class))
       ->willReturn($this->prophet->prophesize(RequestInterface::class)->reveal())
       ->shouldBeCalled();
-    $connector->setProvider($mock_provider->reveal());
+    $connector->setProvider($mockProvider->reveal());
     $connector->createRequest($verb, $path);
 
     $this->prophet->checkPredictions();
@@ -80,10 +80,10 @@ class AccessTokenConnectorTest extends TestBase {
       'token' => self::$accessToken . "\n",
 ];
     $vfs = vfsStream::setup('root', NULL, $directory);
-    $token_file = Path::join($vfs->url(), 'token');
-    $expiry_file = Path::join($vfs->url(), 'expiry');
-    putenv('ACLI_ACCESS_TOKEN_FILE=' . $token_file);
-    putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiry_file);
+    $tokenFile = Path::join($vfs->url(), 'token');
+    $expiryFile = Path::join($vfs->url(), 'expiry');
+    putenv('ACLI_ACCESS_TOKEN_FILE=' . $tokenFile);
+    putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiryFile);
     self::assertEquals(self::$accessToken, $this->cloudCredentials->getCloudAccessToken());
     self::assertEquals($accessTokenExpiry, $this->cloudCredentials->getCloudAccessTokenExpiry());
   }
@@ -94,12 +94,12 @@ class AccessTokenConnectorTest extends TestBase {
       'expiry' => (string) $accessTokenExpiry,
     ];
     $vfs = vfsStream::setup('root', NULL, $directory);
-    $token_file = Path::join($vfs->url(), 'token');
-    $expiry_file = Path::join($vfs->url(), 'expiry');
-    putenv('ACLI_ACCESS_TOKEN_FILE=' . $token_file);
-    putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiry_file);
+    $tokenFile = Path::join($vfs->url(), 'token');
+    $expiryFile = Path::join($vfs->url(), 'expiry');
+    putenv('ACLI_ACCESS_TOKEN_FILE=' . $tokenFile);
+    putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiryFile);
     $this->expectException(AcquiaCliException::class);
-    $this->expectExceptionMessage('Access token file not found at ' . $token_file);
+    $this->expectExceptionMessage('Access token file not found at ' . $tokenFile);
     $this->cloudCredentials->getCloudAccessToken();
   }
 
@@ -108,12 +108,12 @@ class AccessTokenConnectorTest extends TestBase {
       'token' => self::$accessToken,
     ];
     $vfs = vfsStream::setup('root', NULL, $directory);
-    $token_file = Path::join($vfs->url(), 'token');
-    $expiry_file = Path::join($vfs->url(), 'expiry');
-    putenv('ACLI_ACCESS_TOKEN_FILE=' . $token_file);
-    putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiry_file);
+    $tokenFile = Path::join($vfs->url(), 'token');
+    $expiryFile = Path::join($vfs->url(), 'expiry');
+    putenv('ACLI_ACCESS_TOKEN_FILE=' . $tokenFile);
+    putenv('ACLI_ACCESS_TOKEN_EXPIRY_FILE=' . $expiryFile);
     $this->expectException(AcquiaCliException::class);
-    $this->expectExceptionMessage('Access token expiry file not found at ' . $expiry_file);
+    $this->expectExceptionMessage('Access token expiry file not found at ' . $expiryFile);
     $this->cloudCredentials->getCloudAccessTokenExpiry();
   }
 
@@ -125,39 +125,39 @@ class AccessTokenConnectorTest extends TestBase {
     self::setAccessTokenEnvVars();
     // Ensure that ACLI_ACCESS_TOKEN was used to populate the refresh token.
     self::assertEquals(self::$accessToken, $this->cloudCredentials->getCloudAccessToken());
-    $connector_factory = new ConnectorFactory(
+    $connectorFactory = new ConnectorFactory(
       [
         'accessToken' => $this->cloudCredentials->getCloudAccessToken(),
         'accessTokenExpiry' => $this->cloudCredentials->getCloudAccessTokenExpiry(),
         'key' => $this->cloudCredentials->getCloudKey(),
         'secret' => $this->cloudCredentials->getCloudSecret(),
       ]);
-    $connector = $connector_factory->createConnector();
+    $connector = $connectorFactory->createConnector();
     self::assertInstanceOf(Connector::class, $connector);
   }
 
   public function testExpiredAccessToken(): void {
     self::setAccessTokenEnvVars(TRUE);
-    $connector_factory = new ConnectorFactory(
+    $connectorFactory = new ConnectorFactory(
       [
         'accessToken' => $this->cloudCredentials->getCloudAccessToken(),
         'accessTokenExpiry' => $this->cloudCredentials->getCloudAccessTokenExpiry(),
         'key' => NULL,
         'secret' => NULL,
       ]);
-    $connector = $connector_factory->createConnector();
+    $connector = $connectorFactory->createConnector();
     self::assertInstanceOf(Connector::class, $connector);
   }
 
   public function testConnectorConfig(): void {
     self::setAccessTokenEnvVars();
-    $connector_factory = new ConnectorFactory(
+    $connectorFactory = new ConnectorFactory(
       [
         'accessToken' => NULL,
         'key' => $this->cloudCredentials->getCloudKey(),
         'secret' => $this->cloudCredentials->getCloudSecret(),
       ]);
-    $clientService = new ClientService($connector_factory, $this->application, $this->cloudCredentials);
+    $clientService = new ClientService($connectorFactory, $this->application, $this->cloudCredentials);
     $client = $clientService->getClient();
     $options = $client->getOptions();
     $this->assertEquals(['User-Agent' => [0 => 'acli/UNKNOWN']], $options['headers']);
@@ -168,16 +168,16 @@ class AccessTokenConnectorTest extends TestBase {
   public function testIdeHeader(): void {
     self::setAccessTokenEnvVars();
     IdeHelper::setCloudIdeEnvVars();
-    $connector_factory = new ConnectorFactory(
+    $connectorFactory = new ConnectorFactory(
       [
         'accessToken' => NULL,
         'key' => $this->cloudCredentials->getCloudKey(),
         'secret' => $this->cloudCredentials->getCloudSecret(),
       ]);
-    $clientService = new ClientService($connector_factory, $this->application, $this->cloudCredentials);
+    $clientService = new ClientService($connectorFactory, $this->application, $this->cloudCredentials);
     $client = $clientService->getClient();
     $options = $client->getOptions();
-    $this->assertEquals(['User-Agent' => [0 => 'acli/UNKNOWN'], 'X-Cloud-IDE-UUID' => IdeHelper::$remote_ide_uuid], $options['headers']);
+    $this->assertEquals(['User-Agent' => [0 => 'acli/UNKNOWN'], 'X-Cloud-IDE-UUID' => IdeHelper::$remoteIdeUuid], $options['headers']);
 
     $this->prophet->checkPredictions();
     IdeHelper::unsetCloudIdeEnvVars();

--- a/tests/phpunit/src/CloudApi/AcsfClientServiceTest.php
+++ b/tests/phpunit/src/CloudApi/AcsfClientServiceTest.php
@@ -28,15 +28,15 @@ class AcsfClientServiceTest extends TestBase {
 
   /**
    * @dataProvider providerTestIsMachineAuthenticated
-   * @param array $env_vars
+   * @param array $envVars
    */
-  public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated): void {
-    self::setEnvVars($env_vars);
-    $cloud_datastore = $this->prophet->prophesize(CloudDataStore::class);
-    $client_service = new AcsfClientService(new AcsfConnectorFactory(['key' => NULL, 'secret' => NULL, 'accessToken' => NULL]), $this->application, new AcsfCredentials($cloud_datastore->reveal()));
-    $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated());
-    $client_service->getClient();
-    self::unsetEnvVars($env_vars);
+  public function testIsMachineAuthenticated(array $envVars, bool $isAuthenticated): void {
+    self::setEnvVars($envVars);
+    $cloudDatastore = $this->prophet->prophesize(CloudDataStore::class);
+    $clientService = new AcsfClientService(new AcsfConnectorFactory(['key' => NULL, 'secret' => NULL, 'accessToken' => NULL]), $this->application, new AcsfCredentials($cloudDatastore->reveal()));
+    $this->assertEquals($isAuthenticated, $clientService->isMachineAuthenticated());
+    $clientService->getClient();
+    self::unsetEnvVars($envVars);
   }
 
 }

--- a/tests/phpunit/src/CloudApi/ClientServiceTest.php
+++ b/tests/phpunit/src/CloudApi/ClientServiceTest.php
@@ -36,14 +36,14 @@ class ClientServiceTest extends TestBase {
 
   /**
    * @dataProvider providerTestIsMachineAuthenticated
-   * @param array $env_vars
+   * @param array $envVars
    */
-  public function testIsMachineAuthenticated(array $env_vars, bool $is_authenticated): void {
-    self::setEnvVars($env_vars);
-    $cloud_datastore = $this->prophet->prophesize(CloudDataStore::class);
-    $client_service = new ClientService(new ConnectorFactory(['key' => NULL, 'secret' => NULL, 'accessToken' => NULL]), $this->application, new CloudCredentials($cloud_datastore->reveal()));
-    $this->assertEquals($is_authenticated, $client_service->isMachineAuthenticated());
-    self::unsetEnvVars($env_vars);
+  public function testIsMachineAuthenticated(array $envVars, bool $isAuthenticated): void {
+    self::setEnvVars($envVars);
+    $cloudDatastore = $this->prophet->prophesize(CloudDataStore::class);
+    $clientService = new ClientService(new ConnectorFactory(['key' => NULL, 'secret' => NULL, 'accessToken' => NULL]), $this->application, new CloudCredentials($cloudDatastore->reveal()));
+    $this->assertEquals($isAuthenticated, $clientService->isMachineAuthenticated());
+    self::unsetEnvVars($envVars);
   }
 
 }

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -82,8 +82,8 @@ abstract class CommandTestBase extends TestBase {
     $cwd = $this->projectDir;
     $tester = $this->getCommandTester();
     $tester->setInputs($inputs);
-    $command_name = $this->command->getName();
-    $args = array_merge(['command' => $command_name], $args);
+    $commandName = $this->command->getName();
+    $args = array_merge(['command' => $commandName], $args);
 
     if (getenv('ACLI_PRINT_COMMAND_OUTPUT')) {
       $this->consoleOutput->writeln('');
@@ -120,9 +120,9 @@ abstract class CommandTestBase extends TestBase {
     }
 
     $this->application->add($this->command);
-    $found_command = $this->application->find($this->command->getName());
-    $this->assertInstanceOf(get_class($this->command), $found_command, 'Instantiated class.');
-    $this->commandTester = new CommandTester($found_command);
+    $foundCommand = $this->application->find($this->command->getName());
+    $this->assertInstanceOf(get_class($this->command), $foundCommand, 'Instantiated class.');
+    $this->commandTester = new CommandTester($foundCommand);
 
     return $this->commandTester;
   }
@@ -156,9 +156,9 @@ abstract class CommandTestBase extends TestBase {
    *   Output.
    */
   protected function writeFullWidthLine(string $message, OutputInterface $output): void {
-    $terminal_width = (new Terminal())->getWidth();
-    $padding_len = (int) (($terminal_width - strlen($message)) / 2);
-    $pad = $padding_len > 0 ? str_repeat('-', $padding_len) : '';
+    $terminalWidth = (new Terminal())->getWidth();
+    $paddingLen = (int) (($terminalWidth - strlen($message)) / 2);
+    $pad = $paddingLen > 0 ? str_repeat('-', $paddingLen) : '';
     $output->writeln("<comment>{$pad}{$message}{$pad}</comment>");
   }
 
@@ -195,12 +195,12 @@ abstract class CommandTestBase extends TestBase {
     $this->fs->remove([$this->getTargetGitConfigFixture(), dirname($this->getTargetGitConfigFixture())]);
   }
 
-  protected function mockReadIdePhpVersion(string $php_version = '7.1'): LocalMachineHelper|ObjectProphecy {
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $local_machine_helper->getLocalFilepath(Path::join($this->dataDir, 'acquia-cli.json'))->willReturn(Path::join($this->dataDir, 'acquia-cli.json'));
-    $local_machine_helper->readFile('/home/ide/configs/php/.version')->willReturn("$php_version\n")->shouldBeCalled();
+  protected function mockReadIdePhpVersion(string $phpVersion = '7.1'): LocalMachineHelper|ObjectProphecy {
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $localMachineHelper->getLocalFilepath(Path::join($this->dataDir, 'acquia-cli.json'))->willReturn(Path::join($this->dataDir, 'acquia-cli.json'));
+    $localMachineHelper->readFile('/home/ide/configs/php/.version')->willReturn("$phpVersion\n")->shouldBeCalled();
 
-    return $local_machine_helper;
+    return $localMachineHelper;
   }
 
   protected function mockLocalMachineHelper(): LocalMachineHelper|ObjectProphecy {
@@ -217,56 +217,56 @@ abstract class CommandTestBase extends TestBase {
   }
 
   protected function mockGetEnvironments(): object {
-    $environment_response = $this->getMockEnvironmentResponse();
+    $environmentResponse = $this->getMockEnvironmentResponse();
     $this->clientProphecy->request('get',
-      "/environments/" . $environment_response->id)
-      ->willReturn($environment_response)
+      "/environments/" . $environmentResponse->id)
+      ->willReturn($environmentResponse)
       ->shouldBeCalled();
-    return $environment_response;
+    return $environmentResponse;
   }
 
   public function mockAcsfEnvironmentsRequest(
-    object $applications_response
+    object $applicationsResponse
   ): object {
-    $environments_response = $this->getMockEnvironmentsResponse();
-    foreach ($environments_response->_embedded->items as $environment) {
+    $environmentsResponse = $this->getMockEnvironmentsResponse();
+    foreach ($environmentsResponse->_embedded->items as $environment) {
       $environment->ssh_url = 'profserv2.01dev@profserv201dev.ssh.enterprise-g1.acquia-sites.com';
       $environment->domains = ["profserv201dev.enterprise-g1.acquia-sites.com"];
     }
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
-      ->willReturn($environments_response->_embedded->items)
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
+      ->willReturn($environmentsResponse->_embedded->items)
       ->shouldBeCalled();
 
-    return $environments_response;
+    return $environmentsResponse;
   }
 
   /**
-   * @param $ssh_helper
+   * @param $sshHelper
    */
-  protected function mockGetAcsfSites($ssh_helper): void {
-    $acsf_multisite_fetch_process = $this->mockProcess();
-    $acsf_multisite_fetch_process->getOutput()->willReturn(file_get_contents(Path::join($this->realFixtureDir,
+  protected function mockGetAcsfSites($sshHelper): void {
+    $acsfMultisiteFetchProcess = $this->mockProcess();
+    $acsfMultisiteFetchProcess->getOutput()->willReturn(file_get_contents(Path::join($this->realFixtureDir,
       '/multisite-config.json')))->shouldBeCalled();
-    $ssh_helper->executeCommand(
+    $sshHelper->executeCommand(
       Argument::type('object'),
       ['cat', '/var/www/site-php/profserv2.dev/multisite-config.json'],
       FALSE
-    )->willReturn($acsf_multisite_fetch_process->reveal())->shouldBeCalled();
+    )->willReturn($acsfMultisiteFetchProcess->reveal())->shouldBeCalled();
   }
 
   /**
-   * @param $ssh_helper
+   * @param $sshHelper
    */
-  protected function mockGetCloudSites($ssh_helper, $environment): void {
-    $cloud_multisite_fetch_process = $this->mockProcess();
-    $cloud_multisite_fetch_process->getOutput()->willReturn("\nbar\ndefault\nfoo\n")->shouldBeCalled();
+  protected function mockGetCloudSites($sshHelper, $environment): void {
+    $cloudMultisiteFetchProcess = $this->mockProcess();
+    $cloudMultisiteFetchProcess->getOutput()->willReturn("\nbar\ndefault\nfoo\n")->shouldBeCalled();
     $sitegroup = CommandBase::getSiteGroupFromSshUrl($environment->ssh_url);
-    $ssh_helper->executeCommand(
+    $sshHelper->executeCommand(
       Argument::type('object'),
       ['ls', "/mnt/files/$sitegroup.{$environment->name}/sites"],
       FALSE
-    )->willReturn($cloud_multisite_fetch_process->reveal())->shouldBeCalled();
+    )->willReturn($cloudMultisiteFetchProcess->reveal())->shouldBeCalled();
   }
 
   protected function mockProcess(bool $success = TRUE): Process|ObjectProphecy {
@@ -286,176 +286,176 @@ abstract class CommandTestBase extends TestBase {
    * @return \AcquiaCloudApi\Response\DatabaseResponse[]
    */
   protected function mockAcsfDatabasesResponse(
-    object $environments_response
+    object $environmentsResponse
   ): array {
-    $databases_response_json = json_decode(file_get_contents(Path::join($this->realFixtureDir, '/acsf_db_response.json')), FALSE, 512, JSON_THROW_ON_ERROR);
-    $databases_response = array_map(
-      static function ($database_response) {
-        return new DatabaseResponse($database_response);
+    $databasesResponseJson = json_decode(file_get_contents(Path::join($this->realFixtureDir, '/acsf_db_response.json')), FALSE, 512, JSON_THROW_ON_ERROR);
+    $databasesResponse = array_map(
+      static function ($databaseResponse) {
+        return new DatabaseResponse($databaseResponse);
       },
-      $databases_response_json
+      $databasesResponseJson
     );
     $this->clientProphecy->request('get',
-      "/environments/{$environments_response->id}/databases")
-      ->willReturn($databases_response)
+      "/environments/{$environmentsResponse->id}/databases")
+      ->willReturn($databasesResponse)
       ->shouldBeCalled();
 
-    return $databases_response;
+    return $databasesResponse;
   }
 
   /**
-   * @param $db_name
-   * @param $backup_id
+   * @param $dbName
+   * @param $backupId
    */
   protected function mockDatabaseBackupsResponse(
-    object $environments_response,
-    $db_name,
-    $backup_id
+    object $environmentsResponse,
+    $dbName,
+    $backupId
   ): object {
-    $database_backups_response = $this->getMockResponseFromSpec('/environments/{environmentId}/databases/{databaseName}/backups', 'get', 200);
-    foreach ($database_backups_response->_embedded->items as $backup) {
-      $backup->_links->download->href = "/environments/{$environments_response->id}/databases/{$db_name}/backups/{$backup_id}/actions/download";
-      $backup->database->name = $db_name;
+    $databaseBackupsResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/databases/{databaseName}/backups', 'get', 200);
+    foreach ($databaseBackupsResponse->_embedded->items as $backup) {
+      $backup->_links->download->href = "/environments/{$environmentsResponse->id}/databases/{$dbName}/backups/{$backupId}/actions/download";
+      $backup->database->name = $dbName;
       // Acquia PHP SDK mutates the property name. Gross workaround, is there a better way?
       $backup->completedAt = $backup->completed_at;
     }
     $this->clientProphecy->request('get',
-      "/environments/{$environments_response->id}/databases/{$db_name}/backups")
-      ->willReturn($database_backups_response->_embedded->items)
+      "/environments/{$environmentsResponse->id}/databases/{$dbName}/backups")
+      ->willReturn($databaseBackupsResponse->_embedded->items)
       ->shouldBeCalled();
 
-    return $database_backups_response;
+    return $databaseBackupsResponse;
   }
 
   /**
-   * @param $environments_response
-   * @param $db_name
-   * @param $backup_id
+   * @param $environmentsResponse
+   * @param $dbName
+   * @param $backupId
    */
   protected function mockDownloadBackupResponse(
-    $environments_response,
-    $db_name,
-    $backup_id
+    $environmentsResponse,
+    $dbName,
+    $backupId
   ): void {
     $stream = $this->prophet->prophesize(StreamInterface::class);
-    $this->clientProphecy->stream('get', "/environments/{$environments_response->id}/databases/{$db_name}/backups/{$backup_id}/actions/download", [])
+    $this->clientProphecy->stream('get', "/environments/{$environmentsResponse->id}/databases/{$dbName}/backups/{$backupId}/actions/download", [])
       ->willReturn($stream->reveal())
       ->shouldBeCalled();
   }
 
   protected function mockDatabaseBackupCreateResponse(
-    $environments_response,
-    $db_name
+    $environmentsResponse,
+    $dbName
   ) {
-    $backup_create_response = $this->getMockResponseFromSpec('/environments/{environmentId}/databases/{databaseName}/backups', 'post', 202)->{'Creating backup'}->value;
-    $this->clientProphecy->request('post', "/environments/$environments_response->id/databases/{$db_name}/backups")
-      ->willReturn($backup_create_response)
+    $backupCreateResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/databases/{databaseName}/backups', 'post', 202)->{'Creating backup'}->value;
+    $this->clientProphecy->request('post', "/environments/$environmentsResponse->id/databases/{$dbName}/backups")
+      ->willReturn($backupCreateResponse)
       ->shouldBeCalled();
 
-    return $backup_create_response;
+    return $backupCreateResponse;
   }
 
   protected function mockNotificationResponseFromObject(object $responseWithNotificationLink) {
     return $this->mockNotificationResponse(substr($responseWithNotificationLink->_links->notification->href, -36));
   }
 
-  protected function mockNotificationResponse(string $notification_uuid, string $status = NULL) {
-    $notification_response = $this->getMockResponseFromSpec('/notifications/{notificationUuid}', 'get', 200);
+  protected function mockNotificationResponse(string $notificationUuid, string $status = NULL) {
+    $notificationResponse = $this->getMockResponseFromSpec('/notifications/{notificationUuid}', 'get', 200);
     if ($status) {
-      $notification_response->status = $status;
+      $notificationResponse->status = $status;
     }
-    $this->clientProphecy->request('get', "/notifications/$notification_uuid")
-      ->willReturn($notification_response)
+    $this->clientProphecy->request('get', "/notifications/$notificationUuid")
+      ->willReturn($notificationResponse)
       ->shouldBeCalled();
 
-    return $notification_response;
+    return $notificationResponse;
   }
 
-  protected function mockCreateMySqlDumpOnLocal(ObjectProphecy $local_machine_helper): void {
-    $local_machine_helper->checkRequiredBinariesExist(["mysqldump", "gzip"])->shouldBeCalled();
+  protected function mockCreateMySqlDumpOnLocal(ObjectProphecy $localMachineHelper): void {
+    $localMachineHelper->checkRequiredBinariesExist(["mysqldump", "gzip"])->shouldBeCalled();
     $process = $this->mockProcess(TRUE);
     $process->getOutput()->willReturn('');
     $command = 'MYSQL_PWD=drupal mysqldump --host=localhost --user=drupal drupal | pv --rate --bytes | gzip -9 > ' . sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz';
-    $local_machine_helper->executeFromCmd($command, Argument::type('callable'), NULL, TRUE)->willReturn($process->reveal())
+    $localMachineHelper->executeFromCmd($command, Argument::type('callable'), NULL, TRUE)->willReturn($process->reveal())
       ->shouldBeCalled();
   }
 
   protected function mockExecutePvExists(
-        ObjectProphecy $local_machine_helper
+        ObjectProphecy $localMachineHelper
     ): void {
-    $local_machine_helper
+    $localMachineHelper
             ->commandExists('pv')
             ->willReturn(TRUE)
             ->shouldBeCalled();
   }
 
   protected function mockExecuteGlabExists(
-    ObjectProphecy $local_machine_helper
+    ObjectProphecy $localMachineHelper
   ): void {
-    $local_machine_helper
+    $localMachineHelper
       ->commandExists('glab')
       ->willReturn(TRUE)
       ->shouldBeCalled();
   }
 
   /**
-   * Mock guzzle requests for update checks so we don't actually hit Github.
+   * Mock guzzle requests for update checks, so we don't actually hit GitHub.
    */
-  protected function setUpdateClient(int $status_code = 200): void {
-    /** @var ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzle_response */
-    $guzzle_response = $this->prophet->prophesize(Response::class);
+  protected function setUpdateClient(int $statusCode = 200): void {
+    /** @var ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzleResponse */
+    $guzzleResponse = $this->prophet->prophesize(Response::class);
     $stream = $this->prophet->prophesize(StreamInterface::class);
     $stream->__toString()->willReturn(file_get_contents(Path::join(__DIR__, '..', '..', 'fixtures', 'github-releases.json')));
-    $guzzle_response->getBody()->willReturn($stream->reveal());
-    $guzzle_response->getReasonPhrase()->willReturn('');
-    $guzzle_response->getStatusCode()->willReturn($status_code);
-    $guzzle_client = $this->prophet->prophesize(Client::class);
-    $guzzle_client->get('https://api.github.com/repos/acquia/cli/releases')
-      ->willReturn($guzzle_response->reveal());
-    $this->command->setUpdateClient($guzzle_client->reveal());
+    $guzzleResponse->getBody()->willReturn($stream->reveal());
+    $guzzleResponse->getReasonPhrase()->willReturn('');
+    $guzzleResponse->getStatusCode()->willReturn($statusCode);
+    $guzzleClient = $this->prophet->prophesize(Client::class);
+    $guzzleClient->get('https://api.github.com/repos/acquia/cli/releases')
+      ->willReturn($guzzleResponse->reveal());
+    $this->command->setUpdateClient($guzzleClient->reveal());
   }
 
-  protected function mockPollCloudViaSsh(object $environments_response): ObjectProphecy {
+  protected function mockPollCloudViaSsh(object $environmentsResponse): ObjectProphecy {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(0);
     $gitProcess = $this->prophet->prophesize(Process::class);
     $gitProcess->isSuccessful()->willReturn(TRUE);
     $gitProcess->getExitCode()->willReturn(128);
-    $ssh_helper = $this->mockSshHelper();
+    $sshHelper = $this->mockSshHelper();
     // Mock Git.
-    $url_parts = explode(':', $environments_response->_embedded->items[0]->vcs->url);
-    $ssh_helper->executeCommand($url_parts[0], ['ls'], FALSE)
+    $urlParts = explode(':', $environmentsResponse->_embedded->items[0]->vcs->url);
+    $sshHelper->executeCommand($urlParts[0], ['ls'], FALSE)
       ->willReturn($gitProcess->reveal())
       ->shouldBeCalled();
     // Mock non-prod.
-    $ssh_helper->executeCommand(new EnvironmentResponse($environments_response->_embedded->items[0]), ['ls'], FALSE)
+    $sshHelper->executeCommand(new EnvironmentResponse($environmentsResponse->_embedded->items[0]), ['ls'], FALSE)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
     // Mock prod.
-    $ssh_helper->executeCommand(new EnvironmentResponse($environments_response->_embedded->items[1]), ['ls'], FALSE)
+    $sshHelper->executeCommand(new EnvironmentResponse($environmentsResponse->_embedded->items[1]), ['ls'], FALSE)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
-    return $ssh_helper;
+    return $sshHelper;
   }
 
-  protected function mockPollCloudGitViaSsh(object $environment_response): ObjectProphecy {
+  protected function mockPollCloudGitViaSsh(object $environmentResponse): ObjectProphecy {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(128);
-    $ssh_helper = $this->mockSshHelper();
-    $ssh_helper->executeCommand($environment_response->vcs->url, ['ls'], FALSE)
+    $sshHelper = $this->mockSshHelper();
+    $sshHelper->executeCommand($environmentResponse->vcs->url, ['ls'], FALSE)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
-    return $ssh_helper;
+    return $sshHelper;
   }
 
   /**
-   * @param $local_machine_helper
-   * @param $public_key
+   * @param $localMachineHelper
+   * @param $publicKey
    */
-  protected function mockGetLocalSshKey($local_machine_helper, $file_system, $public_key): string {
-    $file_system->exists(Argument::type('string'))->willReturn(TRUE);
+  protected function mockGetLocalSshKey($localMachineHelper, $fileSystem, $publicKey): string {
+    $fileSystem->exists(Argument::type('string'))->willReturn(TRUE);
     /** @var \Symfony\Component\Finder\Finder|\Prophecy\Prophecy\ObjectProphecy $finder */
     $finder = $this->prophet->prophesize(Finder::class);
     $finder->files()->willReturn($finder);
@@ -463,14 +463,14 @@ abstract class CommandTestBase extends TestBase {
     $finder->name(Argument::type('string'))->willReturn($finder);
     $finder->ignoreUnreadableDirs()->willReturn($finder);
     $file = $this->prophet->prophesize(SplFileInfo::class);
-    $file_name = 'id_rsa.pub';
-    $file->getFileName()->willReturn($file_name);
+    $fileName = 'id_rsa.pub';
+    $file->getFileName()->willReturn($fileName);
     $file->getRealPath()->willReturn('somepath');
-    $local_machine_helper->readFile('somepath')->willReturn($public_key);
+    $localMachineHelper->readFile('somepath')->willReturn($publicKey);
     $finder->getIterator()->willReturn(new \ArrayIterator([$file->reveal()]));
-    $local_machine_helper->getFinder()->willReturn($finder);
+    $localMachineHelper->getFinder()->willReturn($finder);
 
-    return $file_name;
+    return $fileName;
   }
 
   /**
@@ -497,16 +497,16 @@ abstract class CommandTestBase extends TestBase {
    * @return array
    */
   protected function getApiCommands(): array {
-    $api_command_helper = new ApiCommandHelper($this->logger);
-    $command_factory = $this->getCommandFactory();
-    return $api_command_helper->getApiCommands($this->apiSpecFixtureFilePath, $this->apiCommandPrefix, $command_factory);
+    $apiCommandHelper = new ApiCommandHelper($this->logger);
+    $commandFactory = $this->getCommandFactory();
+    return $apiCommandHelper->getApiCommands($this->apiSpecFixtureFilePath, $this->apiCommandPrefix, $commandFactory);
   }
 
   protected function getApiCommandByName(string $name): ApiBaseCommand|AcsfCommandBase|null {
-    $api_commands = $this->getApiCommands();
-    foreach ($api_commands as $api_command) {
-      if ($api_command->getName() === $name) {
-        return $api_command;
+    $apiCommands = $this->getApiCommands();
+    foreach ($apiCommands as $apiCommand) {
+      if ($apiCommand->getName() === $name) {
+        return $apiCommand;
       }
     }
 
@@ -514,15 +514,15 @@ abstract class CommandTestBase extends TestBase {
   }
 
   /**
-   * @param $project_id
+   * @param $projectId
    * @return array
    */
-  protected function getMockedGitLabProject($project_id): array {
+  protected function getMockedGitLabProject($projectId): array {
     return [
       'default_branch' => 'master',
       'description' => '',
       'http_url_to_repo' => 'https://code.cloudservices.acquia.io/matthew.grasmick/codestudiodemo.git',
-      'id' => $project_id,
+      'id' => $projectId,
       'name' => 'codestudiodemo',
       'name_with_namespace' => 'Matthew Grasmick / codestudiodemo',
       'path' => 'codestudiodemo',
@@ -537,36 +537,36 @@ abstract class CommandTestBase extends TestBase {
   /**
    * @return \Prophecy\Prophecy\ObjectProphecy|\Gitlab\Client
    */
-  protected function mockGitLabAuthenticate(ObjectProphecy|LocalMachineHelper $local_machine_helper, $gitlab_host, $gitlab_token): ObjectProphecy|\Gitlab\Client {
-    $this->mockGitlabGetHost($local_machine_helper, $gitlab_host);
-    $this->mockGitlabGetToken($local_machine_helper, $gitlab_token, $gitlab_host);
-    $gitlab_client = $this->prophet->prophesize(\Gitlab\Client::class);
-    $gitlab_client->users()->willThrow(RuntimeException::class);
-    return $gitlab_client;
+  protected function mockGitLabAuthenticate(ObjectProphecy|LocalMachineHelper $localMachineHelper, $gitlabHost, $gitlabToken): ObjectProphecy|\Gitlab\Client {
+    $this->mockGitlabGetHost($localMachineHelper, $gitlabHost);
+    $this->mockGitlabGetToken($localMachineHelper, $gitlabToken, $gitlabHost);
+    $gitlabClient = $this->prophet->prophesize(\Gitlab\Client::class);
+    $gitlabClient->users()->willThrow(RuntimeException::class);
+    return $gitlabClient;
   }
 
   /**
-   * @param $local_machine_helper
+   * @param $localMachineHelper
    */
-  protected function mockGitlabGetToken($local_machine_helper, string $gitlab_token, string $gitlab_host, bool $success = TRUE): void {
+  protected function mockGitlabGetToken($localMachineHelper, string $gitlabToken, string $gitlabHost, bool $success = TRUE): void {
     $process = $this->mockProcess($success);
-    $process->getOutput()->willReturn($gitlab_token);
-    $local_machine_helper->execute([
+    $process->getOutput()->willReturn($gitlabToken);
+    $localMachineHelper->execute([
       'glab',
       'config',
       'get',
       'token',
-      '--host=' . $gitlab_host,
+      '--host=' . $gitlabHost,
     ], NULL, NULL, FALSE)->willReturn($process->reveal());
   }
 
   /**
-   * @param $local_machine_helper
+   * @param $localMachineHelper
    */
-  protected function mockGitlabGetHost($local_machine_helper, string $gitlab_host): void {
+  protected function mockGitlabGetHost($localMachineHelper, string $gitlabHost): void {
     $process = $this->mockProcess();
-    $process->getOutput()->willReturn($gitlab_host);
-    $local_machine_helper->execute([
+    $process->getOutput()->willReturn($gitlabHost);
+    $localMachineHelper->execute([
       'glab',
       'config',
       'get',
@@ -575,9 +575,9 @@ abstract class CommandTestBase extends TestBase {
   }
 
   /**
-   * @param \Prophecy\Prophecy\ObjectProphecy|\Gitlab\Client $gitlab_client
+   * @param \Prophecy\Prophecy\ObjectProphecy|\Gitlab\Client $gitlabClient
    */
-  protected function mockGitLabUsersMe(ObjectProphecy|\Gitlab\Client $gitlab_client): void {
+  protected function mockGitLabUsersMe(ObjectProphecy|\Gitlab\Client $gitlabClient): void {
     $users = $this->prophet->prophesize(Users::class);
     $me = [
       'avatar_url' => 'https://secure.gravatar.com/avatar/5ee7b8ad954bf7156e6eb57a45d60dec?s=80&d=identicon',
@@ -621,37 +621,37 @@ abstract class CommandTestBase extends TestBase {
       'work_information' => NULL,
     ];
     $users->me()->willReturn($me);
-    $gitlab_client->users()->willReturn($users->reveal());
+    $gitlabClient->users()->willReturn($users->reveal());
   }
 
   /**
-   * @param $application_uuid
+   * @param $applicationUuid
    * @return array
    */
-  protected function mockGitLabPermissionsRequest($application_uuid): array {
-    $permissions_response = $this->getMockResponseFromSpec('/applications/{applicationUuid}/permissions', 'get', 200);
-    $permissions = $permissions_response->_embedded->items;
+  protected function mockGitLabPermissionsRequest($applicationUuid): array {
+    $permissionsResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/permissions', 'get', 200);
+    $permissions = $permissionsResponse->_embedded->items;
     $permission = clone reset($permissions);
     $permission->name = "administer environment variables on non-prod";
     $permissions[] = $permission;
-    $this->clientProphecy->request('get', "/applications/{$application_uuid}/permissions")
+    $this->clientProphecy->request('get', "/applications/{$applicationUuid}/permissions")
       ->willReturn($permissions)
       ->shouldBeCalled();
     return $permissions;
   }
 
   /**
-   * @param $application_uuid
-   * @param $gitlab_project_id
-   * @param $mocked_gitlab_projects
+   * @param $applicationUuid
+   * @param $gitlabProjectId
+   * @param $mockedGitlabProjects
    * @return \Gitlab\Api\Projects|\Prophecy\Prophecy\ObjectProphecy
    */
-  protected function mockGetGitLabProjects($application_uuid, $gitlab_project_id, $mocked_gitlab_projects): Projects|ObjectProphecy {
+  protected function mockGetGitLabProjects($applicationUuid, $gitlabProjectId, $mockedGitlabProjects): Projects|ObjectProphecy {
     $projects = $this->prophet->prophesize(Projects::class);
-    $projects->all(['search' => $application_uuid])
-      ->willReturn($mocked_gitlab_projects);
+    $projects->all(['search' => $applicationUuid])
+      ->willReturn($mockedGitlabProjects);
     $projects->all()
-      ->willReturn([$this->getMockedGitLabProject($gitlab_project_id)]);
+      ->willReturn([$this->getMockedGitLabProject($gitlabProjectId)]);
     return $projects;
   }
 

--- a/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
@@ -35,8 +35,8 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
   }
 
   public function testAcsfCommandExecutionForHttpPostWithMultipleDataTypes(): void {
-    $mock_body = $this->getMockResponseFromSpec('/api/v1/groups/{group_id}/members', 'post', '200');
-    $this->clientProphecy->request('post', '/api/v1/groups/1/members')->willReturn($mock_body)->shouldBeCalled();
+    $mockBody = $this->getMockResponseFromSpec('/api/v1/groups/{group_id}/members', 'post', '200');
+    $this->clientProphecy->request('post', '/api/v1/groups/1/members')->willReturn($mockBody)->shouldBeCalled();
     $this->clientProphecy->addOption('json', ["uids" => ["1", "2", "3"]])->shouldBeCalled();
     $this->command = $this->getApiCommandByName('acsf:groups:add-members');
     $this->executeCommand([
@@ -52,8 +52,8 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
   }
 
   public function testAcsfCommandExecutionBool(): void {
-    $mock_body = $this->getMockResponseFromSpec('/api/v1/update/pause', 'post', '200');
-    $this->clientProphecy->request('post', '/api/v1/update/pause')->willReturn($mock_body)->shouldBeCalled();
+    $mockBody = $this->getMockResponseFromSpec('/api/v1/update/pause', 'post', '200');
+    $this->clientProphecy->request('post', '/api/v1/update/pause')->willReturn($mockBody)->shouldBeCalled();
     $this->clientProphecy->addOption('json', ["pause" => TRUE])->shouldBeCalled();
     $this->command = $this->getApiCommandByName('acsf:updates:pause');
     $this->executeCommand([], [
@@ -66,9 +66,9 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
   }
 
   public function testAcsfCommandExecutionForHttpGet(): void {
-    $mock_body = $this->getMockResponseFromSpec('/api/v1/audit', 'get', '200');
+    $mockBody = $this->getMockResponseFromSpec('/api/v1/audit', 'get', '200');
     $this->clientProphecy->addQuery('limit', '1')->shouldBeCalled();
-    $this->clientProphecy->request('get', '/api/v1/audit')->willReturn($mock_body)->shouldBeCalled();
+    $this->clientProphecy->request('get', '/api/v1/audit')->willReturn($mockBody)->shouldBeCalled();
     $this->command = $this->getApiCommandByName('acsf:info:audit-events-find');
     // Our mock Client doesn't actually return a limited dataset, but we still assert it was passed added to the
     // client's query correctly.
@@ -97,11 +97,11 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
   /**
    * @dataProvider providerTestAcsfCommandExecutionForHttpGetMultiple
    */
-  public function testAcsfCommandExecutionForHttpGetMultiple($method, $spec_path, $path, $command, $arguments = [], $json_arguments = []): void {
-    $mock_body = $this->getMockResponseFromSpec($spec_path, $method, '200');
-    $this->clientProphecy->request($method, $path)->willReturn($mock_body)->shouldBeCalled();
-    foreach ($json_arguments as $argument_name => $value) {
-      $this->clientProphecy->addOption('json', [$argument_name => $value]);
+  public function testAcsfCommandExecutionForHttpGetMultiple($method, $specPath, $path, $command, $arguments = [], $jsonArguments = []): void {
+    $mockBody = $this->getMockResponseFromSpec($specPath, $method, '200');
+    $this->clientProphecy->request($method, $path)->willReturn($mockBody)->shouldBeCalled();
+    foreach ($jsonArguments as $argumentName => $value) {
+      $this->clientProphecy->addOption('json', [$argumentName => $value]);
     }
     $this->command = $this->getApiCommandByName($command);
     $this->executeCommand($arguments, []);
@@ -114,11 +114,11 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
     $contents = json_decode($output, TRUE);
   }
 
-  protected function setClientProphecies($client_service_class = ClientService::class): void {
+  protected function setClientProphecies($clientServiceClass = ClientService::class): void {
     $this->clientProphecy = $this->prophet->prophesize(AcsfClient::class);
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN']);
     $this->clientProphecy->addOption('debug', Argument::type(OutputInterface::class));
-    $this->clientServiceProphecy = $this->prophet->prophesize($client_service_class);
+    $this->clientServiceProphecy = $this->prophet->prophesize($clientServiceClass);
     $this->clientServiceProphecy->getClient()
       ->willReturn($this->clientProphecy->reveal());
     $this->clientServiceProphecy->isMachineAuthenticated()

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
@@ -22,7 +22,7 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
     return [
       // Data set 0.
       [
-        // $machine_is_authenticated
+        // $machineIsAuthenticated
         FALSE,
         // $inputs
         [
@@ -42,7 +42,7 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
       ],
       // Data set 1.
       [
-        // $machine_is_authenticated
+        // $machineIsAuthenticated
         FALSE,
         // $inputs
         [],
@@ -62,7 +62,7 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
       ],
       // Data set 2.
       [
-        // $machine_is_authenticated
+        // $machineIsAuthenticated
         TRUE,
         // $inputs
         [
@@ -85,15 +85,15 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
    * Tests the 'acsf:auth:login' command.
    *
    * @dataProvider providerTestAuthLoginCommand
-   * @param $machine_is_authenticated
+   * @param $machineIsAuthenticated
    * @param $inputs
    * @param $args
-   * @param $output_to_assert
+   * @param $outputToAssert
    * @param array $config
    * @requires OS linux|darwin
    */
-  public function testAcsfAuthLoginCommand($machine_is_authenticated, $inputs, $args, $output_to_assert, array $config = []): void {
-    if (!$machine_is_authenticated) {
+  public function testAcsfAuthLoginCommand($machineIsAuthenticated, $inputs, $args, $outputToAssert, array $config = []): void {
+    if (!$machineIsAuthenticated) {
       $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
     }
@@ -106,8 +106,8 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
 
     $this->executeCommand($args, $inputs);
     $output = $this->getDisplay();
-    $this->assertStringContainsString($output_to_assert, $output);
-    if (!$machine_is_authenticated && !array_key_exists('--key', $args)) {
+    $this->assertStringContainsString($outputToAssert, $output);
+    if (!$machineIsAuthenticated && !array_key_exists('--key', $args)) {
       $this->assertStringContainsString('Enter your Site Factory key (option -k, --key) (input will be hidden):', $output);
     }
     $this->assertKeySavedCorrectly();
@@ -118,15 +118,15 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
   }
 
   protected function assertKeySavedCorrectly(): void {
-    $creds_file = $this->cloudConfigFilepath;
-    $this->assertFileExists($creds_file);
-    $config = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $creds_file);
+    $credsFile = $this->cloudConfigFilepath;
+    $this->assertFileExists($credsFile);
+    $config = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $credsFile);
     $this->assertTrue($config->exists('acsf_active_factory'));
-    $factory_url = $config->get('acsf_active_factory');
+    $factoryUrl = $config->get('acsf_active_factory');
     $this->assertTrue($config->exists('acsf_factories'));
     $factories = $config->get('acsf_factories');
-    $this->assertArrayHasKey($factory_url, $factories);
-    $factory = $factories[$factory_url];
+    $this->assertArrayHasKey($factoryUrl, $factories);
+    $factory = $factories[$factoryUrl];
     $this->assertArrayHasKey('users', $factory);
     $this->assertArrayHasKey('active_user', $factory);
     $this->assertEquals($this->acsfUsername, $factory['active_user']);

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
@@ -25,14 +25,14 @@ class AcsfAuthLogoutCommandTest extends AcsfCommandTestBase {
     return [
       // Data set 0.
       [
-        // $machine_is_authenticated
+        // $machineIsAuthenticated
         FALSE,
         // $inputs
         [],
       ],
       // Data set 1.
       [
-        // $machine_is_authenticated
+        // $machineIsAuthenticated
         TRUE,
         // $inputs
         [
@@ -52,8 +52,8 @@ class AcsfAuthLogoutCommandTest extends AcsfCommandTestBase {
    * @param array $inputs
    * @param array $config
    */
-  public function testAcsfAuthLogoutCommand(bool $machine_is_authenticated, array $inputs, array $config = []): void {
-    if (!$machine_is_authenticated) {
+  public function testAcsfAuthLogoutCommand(bool $machineIsAuthenticated, array $inputs, array $config = []): void {
+    if (!$machineIsAuthenticated) {
       $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
     }

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -75,16 +75,16 @@ class ApiCommandTest extends CommandTestBase {
    * Tests invalid UUID.
    */
   public function testApiCommandErrorResponse(): void {
-    $invalid_uuid = '257a5440-22c3-49d1-894d-29497a1cf3b9';
+    $invalidUuid = '257a5440-22c3-49d1-894d-29497a1cf3b9';
     $this->command = $this->getApiCommandByName('api:applications:find');
-    $mock_body = $this->getMockResponseFromSpec($this->command->getPath(), $this->command->getMethod(), '404');
-    $this->clientProphecy->request('get', '/applications/' . $invalid_uuid)->willThrow(new ApiErrorException($mock_body))->shouldBeCalled();
+    $mockBody = $this->getMockResponseFromSpec($this->command->getPath(), $this->command->getMethod(), '404');
+    $this->clientProphecy->request('get', '/applications/' . $invalidUuid)->willThrow(new ApiErrorException($mockBody))->shouldBeCalled();
 
     // ApiCommandBase::convertApplicationAliastoUuid() will try to convert the invalid string to a uuid:
-    $this->clientProphecy->addQuery('filter', 'hosting=@*:' . $invalid_uuid);
+    $this->clientProphecy->addQuery('filter', 'hosting=@*:' . $invalidUuid);
     $this->clientProphecy->request('get', '/applications')->willReturn([]);
 
-    $this->executeCommand(['applicationUuid' => $invalid_uuid], [
+    $this->executeCommand(['applicationUuid' => $invalidUuid], [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
       'n',
       // Select a Cloud Platform application:
@@ -97,14 +97,14 @@ class ApiCommandTest extends CommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
     $this->assertJson($output);
-    $this->assertStringContainsString($mock_body->message, $output);
+    $this->assertStringContainsString($mockBody->message, $output);
     $this->assertEquals(1, $this->getStatusCode());
   }
 
   public function testApiCommandExecutionForHttpGet(): void {
-    $mock_body = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
+    $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
     $this->clientProphecy->addQuery('limit', '1')->shouldBeCalled();
-    $this->clientProphecy->request('get', '/account/ssh-keys')->willReturn($mock_body->{'_embedded'}->items)->shouldBeCalled();
+    $this->clientProphecy->request('get', '/account/ssh-keys')->willReturn($mockBody->{'_embedded'}->items)->shouldBeCalled();
     $this->command = $this->getApiCommandByName('api:accounts:ssh-keys-list');
     // Our mock Client doesn't actually return a limited dataset, but we still assert it was passed added to the
     // client's query correctly.
@@ -121,9 +121,9 @@ class ApiCommandTest extends CommandTestBase {
   }
 
   public function testInferApplicationUuidArgument(): void {
-    $mock_body = $this->getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
-    $this->clientProphecy->request('get', '/applications')->willReturn([$mock_body])->shouldBeCalled();
-    $this->clientProphecy->request('get', '/applications/' . $mock_body->uuid)->willReturn($mock_body)->shouldBeCalled();
+    $mockBody = $this->getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
+    $this->clientProphecy->request('get', '/applications')->willReturn([$mockBody])->shouldBeCalled();
+    $this->clientProphecy->request('get', '/applications/' . $mockBody->uuid)->willReturn($mockBody)->shouldBeCalled();
     $this->command = $this->getApiCommandByName('api:applications:find');
     $this->executeCommand([], [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -138,7 +138,7 @@ class ApiCommandTest extends CommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
     $this->assertStringContainsString('Inferring Cloud Application UUID for this command since none was provided...', $output);
-    $this->assertStringContainsString('Set application uuid to ' . $mock_body->uuid, $output);
+    $this->assertStringContainsString('Set application uuid to ' . $mockBody->uuid, $output);
     $this->assertEquals(0, $this->getStatusCode());
   }
 
@@ -224,9 +224,9 @@ class ApiCommandTest extends CommandTestBase {
    */
   public function testConvertEnvironmentAliasToUuidArgument(): void {
     ClearCacheCommand::clearCaches();
-    $applications_response = $this->mockApplicationsRequest(1);
+    $applicationsResponse = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
-    $this->mockEnvironmentsRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
     $this->mockAccountRequest();
 
     $response = $this->getMockEnvironmentResponse();
@@ -255,9 +255,9 @@ class ApiCommandTest extends CommandTestBase {
    */
   public function testConvertInvalidEnvironmentAliasToUuidArgument(): void {
     ClearCacheCommand::clearCaches();
-    $applications_response = $this->mockApplicationsRequest(1);
+    $applicationsResponse = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
-    $this->mockEnvironmentsRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
     $this->mockAccountRequest();
     $this->command = $this->getApiCommandByName('api:environments:find');
     $alias = 'devcloud2.invalid';
@@ -268,14 +268,14 @@ class ApiCommandTest extends CommandTestBase {
   }
 
   public function testApiCommandExecutionForHttpPost(): void {
-    $mock_request_args = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
-    $mock_response_body = $this->getMockResponseFromSpec('/account/ssh-keys', 'post', '202');
-    foreach ($mock_request_args as $name => $value) {
+    $mockRequestArgs = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+    $mockResponseBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'post', '202');
+    foreach ($mockRequestArgs as $name => $value) {
       $this->clientProphecy->addOption('json', [$name => $value])->shouldBeCalled();
     }
-    $this->clientProphecy->request('post', '/account/ssh-keys')->willReturn($mock_response_body)->shouldBeCalled();
+    $this->clientProphecy->request('post', '/account/ssh-keys')->willReturn($mockResponseBody)->shouldBeCalled();
     $this->command = $this->getApiCommandByName('api:accounts:ssh-key-create');
-    $this->executeCommand($mock_request_args);
+    $this->executeCommand($mockRequestArgs);
 
     // Assert.
     $this->prophet->checkPredictions();
@@ -286,18 +286,18 @@ class ApiCommandTest extends CommandTestBase {
   }
 
   public function testApiCommandExecutionForHttpPut(): void {
-    $mock_request_options = $this->getMockRequestBodyFromSpec('/environments/{environmentId}', 'put');
-    $mock_request_options['max_input_vars'] = 1001;
-    $mock_response_body = $this->getMockEnvironmentResponse('put', '202');
+    $mockRequestOptions = $this->getMockRequestBodyFromSpec('/environments/{environmentId}', 'put');
+    $mockRequestOptions['max_input_vars'] = 1001;
+    $mockResponseBody = $this->getMockEnvironmentResponse('put', '202');
 
-    foreach ($mock_request_options as $name => $value) {
+    foreach ($mockRequestOptions as $name => $value) {
       $this->clientProphecy->addOption('json', [$name => $value])->shouldBeCalled();
     }
-    $this->clientProphecy->request('put', '/environments/24-a47ac10b-58cc-4372-a567-0e02b2c3d470')->willReturn($mock_response_body)->shouldBeCalled();
+    $this->clientProphecy->request('put', '/environments/24-a47ac10b-58cc-4372-a567-0e02b2c3d470')->willReturn($mockResponseBody)->shouldBeCalled();
     $this->command = $this->getApiCommandByName('api:environments:update');
 
     $options = [];
-    foreach ($mock_request_options as $key => $value) {
+    foreach ($mockRequestOptions as $key => $value) {
       $options['--' . $key] = $value;
     }
     $options['--lang_version'] = $options['--version'];
@@ -314,11 +314,11 @@ class ApiCommandTest extends CommandTestBase {
   }
 
   public function providerTestApiCommandDefinitionParameters(): array {
-    $api_accounts_ssh_keys_list_usage = '--from="-7d" --to="-1d" --sort="field1,-field2" --limit="10" --offset="10"';
+    $apiAccountsSshKeysListUsage = '--from="-7d" --to="-1d" --sort="field1,-field2" --limit="10" --offset="10"';
     return [
-      ['0', 'api:accounts:ssh-keys-list', 'get', $api_accounts_ssh_keys_list_usage],
-      ['1', 'api:accounts:ssh-keys-list', 'get', $api_accounts_ssh_keys_list_usage],
-      ['1', 'api:accounts:ssh-keys-list', 'get', $api_accounts_ssh_keys_list_usage],
+      ['0', 'api:accounts:ssh-keys-list', 'get', $apiAccountsSshKeysListUsage],
+      ['1', 'api:accounts:ssh-keys-list', 'get', $apiAccountsSshKeysListUsage],
+      ['1', 'api:accounts:ssh-keys-list', 'get', $apiAccountsSshKeysListUsage],
       ['1', 'api:environments:domain-clear-caches', 'post', '12-d314739e-296f-11e9-b210-d663bd873d93 example.com'],
       ['1', 'api:applications:find', 'get', 'da1c0a8e-ff69-45db-88fc-acd6d2affbb7'],
       ['1', 'api:applications:find', 'get', 'myapp'],
@@ -327,33 +327,33 @@ class ApiCommandTest extends CommandTestBase {
 
   /**
    * @dataProvider providerTestApiCommandDefinitionParameters
-   * @param $use_spec_cache
-   * @param $command_name
+   * @param $useSpecCache
+   * @param $commandName
    * @param $method
    * @param $usage
    */
-  public function testApiCommandDefinitionParameters($use_spec_cache, $command_name, $method, $usage): void {
-    putenv('ACQUIA_CLI_USE_CLOUD_API_SPEC_CACHE=' . $use_spec_cache);
+  public function testApiCommandDefinitionParameters($useSpecCache, $commandName, $method, $usage): void {
+    putenv('ACQUIA_CLI_USE_CLOUD_API_SPEC_CACHE=' . $useSpecCache);
 
-    $this->command = $this->getApiCommandByName($command_name);
+    $this->command = $this->getApiCommandByName($commandName);
     $resource = $this->getResourceFromSpec($this->command->getPath(), $method);
     $this->assertEquals($resource['summary'], $this->command->getDescription());
 
-    $expected_command_name = 'api:' . $resource['x-cli-name'];
-    $this->assertEquals($expected_command_name, $this->command->getName());
+    $expectedCommandName = 'api:' . $resource['x-cli-name'];
+    $this->assertEquals($expectedCommandName, $this->command->getName());
 
     foreach ($resource['parameters'] as $parameter) {
-      $param_key = str_replace('#/components/parameters/', '', $parameter['$ref']);
-      $param = $this->getCloudApiSpec()['components']['parameters'][$param_key];
+      $paramKey = str_replace('#/components/parameters/', '', $parameter['$ref']);
+      $param = $this->getCloudApiSpec()['components']['parameters'][$paramKey];
       $this->assertTrue(
             $this->command->getDefinition()->hasOption($param['name']) ||
             $this->command->getDefinition()->hasArgument($param['name']),
-            "Command $expected_command_name does not have expected argument or option {$param['name']}"
+            "Command $expectedCommandName does not have expected argument or option {$param['name']}"
         );
     }
 
     $usages = $this->command->getUsages();
-    $this->assertContains($command_name . ' ' . $usage, $usages);
+    $this->assertContains($commandName . ' ' . $usage, $usages);
   }
 
   public function testModifiedParameterDescriptions(): void {
@@ -373,31 +373,31 @@ class ApiCommandTest extends CommandTestBase {
 
   /**
    * @dataProvider providerTestApiCommandDefinitionRequestBody
-   * @param $command_name
+   * @param $commandName
    * @param $method
    * @param $usage
    */
-  public function testApiCommandDefinitionRequestBody($command_name, $method, $usage): void {
-    $this->command = $this->getApiCommandByName($command_name);
+  public function testApiCommandDefinitionRequestBody($commandName, $method, $usage): void {
+    $this->command = $this->getApiCommandByName($commandName);
     $resource = $this->getResourceFromSpec($this->command->getPath(), $method);
-    foreach ($resource['requestBody']['content']['application/json']['example'] as $prop_key => $value) {
-      $this->assertTrue($this->command->getDefinition()->hasArgument($prop_key) || $this->command->getDefinition()
-          ->hasOption($prop_key),
-        "Command {$this->command->getName()} does not have expected argument or option $prop_key");
+    foreach ($resource['requestBody']['content']['application/json']['example'] as $propKey => $value) {
+      $this->assertTrue($this->command->getDefinition()->hasArgument($propKey) || $this->command->getDefinition()
+          ->hasOption($propKey),
+        "Command {$this->command->getName()} does not have expected argument or option $propKey");
     }
     $this->assertStringContainsString($usage, $this->command->getUsages()[0]);
   }
 
   public function testGetApplicationUuidFromBltYml(): void {
-    $mock_body = $this->getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
-    $this->clientProphecy->request('get', '/applications/' . $mock_body->uuid)->willReturn($mock_body)->shouldBeCalled();
+    $mockBody = $this->getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
+    $this->clientProphecy->request('get', '/applications/' . $mockBody->uuid)->willReturn($mockBody)->shouldBeCalled();
     $this->command = $this->getApiCommandByName('api:applications:find');
-    $blt_config_file_path = Path::join($this->projectDir, 'blt', 'blt.yml');
-    $this->fs->dumpFile($blt_config_file_path, Yaml::dump(['cloud' => ['appId' => $mock_body->uuid]]));
+    $bltConfigFilePath = Path::join($this->projectDir, 'blt', 'blt.yml');
+    $this->fs->dumpFile($bltConfigFilePath, Yaml::dump(['cloud' => ['appId' => $mockBody->uuid]]));
     $this->executeCommand();
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->fs->remove($blt_config_file_path);
+    $this->fs->remove($bltConfigFilePath);
   }
 
 }

--- a/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
+++ b/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
@@ -19,11 +19,11 @@ class AppOpenCommandTest extends CommandTestBase {
    * Tests the 'app:open' command.
    */
   public function testAppOpenCommand(): void {
-    $application_uuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $local_machine_helper->startBrowser('https://cloud.acquia.com/a/applications/' . $application_uuid)->shouldBeCalled();
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->createMockAcliConfigFile($application_uuid);
+    $applicationUuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $localMachineHelper->startBrowser('https://cloud.acquia.com/a/applications/' . $applicationUuid)->shouldBeCalled();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
+    $this->createMockAcliConfigFile($applicationUuid);
     $this->mockApplicationRequest();
     $this->executeCommand([], []);
 

--- a/tests/phpunit/src/Commands/App/AppVcsInfoTest.php
+++ b/tests/phpunit/src/Commands/App/AppVcsInfoTest.php
@@ -20,13 +20,13 @@ class AppVcsInfoTest extends CommandTestBase {
    * Test when no environment available for the app.
    */
   public function testNoEnvAvailableCommand(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
       ->willReturn([])
       ->shouldBeCalled();
-    $this->mockApplicationCodeRequest($applications_response);
+    $this->mockApplicationCodeRequest($applicationsResponse);
 
     $this->expectException(AcquiaCliException::class);
     $this->expectExceptionMessage('There are no environments available with this application.');
@@ -42,12 +42,12 @@ class AppVcsInfoTest extends CommandTestBase {
    * Test when no branch or tag available for the app.
    */
   public function testNoVcsAvailableCommand(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
 
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/code")
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/code")
       ->willReturn([])
       ->shouldBeCalled();
 
@@ -64,10 +64,10 @@ class AppVcsInfoTest extends CommandTestBase {
    * Test the list of the VCS details of the application.
    */
   public function testShowVcsListCommand(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
-    $this->mockApplicationCodeRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
+    $this->mockApplicationCodeRequest($applicationsResponse);
 
     $this->executeCommand(
       [
@@ -95,7 +95,7 @@ EOD;
    * Test the list of deployed VCS but no deployed VCS available.
    */
   public function testNoDeployedVcs(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
     $response = $this->getMockEnvironmentsResponse();
     foreach ($response->_embedded->items as $key => $item) {
@@ -105,10 +105,10 @@ EOD;
     }
 
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
       ->willReturn($response->_embedded->items)
       ->shouldBeCalled();
-    $this->mockApplicationCodeRequest($applications_response);
+    $this->mockApplicationCodeRequest($applicationsResponse);
 
     $this->expectException(AcquiaCliException::class);
     $this->expectExceptionMessage('No branch or tag is deployed on any of the environment of this application.');
@@ -124,10 +124,10 @@ EOD;
    * Test the list of the only deployed VCS.
    */
   public function testListOnlyDeployedVcs(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
-    $this->mockApplicationCodeRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
+    $this->mockApplicationCodeRequest($applicationsResponse);
 
     $this->executeCommand(
       [

--- a/tests/phpunit/src/Commands/App/LinkCommandTest.php
+++ b/tests/phpunit/src/Commands/App/LinkCommandTest.php
@@ -20,7 +20,7 @@ class LinkCommandTest extends CommandTestBase {
    * Tests the 'link' command.
    */
   public function testLinkCommand(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
 
     $inputs = [
@@ -31,7 +31,7 @@ class LinkCommandTest extends CommandTestBase {
     ];
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
-    $this->assertEquals($applications_response->{'_embedded'}->items[0]->uuid, $this->datastoreAcli->get('cloud_app_uuid'));
+    $this->assertEquals($applicationsResponse->{'_embedded'}->items[0]->uuid, $this->datastoreAcli->get('cloud_app_uuid'));
     $this->assertStringContainsString('There is no Cloud Platform application linked to', $output);
     $this->assertStringContainsString('Select a Cloud Platform application', $output);
     $this->assertStringContainsString('[0] Sample application 1', $output);

--- a/tests/phpunit/src/Commands/App/LogTailCommandTest.php
+++ b/tests/phpunit/src/Commands/App/LogTailCommandTest.php
@@ -20,9 +20,9 @@ class LogTailCommandTest extends CommandTestBase {
    */
   public function testLogTailCommand(): void {
 
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
     $this->mockLogStreamRequest();
     $this->executeCommand([], [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?

--- a/tests/phpunit/src/Commands/App/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/App/NewCommandTest.php
@@ -47,24 +47,24 @@ class NewCommandTest extends CommandTestBase {
    */
   public function testNewDrupalCommand(array $package, string $directory = 'drupal'): void {
     $this->newProjectDir = Path::makeAbsolute($directory, $this->projectDir);
-    $project_key = array_keys($package)[0];
-    $project = $package[$project_key];
+    $projectKey = array_keys($package)[0];
+    $project = $package[$projectKey];
 
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(0);
 
-    $local_machine_helper = $this->mockLocalMachineHelper();
+    $localMachineHelper = $this->mockLocalMachineHelper();
 
-    $mock_file_system = $this->mockGetFilesystem($local_machine_helper);
-    $local_machine_helper->checkRequiredBinariesExist(["composer"])->shouldBeCalled();
-    $this->mockExecuteComposerCreate($this->newProjectDir, $local_machine_helper, $process, $project);
-    $local_machine_helper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
-    $this->mockExecuteGitInit($local_machine_helper, $this->newProjectDir, $process);
-    $this->mockExecuteGitAdd($local_machine_helper, $this->newProjectDir, $process);
-    $this->mockExecuteGitCommit($local_machine_helper, $this->newProjectDir, $process);
+    $mockFileSystem = $this->mockGetFilesystem($localMachineHelper);
+    $localMachineHelper->checkRequiredBinariesExist(["composer"])->shouldBeCalled();
+    $this->mockExecuteComposerCreate($this->newProjectDir, $localMachineHelper, $process, $project);
+    $localMachineHelper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
+    $this->mockExecuteGitInit($localMachineHelper, $this->newProjectDir, $process);
+    $this->mockExecuteGitAdd($localMachineHelper, $this->newProjectDir, $process);
+    $this->mockExecuteGitCommit($localMachineHelper, $this->newProjectDir, $process);
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $inputs = [
       // Choose a starting project
       $project,
@@ -77,7 +77,7 @@ class NewCommandTest extends CommandTestBase {
     $this->assertStringContainsString('Acquia recommends most customers use acquia/drupal-recommended-project to setup a Drupal project', $output);
     $this->assertStringContainsString('Choose a starting project', $output);
     $this->assertStringContainsString($project, $output);
-    $this->assertTrue($mock_file_system->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');
+    $this->assertTrue($mockFileSystem->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');
     $this->assertStringContainsString('New 💧 Drupal project created in ' . $this->newProjectDir, $output);
   }
 
@@ -89,25 +89,25 @@ class NewCommandTest extends CommandTestBase {
    */
   public function testNewNextJSAppCommand(array $package, string $directory = 'nextjs'): void {
     $this->newProjectDir = Path::makeAbsolute($directory, $this->projectDir);
-    $project_key = array_keys($package)[0];
-    $project = $package[$project_key];
+    $projectKey = array_keys($package)[0];
+    $project = $package[$projectKey];
 
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(0);
 
-    $local_machine_helper = $this->mockLocalMachineHelper();
+    $localMachineHelper = $this->mockLocalMachineHelper();
 
-    $mock_file_system = $this->mockGetFilesystem($local_machine_helper);
+    $mockFileSystem = $this->mockGetFilesystem($localMachineHelper);
 
-    $local_machine_helper->checkRequiredBinariesExist(["node"])->shouldBeCalled();
-    $this->mockExecuteNpxCreate($this->newProjectDir, $local_machine_helper, $process);
-    $local_machine_helper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
-    $this->mockExecuteGitInit($local_machine_helper, $this->newProjectDir, $process);
-    $this->mockExecuteGitAdd($local_machine_helper, $this->newProjectDir, $process);
-    $this->mockExecuteGitCommit($local_machine_helper, $this->newProjectDir, $process);
+    $localMachineHelper->checkRequiredBinariesExist(["node"])->shouldBeCalled();
+    $this->mockExecuteNpxCreate($this->newProjectDir, $localMachineHelper, $process);
+    $localMachineHelper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
+    $this->mockExecuteGitInit($localMachineHelper, $this->newProjectDir, $process);
+    $this->mockExecuteGitAdd($localMachineHelper, $this->newProjectDir, $process);
+    $this->mockExecuteGitCommit($localMachineHelper, $this->newProjectDir, $process);
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $inputs = [
       // Choose a starting project
       $project,
@@ -120,13 +120,13 @@ class NewCommandTest extends CommandTestBase {
     $this->assertStringContainsString('acquia/next-acms is a starter template for building a headless site', $output);
     $this->assertStringContainsString('Choose a starting project', $output);
     $this->assertStringContainsString($project, $output);
-    $this->assertTrue($mock_file_system->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');
+    $this->assertTrue($mockFileSystem->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');
     $this->assertStringContainsString('New Next JS project created in ' . $this->newProjectDir, $output);
   }
 
   protected function mockExecuteComposerCreate(
-    string $project_dir,
-    ObjectProphecy $local_machine_helper,
+    string $projectDir,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process,
     string $project
   ): void {
@@ -134,18 +134,18 @@ class NewCommandTest extends CommandTestBase {
       'composer',
       'create-project',
       $project,
-      $project_dir,
+      $projectDir,
       '--no-interaction',
     ];
-    $local_machine_helper
+    $localMachineHelper
       ->execute($command)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }
 
   protected function mockExecuteNpxCreate(
-    string $project_dir,
-    ObjectProphecy $local_machine_helper,
+    string $projectDir,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process,
   ): void {
     $command = [
@@ -153,17 +153,17 @@ class NewCommandTest extends CommandTestBase {
       'create-next-app',
       '-e',
       'https://github.com/acquia/next-acms/tree/main/starters/basic-starter',
-      $project_dir,
+      $projectDir,
     ];
-    $local_machine_helper
+    $localMachineHelper
       ->execute($command)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }
 
   protected function mockExecuteGitInit(
-    ObjectProphecy $local_machine_helper,
-    string $project_dir,
+    ObjectProphecy $localMachineHelper,
+    string $projectDir,
     ObjectProphecy $process
   ): void {
     $command = [
@@ -171,15 +171,15 @@ class NewCommandTest extends CommandTestBase {
       'init',
       '--initial-branch=main',
     ];
-    $local_machine_helper
-      ->execute($command, NULL, $project_dir)
+    $localMachineHelper
+      ->execute($command, NULL, $projectDir)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }
 
   protected function mockExecuteGitAdd(
-    ObjectProphecy $local_machine_helper,
-    string $project_dir,
+    ObjectProphecy $localMachineHelper,
+    string $projectDir,
     ObjectProphecy $process
   ): void {
     $command = [
@@ -187,15 +187,15 @@ class NewCommandTest extends CommandTestBase {
       'add',
       '-A',
     ];
-    $local_machine_helper
-      ->execute($command, NULL, $project_dir)
+    $localMachineHelper
+      ->execute($command, NULL, $projectDir)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }
 
   protected function mockExecuteGitCommit(
-    ObjectProphecy $local_machine_helper,
-    string $project_dir,
+    ObjectProphecy $localMachineHelper,
+    string $projectDir,
     ObjectProphecy $process
   ): void {
     $command = [
@@ -205,8 +205,8 @@ class NewCommandTest extends CommandTestBase {
       'Initial commit.',
       '--quiet',
     ];
-    $local_machine_helper
-      ->execute($command, NULL, $project_dir)
+    $localMachineHelper
+      ->execute($command, NULL, $projectDir)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -20,10 +20,10 @@ class TaskWaitCommandTest extends CommandTestBase {
    * @dataProvider providerTestTaskWaitCommand
    */
   public function testTaskWaitCommand(string $status, string $message): void {
-    $notification_uuid = '94835c3e-b112-4660-a14d-d541906c205b';
-    $this->mockNotificationResponse($notification_uuid, $status);
+    $notificationUuid = '94835c3e-b112-4660-a14d-d541906c205b';
+    $this->mockNotificationResponse($notificationUuid, $status);
     $this->executeCommand([
-      'notification-uuid' => $notification_uuid,
+      'notification-uuid' => $notificationUuid,
     ], []);
 
     // Assert.
@@ -50,9 +50,9 @@ class TaskWaitCommandTest extends CommandTestBase {
   }
 
   public function testTaskWaitCommandWithStandardInput(): void {
-    $task_response = $this->getMockResponseFromSpec('/environments/{environmentId}/domains/{domain}/actions/clear-caches', 'post', 202);
-    $this->mockNotificationResponseFromObject($task_response->{'Clearing cache'}->value);
-    $json = json_encode($task_response->{'Clearing cache'}->value);
+    $taskResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/domains/{domain}/actions/clear-caches', 'post', 202);
+    $this->mockNotificationResponseFromObject($taskResponse->{'Clearing cache'}->value);
+    $json = json_encode($taskResponse->{'Clearing cache'}->value);
     $this->executeCommand(['notification-uuid' => $json], []);
 
     // Assert.

--- a/tests/phpunit/src/Commands/App/UnlinkCommandTest.php
+++ b/tests/phpunit/src/Commands/App/UnlinkCommandTest.php
@@ -20,22 +20,22 @@ class UnlinkCommandTest extends CommandTestBase {
    * Tests the 'unlink' command.
    */
   public function testUnlinkCommand(): void {
-    $applications_response = $this->getMockResponseFromSpec('/applications',
+    $applicationsResponse = $this->getMockResponseFromSpec('/applications',
       'get', '200');
-    $cloud_application = $applications_response->{'_embedded'}->items[0];
-    $cloud_application_uuid = $cloud_application->uuid;
-    $this->createMockAcliConfigFile($cloud_application_uuid);
+    $cloudApplication = $applicationsResponse->{'_embedded'}->items[0];
+    $cloudApplicationUuid = $cloudApplication->uuid;
+    $this->createMockAcliConfigFile($cloudApplicationUuid);
     $this->mockApplicationRequest();
 
     // Assert we set it correctly.
-    $this->assertEquals($applications_response->{'_embedded'}->items[0]->uuid, $this->datastoreAcli->get('cloud_app_uuid'));
+    $this->assertEquals($applicationsResponse->{'_embedded'}->items[0]->uuid, $this->datastoreAcli->get('cloud_app_uuid'));
 
     $this->executeCommand([], []);
     $output = $this->getDisplay();
 
     // Assert it's been unset.
     $this->assertNull($this->datastoreAcli->get('cloud_app_uuid'));
-    $this->assertStringContainsString("Unlinked $this->projectDir from Cloud application " . $cloud_application->name, $output);
+    $this->assertStringContainsString("Unlinked $this->projectDir from Cloud application " . $cloudApplication->name, $output);
   }
 
   public function testUnlinkCommandInvalidDir(): void {

--- a/tests/phpunit/src/Commands/Archive/ArchiveExporterCommandTest.php
+++ b/tests/phpunit/src/Commands/Archive/ArchiveExporterCommandTest.php
@@ -22,28 +22,28 @@ class ArchiveExporterCommandTest extends PullCommandTestBase {
 
   public function testArchiveExport(): void {
     touch(Path::join($this->projectDir, '.gitignore'));
-    $destination_dir = 'foo';
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $file_system = $this->mockFileSystem($destination_dir);
-    $local_machine_helper->getFilesystem()->willReturn($file_system->reveal())->shouldBeCalled();
-    $this->mockExecutePvExists($local_machine_helper);
-    $this->mockExecuteDrushExists($local_machine_helper);
-    $this->mockExecuteDrushStatus($local_machine_helper, TRUE, $this->projectDir);
-    $this->mockCreateMySqlDumpOnLocal($local_machine_helper);
-    $local_machine_helper->checkRequiredBinariesExist(["tar"])->shouldBeCalled();
-    $local_machine_helper->execute(Argument::type('array'), Argument::type('callable'), NULL, TRUE)->willReturn($this->mockProcess())->shouldBeCalled();
+    $destinationDir = 'foo';
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $fileSystem = $this->mockFileSystem($destinationDir);
+    $localMachineHelper->getFilesystem()->willReturn($fileSystem->reveal())->shouldBeCalled();
+    $this->mockExecutePvExists($localMachineHelper);
+    $this->mockExecuteDrushExists($localMachineHelper);
+    $this->mockExecuteDrushStatus($localMachineHelper, TRUE, $this->projectDir);
+    $this->mockCreateMySqlDumpOnLocal($localMachineHelper);
+    $localMachineHelper->checkRequiredBinariesExist(["tar"])->shouldBeCalled();
+    $localMachineHelper->execute(Argument::type('array'), Argument::type('callable'), NULL, TRUE)->willReturn($this->mockProcess())->shouldBeCalled();
 
     $finder = $this->mockFinder();
-    $local_machine_helper->getFinder()->willReturn($finder->reveal());
+    $localMachineHelper->getFinder()->willReturn($finder->reveal());
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
 
     $inputs = [
       // ... Do you want to continue? (yes/no) [yes]
       'y',
     ];
     $this->executeCommand([
-      'destination-dir' => $destination_dir,
+      'destination-dir' => $destinationDir,
     ], $inputs);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
@@ -52,17 +52,17 @@ class ArchiveExporterCommandTest extends PullCommandTestBase {
     self::assertStringContainsString('foo/acli-archive-project-', $output);
   }
 
-  protected function mockFileSystem(string $destination_dir): ObjectProphecy {
-    $file_system = $this->prophet->prophesize(Filesystem::class);
-    $file_system->mirror($this->projectDir, Argument::type('string'),
+  protected function mockFileSystem(string $destinationDir): ObjectProphecy {
+    $fileSystem = $this->prophet->prophesize(Filesystem::class);
+    $fileSystem->mirror($this->projectDir, Argument::type('string'),
       Argument::type(Finder::class), ['override' => TRUE, 'delete' => TRUE],
       Argument::type(Finder::class))->shouldBeCalled();
-    $file_system->exists($destination_dir)->willReturn(TRUE)->shouldBeCalled();
-    $file_system->rename(Argument::type('string'), Argument::type('string'))
+    $fileSystem->exists($destinationDir)->willReturn(TRUE)->shouldBeCalled();
+    $fileSystem->rename(Argument::type('string'), Argument::type('string'))
       ->shouldBeCalled();
-    $file_system->remove(Argument::type('string'))->shouldBeCalled();
-    $file_system->mkdir(Argument::type('array'))->shouldBeCalled();
-    return $file_system;
+    $fileSystem->remove(Argument::type('string'))->shouldBeCalled();
+    $fileSystem->mkdir(Argument::type('array'))->shouldBeCalled();
+    return $fileSystem;
   }
 
 }

--- a/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
@@ -21,9 +21,9 @@ class AuthLoginCommandTest extends CommandTestBase {
   public function providerTestAuthLoginCommand(): array {
     return [
       [
-        // $machine_is_authenticated
+        // $machineIsAuthenticated
         FALSE,
-        // $assert_cloud_prompts
+        // $assertCloudPrompts
         TRUE,
         [
           // Would you like to share anonymous performance usage and data? (yes/no) [yes]
@@ -41,9 +41,9 @@ class AuthLoginCommandTest extends CommandTestBase {
         'Saved credentials',
       ],
       [
-        // $machine_is_authenticated
+        // $machineIsAuthenticated
         TRUE,
-        // $assert_cloud_prompts
+        // $assertCloudPrompts
         TRUE,
         [
           // Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?
@@ -63,9 +63,9 @@ class AuthLoginCommandTest extends CommandTestBase {
         'Saved credentials',
       ],
       [
-        // $machine_is_authenticated
+        // $machineIsAuthenticated
         TRUE,
-        // $assert_cloud_prompts
+        // $assertCloudPrompts
         FALSE,
         [
           // Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?
@@ -80,9 +80,9 @@ class AuthLoginCommandTest extends CommandTestBase {
         'Acquia CLI will use the API Key',
       ],
       [
-        // $machine_is_authenticated
+        // $machineIsAuthenticated
         FALSE,
-        // $assert_cloud_prompts
+        // $assertCloudPrompts
         FALSE,
         // No interaction
         [],
@@ -98,15 +98,15 @@ class AuthLoginCommandTest extends CommandTestBase {
    * Tests the 'auth:login' command.
    *
    * @dataProvider providerTestAuthLoginCommand
-   * @param $machine_is_authenticated
-   * @param $assert_cloud_prompts
+   * @param $machineIsAuthenticated
+   * @param $assertCloudPrompts
    * @param $inputs
    * @param $args
-   * @param $output_to_assert
+   * @param $outputToAssert
    */
-  public function testAuthLoginCommand($machine_is_authenticated, $assert_cloud_prompts, $inputs, $args, $output_to_assert): void {
+  public function testAuthLoginCommand($machineIsAuthenticated, $assertCloudPrompts, $inputs, $args, $outputToAssert): void {
     $this->mockTokenRequest();
-    if (!$machine_is_authenticated) {
+    if (!$machineIsAuthenticated) {
       $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
       $this->createDataStores();
@@ -116,10 +116,10 @@ class AuthLoginCommandTest extends CommandTestBase {
     $this->executeCommand($args, $inputs);
     $output = $this->getDisplay();
 
-    if ($assert_cloud_prompts) {
+    if ($assertCloudPrompts) {
       $this->assertInteractivePrompts($output);
     }
-    $this->assertStringContainsString($output_to_assert, $output);
+    $this->assertStringContainsString($outputToAssert, $output);
     $this->assertKeySavedCorrectly();
   }
 
@@ -165,9 +165,9 @@ class AuthLoginCommandTest extends CommandTestBase {
   }
 
   protected function assertKeySavedCorrectly(): void {
-    $creds_file = $this->cloudConfigFilepath;
-    $this->assertFileExists($creds_file);
-    $config = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $creds_file);
+    $credsFile = $this->cloudConfigFilepath;
+    $this->assertFileExists($credsFile);
+    $config = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $credsFile);
     $this->assertTrue($config->exists('acli_key'));
     $this->assertEquals($this->key, $config->get('acli_key'));
     $this->assertTrue($config->exists('keys'));
@@ -179,11 +179,11 @@ class AuthLoginCommandTest extends CommandTestBase {
   }
 
   protected function mockTokenRequest(): object {
-    $mock_body = $this->getMockResponseFromSpec('/account/tokens/{tokenUuid}',
+    $mockBody = $this->getMockResponseFromSpec('/account/tokens/{tokenUuid}',
       'get', '200');
     $this->clientProphecy->request('get', "/account/tokens/{$this->key}")
-      ->willReturn($mock_body);
-    return $mock_body;
+      ->willReturn($mockBody);
+    return $mockBody;
   }
 
 }

--- a/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
@@ -34,8 +34,8 @@ class AuthLogoutCommandTest extends CommandTestBase {
    * @dataProvider providerTestAuthLogoutCommand
    * @param array $inputs
    */
-  public function testAuthLogoutCommand(bool $machine_is_authenticated, array $inputs): void {
-    if (!$machine_is_authenticated) {
+  public function testAuthLogoutCommand(bool $machineIsAuthenticated, array $inputs): void {
+    if (!$machineIsAuthenticated) {
       $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
       $this->removeMockCloudConfigFile();
     }

--- a/tests/phpunit/src/Commands/ChecklistTest.php
+++ b/tests/phpunit/src/Commands/ChecklistTest.php
@@ -26,17 +26,17 @@ class ChecklistTest extends TestBase {
     $checklist->addItem('Testing!');
 
     // Make the spinner spin with some output.
-    $output_callback = static function ($type, $buffer) use ($checklist): void {
+    $outputCallback = static function ($type, $buffer) use ($checklist): void {
       $checklist->updateProgressBar($buffer);
     };
-    $this->localMachineHelper->execute(['echo', 'hello world'], $output_callback, NULL, FALSE);
+    $this->localMachineHelper->execute(['echo', 'hello world'], $outputCallback, NULL, FALSE);
 
     // Complete the item.
     $checklist->completePreviousItem();
     $items = $checklist->getItems();
-    /** @var \Symfony\Component\Console\Helper\ProgressBar $progress_bar */
-    $progress_bar = $items[0]['spinner']->getProgressBar();
-    $this->assertEquals('Testing!', $progress_bar->getMessage());
+    /** @var \Symfony\Component\Console\Helper\ProgressBar $progressBar */
+    $progressBar = $items[0]['spinner']->getProgressBar();
+    $this->assertEquals('Testing!', $progressBar->getMessage());
 
     putenv('PHPUNIT_RUNNING');
   }

--- a/tests/phpunit/src/Commands/ClearCacheCommandTest.php
+++ b/tests/phpunit/src/Commands/ClearCacheCommandTest.php
@@ -25,11 +25,11 @@ class ClearCacheCommandTest extends CommandTestBase {
     $this->command = $this->injectCommand(IdeListCommand::class);
 
     // Request for applications.
-    $applications_response = $this->getMockResponseFromSpec('/applications',
+    $applicationsResponse = $this->getMockResponseFromSpec('/applications',
       'get', '200');
-    $applications_response = $this->filterApplicationsResponse($applications_response, 1, TRUE);
+    $applicationsResponse = $this->filterApplicationsResponse($applicationsResponse, 1, TRUE);
     $this->clientProphecy->request('get', '/applications')
-      ->willReturn($applications_response->{'_embedded'}->items)
+      ->willReturn($applicationsResponse->{'_embedded'}->items)
       // Ensure this is only called once, even though we execute the command twice.
       ->shouldBeCalledTimes(1);
 

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPhpVersionCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPhpVersionCommandTest.php
@@ -18,7 +18,7 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase {
   private string $gitLabHost = 'gitlabhost';
   private string $gitLabToken = 'gitlabtoken';
   private int $gitLabProjectId = 33;
-  public static string $application_uuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
+  public static string $applicationUuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
 
   protected function createCommand(): Command {
     return $this->injectCommand(CodeStudioPhpVersionCommand::class);
@@ -41,11 +41,11 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase {
    *
    * @dataProvider providerTestPhpVersionFailure
    */
-  public function testPhpVersionFailure($php_version): void {
+  public function testPhpVersionFailure($phpVersion): void {
     $this->expectException(ValidatorException::class);
     $this->executeCommand([
-      'applicationUuid' => self::$application_uuid,
-      'php-version' => $php_version,
+      'applicationUuid' => self::$applicationUuid,
+      'php-version' => $phpVersion,
     ]);
   }
 
@@ -54,21 +54,21 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase {
    */
   public function testCiCdNotEnabled(): void {
     $this->mockApplicationRequest();
-    $gitlab_client = $this->prophet->prophesize(Client::class);
-    $this->mockGitLabUsersMe($gitlab_client);
+    $gitlabClient = $this->prophet->prophesize(Client::class);
+    $this->mockGitLabUsersMe($gitlabClient);
     $projects = $this->mockGetGitLabProjects(
-      self::$application_uuid,
+      self::$applicationUuid,
       $this->gitLabProjectId,
       [$this->getMockedGitLabProject($this->gitLabProjectId)],
     );
 
-    $gitlab_client->projects()->willReturn($projects);
+    $gitlabClient->projects()->willReturn($projects);
 
-    $this->command->setGitLabClient($gitlab_client->reveal());
+    $this->command->setGitLabClient($gitlabClient->reveal());
     $this->executeCommand([
       '--gitlab-host-name' => $this->gitLabHost,
       '--gitlab-token' => $this->gitLabToken,
-      'applicationUuid' => self::$application_uuid,
+      'applicationUuid' => self::$applicationUuid,
       'php-version' => '8.1',
     ]);
 
@@ -81,26 +81,26 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase {
    */
   public function testPhpVersionAddFail(): void {
     $this->mockApplicationRequest();
-    $gitlab_client = $this->prophet->prophesize(Client::class);
-    $this->mockGitLabUsersMe($gitlab_client);
-    $mocked_project = $this->getMockedGitLabProject($this->gitLabProjectId);
-    $mocked_project['jobs_enabled'] = TRUE;
+    $gitlabClient = $this->prophet->prophesize(Client::class);
+    $this->mockGitLabUsersMe($gitlabClient);
+    $mockedProject = $this->getMockedGitLabProject($this->gitLabProjectId);
+    $mockedProject['jobs_enabled'] = TRUE;
     $projects = $this->mockGetGitLabProjects(
-      self::$application_uuid,
+      self::$applicationUuid,
       $this->gitLabProjectId,
-      [$mocked_project],
+      [$mockedProject],
     );
 
     $projects->variables($this->gitLabProjectId)->willReturn($this->getMockGitLabVariables());
     $projects->addVariable($this->gitLabProjectId, Argument::type('string'), Argument::type('string'))
       ->willThrow(RuntimeException::class);
 
-    $gitlab_client->projects()->willReturn($projects);
-    $this->command->setGitLabClient($gitlab_client->reveal());
+    $gitlabClient->projects()->willReturn($projects);
+    $this->command->setGitLabClient($gitlabClient->reveal());
     $this->executeCommand([
       '--gitlab-host-name' => $this->gitLabHost,
       '--gitlab-token' => $this->gitLabToken,
-      'applicationUuid' => self::$application_uuid,
+      'applicationUuid' => self::$applicationUuid,
       'php-version' => '8.1',
     ]);
 
@@ -113,26 +113,26 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase {
    */
   public function testPhpVersionAdd(): void {
     $this->mockApplicationRequest();
-    $gitlab_client = $this->prophet->prophesize(Client::class);
-    $this->mockGitLabUsersMe($gitlab_client);
-    $mocked_project = $this->getMockedGitLabProject($this->gitLabProjectId);
-    $mocked_project['jobs_enabled'] = TRUE;
+    $gitlabClient = $this->prophet->prophesize(Client::class);
+    $this->mockGitLabUsersMe($gitlabClient);
+    $mockedProject = $this->getMockedGitLabProject($this->gitLabProjectId);
+    $mockedProject['jobs_enabled'] = TRUE;
     $projects = $this->mockGetGitLabProjects(
-      self::$application_uuid,
+      self::$applicationUuid,
       $this->gitLabProjectId,
-      [$mocked_project],
+      [$mockedProject],
     );
 
     $projects->variables($this->gitLabProjectId)->willReturn($this->getMockGitLabVariables());
     $projects->addVariable($this->gitLabProjectId, Argument::type('string'), Argument::type('string'));
 
-    $gitlab_client->projects()->willReturn($projects);
+    $gitlabClient->projects()->willReturn($projects);
 
-    $this->command->setGitLabClient($gitlab_client->reveal());
+    $this->command->setGitLabClient($gitlabClient->reveal());
     $this->executeCommand([
       '--gitlab-host-name' => $this->gitLabHost,
       '--gitlab-token' => $this->gitLabToken,
-      'applicationUuid' => self::$application_uuid,
+      'applicationUuid' => self::$applicationUuid,
       'php-version' => '8.1',
     ]);
 
@@ -145,14 +145,14 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase {
    */
   public function testPhpVersionUpdateFail(): void {
     $this->mockApplicationRequest();
-    $gitlab_client = $this->prophet->prophesize(Client::class);
-    $this->mockGitLabUsersMe($gitlab_client);
-    $mocked_project = $this->getMockedGitLabProject($this->gitLabProjectId);
-    $mocked_project['jobs_enabled'] = TRUE;
+    $gitlabClient = $this->prophet->prophesize(Client::class);
+    $this->mockGitLabUsersMe($gitlabClient);
+    $mockedProject = $this->getMockedGitLabProject($this->gitLabProjectId);
+    $mockedProject['jobs_enabled'] = TRUE;
     $projects = $this->mockGetGitLabProjects(
-      self::$application_uuid,
+      self::$applicationUuid,
       $this->gitLabProjectId,
-      [$mocked_project],
+      [$mockedProject],
     );
 
     $variables = $this->getMockGitLabVariables();
@@ -168,12 +168,12 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase {
     $projects->updateVariable($this->gitLabProjectId, Argument::type('string'), Argument::type('string'))
       ->willThrow(RuntimeException::class);
 
-    $gitlab_client->projects()->willReturn($projects);
-    $this->command->setGitLabClient($gitlab_client->reveal());
+    $gitlabClient->projects()->willReturn($projects);
+    $this->command->setGitLabClient($gitlabClient->reveal());
     $this->executeCommand([
       '--gitlab-host-name' => $this->gitLabHost,
       '--gitlab-token' => $this->gitLabToken,
-      'applicationUuid' => self::$application_uuid,
+      'applicationUuid' => self::$applicationUuid,
       'php-version' => '8.1',
     ]);
 
@@ -186,14 +186,14 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase {
    */
   public function testPhpVersionUpdate(): void {
     $this->mockApplicationRequest();
-    $gitlab_client = $this->prophet->prophesize(Client::class);
-    $this->mockGitLabUsersMe($gitlab_client);
-    $mocked_project = $this->getMockedGitLabProject($this->gitLabProjectId);
-    $mocked_project['jobs_enabled'] = TRUE;
+    $gitlabClient = $this->prophet->prophesize(Client::class);
+    $this->mockGitLabUsersMe($gitlabClient);
+    $mockedProject = $this->getMockedGitLabProject($this->gitLabProjectId);
+    $mockedProject['jobs_enabled'] = TRUE;
     $projects = $this->mockGetGitLabProjects(
-      self::$application_uuid,
+      self::$applicationUuid,
       $this->gitLabProjectId,
-      [$mocked_project],
+      [$mockedProject],
     );
 
     $variables = $this->getMockGitLabVariables();
@@ -208,13 +208,13 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase {
     $projects->variables($this->gitLabProjectId)->willReturn($variables);
     $projects->updateVariable($this->gitLabProjectId, Argument::type('string'), Argument::type('string'));
 
-    $gitlab_client->projects()->willReturn($projects);
+    $gitlabClient->projects()->willReturn($projects);
 
-    $this->command->setGitLabClient($gitlab_client->reveal());
+    $this->command->setGitLabClient($gitlabClient->reveal());
     $this->executeCommand([
       '--gitlab-host-name' => $this->gitLabHost,
       '--gitlab-token' => $this->gitLabToken,
-      'applicationUuid' => self::$application_uuid,
+      'applicationUuid' => self::$applicationUuid,
       'php-version' => '8.1',
     ]);
 

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -26,7 +26,7 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase {
   private string $gitLabToken = 'gitlabtoken';
   private int $gitLabProjectId = 33;
   private int $gitLabTokenId = 118;
-  public static string $application_uuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
+  public static string $applicationUuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
 
   public function setUp($output = NULL): void {
     parent::setUp($output);
@@ -71,44 +71,44 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase {
 
   /**
    * @dataProvider providerTestCommand
-   * @param $mocked_gitlab_projects
+   * @param $mockedGitlabProjects
    * @param $args
    * @param $inputs
    */
-  public function testCommand($mocked_gitlab_projects, $inputs, $args): void {
+  public function testCommand($mockedGitlabProjects, $inputs, $args): void {
     copy(
       Path::join($this->realFixtureDir, 'acquia-pipelines.yml'),
       Path::join($this->projectDir, 'acquia-pipelines.yml')
     );
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->mockExecuteGlabExists($local_machine_helper);
-    $this->mockGitlabGetHost($local_machine_helper, $this->gitLabHost);
-    $this->mockGitlabGetToken($local_machine_helper, $this->gitLabToken, $this->gitLabHost);
-    $gitlab_client = $this->prophet->prophesize(Client::class);
-    $this->mockGitLabUsersMe($gitlab_client);
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->mockExecuteGlabExists($localMachineHelper);
+    $this->mockGitlabGetHost($localMachineHelper, $this->gitLabHost);
+    $this->mockGitlabGetToken($localMachineHelper, $this->gitLabToken, $this->gitLabHost);
+    $gitlabClient = $this->prophet->prophesize(Client::class);
+    $this->mockGitLabUsersMe($gitlabClient);
     $this->mockAccountRequest();
-    $this->mockGitLabPermissionsRequest($this::$application_uuid);
-    $projects = $this->mockGetGitLabProjects($this::$application_uuid, $this->gitLabProjectId, $mocked_gitlab_projects);
+    $this->mockGitLabPermissionsRequest($this::$applicationUuid);
+    $projects = $this->mockGetGitLabProjects($this::$applicationUuid, $this->gitLabProjectId, $mockedGitlabProjects);
     $projects->variables($this->gitLabProjectId)->willReturn(CodeStudioCiCdVariables::getDefaults());
     $projects->update($this->gitLabProjectId, Argument::type('array'));
-    $gitlab_client->projects()->willReturn($projects);
-    $local_machine_helper->getFilesystem()->willReturn(new Filesystem())->shouldBeCalled();
-    $this->command->setGitLabClient($gitlab_client->reveal());
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $gitlabClient->projects()->willReturn($projects);
+    $localMachineHelper->getFilesystem()->willReturn(new Filesystem())->shouldBeCalled();
+    $this->command->setGitLabClient($gitlabClient->reveal());
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->mockApplicationsRequest();
     // Set properties and execute.
     $this->executeCommand($args, $inputs);
 
     // Assertions.
     $this->assertEquals(0, $this->getStatusCode());
-    $gitlab_ci_yml_file_path = $this->projectDir . '/.gitlab-ci.yml';
-    $this->assertFileExists($gitlab_ci_yml_file_path);
+    $gitlabCiYmlFilePath = $this->projectDir . '/.gitlab-ci.yml';
+    $this->assertFileExists($gitlabCiYmlFilePath);
     // @todo Assert things about skips. Composer install, BLT, launch_ode.
-    $contents = Yaml::parseFile($gitlab_ci_yml_file_path);
-    $array_skip_map = ['composer install', '${BLT_DIR}', 'launch_ode'];
+    $contents = Yaml::parseFile($gitlabCiYmlFilePath);
+    $arraySkipMap = ['composer install', '${BLT_DIR}', 'launch_ode'];
     foreach ($contents as $values) {
       if (array_key_exists('script', $values)) {
-        foreach ($array_skip_map as $map) {
+        foreach ($arraySkipMap as $map) {
           $this->assertNotContains($map, $values['script'], "Skip option found");
         }
       }

--- a/tests/phpunit/src/Commands/DocsCommandTest.php
+++ b/tests/phpunit/src/Commands/DocsCommandTest.php
@@ -22,9 +22,9 @@ class DocsCommandTest extends CommandTestBase {
    * @dataProvider providerTestDocsCommand
    */
   public function testDocsCommand($input, $expectedOutput): void {
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $local_machine_helper->startBrowser(Argument::any())->shouldBeCalled();
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $localMachineHelper->startBrowser(Argument::any())->shouldBeCalled();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->executeCommand([], [$input]);
     $output = $this->getDisplay();
     $this->assertStringContainsString('Select the Acquia Product [Acquia CLI]:', $output);

--- a/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
@@ -30,45 +30,45 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Select a Cloud Platform subscription
       0,
     ];
-    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
     $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
       ->shouldBeCalledTimes(1);
 
-    $get_domains_response = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
     // duplicating the request to ensure there is at least one domain with a successful, pending, and failed health code
-    $get_domains_response_2 = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
-    $total_domains_list = array_merge($get_domains_response->_embedded->items, $get_domains_response_2->_embedded->items);
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($total_domains_list);
+    $getDomainsResponse2 = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $totalDomainsList = array_merge($getDomainsResponse->_embedded->items, $getDomainsResponse2->_embedded->items);
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($totalDomainsList);
 
-    $total_domains_list[2]->domain_name = 'example3.com';
-    $total_domains_list[2]->health->code = '200';
+    $totalDomainsList[2]->domain_name = 'example3.com';
+    $totalDomainsList[2]->health->code = '200';
 
-    $total_domains_list[3]->domain_name = 'example4.com';
-    $total_domains_list[3]->health->code = '202';
+    $totalDomainsList[3]->domain_name = 'example4.com';
+    $totalDomainsList[3]->health->code = '202';
 
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
 
-    $applications_response->_embedded->items[0]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+    $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
 
-    $get_app_domains_response = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
+    $getAppDomainsResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
     // duplicating the request to ensure added domains are included in association list
-    $get_app_domains_response_2 = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
-    $total_app_domains_list = array_merge($get_app_domains_response->_embedded->items, $get_app_domains_response_2->_embedded->items);
-    $this->clientProphecy->request('get', "/applications/{$applications_response->_embedded->items[0]->uuid}/email/domains")->willReturn($total_app_domains_list);
+    $getAppDomainsResponse2 = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
+    $totalAppDomainsList = array_merge($getAppDomainsResponse->_embedded->items, $getAppDomainsResponse2->_embedded->items);
+    $this->clientProphecy->request('get', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains")->willReturn($totalAppDomainsList);
 
-    $total_app_domains_list[2]->domain_name = 'example3.com';
-    $total_app_domains_list[2]->flags->associated = TRUE;
+    $totalAppDomainsList[2]->domain_name = 'example3.com';
+    $totalAppDomainsList[2]->flags->associated = TRUE;
 
-    $total_app_domains_list[3]->domain_name = 'example4.com';
-    $total_app_domains_list[3]->flags->associated = FALSE;
+    $totalAppDomainsList[3]->domain_name = 'example4.com';
+    $totalAppDomainsList[3]->flags->associated = FALSE;
 
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
     $this->assertEquals(0, $this->getStatusCode());
     $this->assertStringContainsString('Application: ', $output);
-    foreach ($get_app_domains_response->_embedded->items as $app_domain) {
-      $this->assertEquals(3, substr_count($output, $app_domain->domain_name));
+    foreach ($getAppDomainsResponse->_embedded->items as $appDomain) {
+      $this->assertEquals(3, substr_count($output, $appDomain->domain_name));
     }
 
     $this->assertEquals(2, substr_count($output, 'Failed - 404'));
@@ -87,13 +87,13 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Select a Cloud Platform subscription
       0,
     ];
-    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
     $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
       ->shouldBeCalledTimes(1);
 
-    $get_domains_response = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($get_domains_response->_embedded->items);
+    $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
     $this->mockApplicationsRequest();
 
@@ -112,27 +112,27 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Do you wish to continue?
       'no',
     ];
-    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
     $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
       ->shouldBeCalledTimes(1);
 
-    $get_domains_response = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($get_domains_response->_embedded->items);
+    $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
-    $applications_response = $this->getMockResponseFromSpec('/applications', 'get', '200');
-    $applications_response->_embedded->items[0]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
-    $applications_response->_embedded->items[1]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+    $applicationsResponse = $this->getMockResponseFromSpec('/applications', 'get', '200');
+    $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
+    $applicationsResponse->_embedded->items[1]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
 
     $app = $this->getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
     for ($i = 2; $i < 101; $i++) {
-      $applications_response->_embedded->items[$i] = $app;
-      $applications_response->_embedded->items[$i]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+      $applicationsResponse->_embedded->items[$i] = $app;
+      $applicationsResponse->_embedded->items[$i]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
     }
 
-    $this->clientProphecy->request('get', '/applications')->willReturn($applications_response->_embedded->items);
+    $this->clientProphecy->request('get', '/applications')->willReturn($applicationsResponse->_embedded->items);
 
-    foreach ($applications_response->_embedded->items as $app) {
+    foreach ($applicationsResponse->_embedded->items as $app) {
       $this->clientProphecy->request('get', "/applications/{$app->uuid}/email/domains")->willReturn([]);
     }
 
@@ -150,12 +150,12 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Select a Cloud Platform subscription
       0,
     ];
-    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
     $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
       ->shouldBeCalledTimes(1);
 
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn([]);
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn([]);
 
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
@@ -170,19 +170,19 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Select a Cloud Platform subscription
       0,
     ];
-    $subscriptions_response = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
     $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptions_response->{'_embedded'}->items)
+      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
       ->shouldBeCalledTimes(1);
 
-    $get_domains_response = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions_response->_embedded->items[0]->uuid}/domains")->willReturn($get_domains_response->_embedded->items);
+    $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
 
-    $applications_response->_embedded->items[0]->subscription->uuid = $subscriptions_response->_embedded->items[0]->uuid;
+    $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
 
-    $this->clientProphecy->request('get', "/applications/{$applications_response->_embedded->items[0]->uuid}/email/domains")->willReturn([]);
+    $this->clientProphecy->request('get', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains")->willReturn([]);
 
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();

--- a/tests/phpunit/src/Commands/Env/EnvCopyCronCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvCopyCronCommandTest.php
@@ -21,17 +21,17 @@ class EnvCopyCronCommandTest extends CommandTestBase {
    * Tests the 'app:cron-copy' command.
    */
   public function testCopyCronTasksCommandTest(): void {
-    $environments_response = $this->getMockEnvironmentsResponse();
-    $source_crons_list_response = $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'get', '200');
+    $environmentsResponse = $this->getMockEnvironmentsResponse();
+    $sourceCronsListResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'get', '200');
     $this->clientProphecy->request('get',
-      '/environments/' . $environments_response->{'_embedded'}->items[0]->id . '/crons')
-      ->willReturn($source_crons_list_response->{'_embedded'}->items)
+      '/environments/' . $environmentsResponse->{'_embedded'}->items[0]->id . '/crons')
+      ->willReturn($sourceCronsListResponse->{'_embedded'}->items)
       ->shouldBeCalled();
 
-    $create_cron_response = $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'post', '202');
+    $createCronResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'post', '202');
     $this->clientProphecy->request('post',
-      '/environments/' . $environments_response->{'_embedded'}->items[2]->id . '/crons', Argument::type('array'))
-      ->willReturn($create_cron_response->{'Adding cron'}->value)
+      '/environments/' . $environmentsResponse->{'_embedded'}->items[2]->id . '/crons', Argument::type('array'))
+      ->willReturn($createCronResponse->{'Adding cron'}->value)
       ->shouldBeCalled();
 
     $source = '24-a47ac10b-58cc-4372-a567-0e02b2c3d470';
@@ -71,9 +71,9 @@ class EnvCopyCronCommandTest extends CommandTestBase {
    * Tests for no cron job available on source environment to copy.
    */
   public function testNoCronJobOnSource(): void {
-    $environments_response = $this->getMockEnvironmentsResponse();
+    $environmentsResponse = $this->getMockEnvironmentsResponse();
     $this->clientProphecy->request('get',
-      '/environments/' . $environments_response->{'_embedded'}->items[0]->id . '/crons')
+      '/environments/' . $environmentsResponse->{'_embedded'}->items[0]->id . '/crons')
       ->willReturn([])
       ->shouldBeCalled();
 
@@ -97,16 +97,16 @@ class EnvCopyCronCommandTest extends CommandTestBase {
    * Tests for exception during the cron job copy.
    */
   public function testExceptionOnCronJobCopy(): void {
-    $environments_response = $this->getMockEnvironmentsResponse();
-    $source_crons_list_response = $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'get', '200');
+    $environmentsResponse = $this->getMockEnvironmentsResponse();
+    $sourceCronsListResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'get', '200');
     $this->clientProphecy->request('get',
-      '/environments/' . $environments_response->{'_embedded'}->items[0]->id . '/crons')
-      ->willReturn($source_crons_list_response->{'_embedded'}->items)
+      '/environments/' . $environmentsResponse->{'_embedded'}->items[0]->id . '/crons')
+      ->willReturn($sourceCronsListResponse->{'_embedded'}->items)
       ->shouldBeCalled();
 
     $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'post', '202');
     $this->clientProphecy->request('post',
-      '/environments/' . $environments_response->{'_embedded'}->items[2]->id . '/crons', Argument::type('array'))
+      '/environments/' . $environmentsResponse->{'_embedded'}->items[2]->id . '/crons', Argument::type('array'))
       ->willThrow(Exception::class);
 
     $source = '24-a47ac10b-58cc-4372-a567-0e02b2c3d470';

--- a/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
@@ -16,9 +16,9 @@ class EnvCreateCommandTest extends CommandTestBase {
   private static string $validLabel = 'New CDE';
 
   private function setupCdeTest(string $label): string {
-    $applications_response = $this->mockApplicationsRequest();
-    $application_response = $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
+    $applicationsResponse = $this->mockApplicationsRequest();
+    $applicationResponse = $this->mockApplicationRequest();
+    $this->mockEnvironmentsRequest($applicationsResponse);
 
     $response1 = $this->getMockEnvironmentsResponse();
     $response2 = $this->getMockEnvironmentsResponse();
@@ -26,41 +26,41 @@ class EnvCreateCommandTest extends CommandTestBase {
     $cde->label = $label;
     $response2->_embedded->items[3] = $cde;
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
       ->willReturn($response1->_embedded->items, $response2->_embedded->items)
       ->shouldBeCalled();
 
-    $code_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
+    $codeResponse = $this->getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
     $this->clientProphecy->request('get',
-      "/applications/$application_response->uuid/code")
-      ->willReturn($code_response->_embedded->items)
+      "/applications/$applicationResponse->uuid/code")
+      ->willReturn($codeResponse->_embedded->items)
       ->shouldBeCalled();
 
-    $databases_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/databases", 'get', '200');
+    $databasesResponse = $this->getMockResponseFromSpec("/applications/{applicationUuid}/databases", 'get', '200');
     $this->clientProphecy->request('get',
-      "/applications/$application_response->uuid/databases")
-      ->willReturn($databases_response->_embedded->items)
+      "/applications/$applicationResponse->uuid/databases")
+      ->willReturn($databasesResponse->_embedded->items)
       ->shouldBeCalled();
 
-    $environments_response = $this->getMockResponseFromSpec('/applications/{applicationUuid}/environments',
+    $environmentsResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/environments',
       'post', 202);
-    $this->clientProphecy->request('post', "/applications/$application_response->uuid/environments", Argument::type('array'))
-      ->willReturn($environments_response->{'Adding environment'}->value)
+    $this->clientProphecy->request('post', "/applications/$applicationResponse->uuid/environments", Argument::type('array'))
+      ->willReturn($environmentsResponse->{'Adding environment'}->value)
       ->shouldBeCalled();
 
-    $this->mockNotificationResponseFromObject($environments_response->{'Adding environment'}->value);
+    $this->mockNotificationResponseFromObject($environmentsResponse->{'Adding environment'}->value);
     return $response2->_embedded->items[3]->domains[0];
   }
 
   private function getBranch(): string {
-    $code_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
-    return $code_response->_embedded->items[0]->name;
+    $codeResponse = $this->getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
+    return $codeResponse->_embedded->items[0]->name;
   }
 
   private function getApplication(): string {
-    $applications_response = $this->getMockResponseFromSpec('/applications',
+    $applicationsResponse = $this->getMockResponseFromSpec('/applications',
       'get', '200');
-    return $applications_response->{'_embedded'}->items[0]->uuid;
+    return $applicationsResponse->{'_embedded'}->items[0]->uuid;
   }
 
   protected function createCommand(): Command {

--- a/tests/phpunit/src/Commands/Env/EnvDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvDeleteCommandTest.php
@@ -20,8 +20,8 @@ class EnvDeleteCommandTest extends CommandTestBase {
    * @return array
    */
   public function providerTestDeleteCde(): array {
-    $environment_response = $this->getMockEnvironmentsResponse();
-    $environment = $environment_response->_embedded->items[0];
+    $environmentResponse = $this->getMockEnvironmentsResponse();
+    $environment = $environmentResponse->_embedded->items[0];
     return [
       [$environment->id],
       [NULL],
@@ -33,10 +33,10 @@ class EnvDeleteCommandTest extends CommandTestBase {
    *
    * @dataProvider providerTestDeleteCde
    */
-  public function testDeleteCde($environment_id): void {
-    $applications_response = $this->mockApplicationsRequest();
+  public function testDeleteCde($environmentId): void {
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
 
     $this->getMockEnvironmentsResponse();
     $response2 = $this->getMockEnvironmentsResponse();
@@ -46,14 +46,14 @@ class EnvDeleteCommandTest extends CommandTestBase {
     $cde->label = $label;
     $response2->_embedded->items[3] = $cde;
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
       ->willReturn($response2->_embedded->items)
       ->shouldBeCalled();
 
-    $environments_response = $this->getMockResponseFromSpec('/environments/{environmentId}',
+    $environmentsResponse = $this->getMockResponseFromSpec('/environments/{environmentId}',
       'delete', 202);
     $this->clientProphecy->request('delete', "/environments/" . $cde->id)
-      ->willReturn($environments_response)
+      ->willReturn($environmentsResponse)
       ->shouldBeCalled();
 
     $this->getMockResponseFromSpec('/environments/{environmentId}',
@@ -64,7 +64,7 @@ class EnvDeleteCommandTest extends CommandTestBase {
 
     $this->executeCommand(
       [
-        'environmentId' => $environment_id,
+        'environmentId' => $environmentId,
       ],
       [
         // Would you like Acquia CLI to search for a Cloud application that matches your local git config?'
@@ -83,9 +83,9 @@ class EnvDeleteCommandTest extends CommandTestBase {
    * Tests the case when no CDE available for application.
    */
   public function testNoExistingCDEEnvironment(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
 
     $this->expectException(AcquiaCliException::class);
     $this->expectExceptionMessage('There are no existing CDEs for Application');
@@ -104,7 +104,7 @@ class EnvDeleteCommandTest extends CommandTestBase {
    * Tests the case when multiple CDE available for application.
    */
   public function testNoEnvironmentArgumentPassed(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
     $response = $this->getMockEnvironmentsResponse();
     foreach ($response->{'_embedded'}->items as $key => $env) {
@@ -112,15 +112,15 @@ class EnvDeleteCommandTest extends CommandTestBase {
       $response->{'_embedded'}->items[$key] = $env;
     }
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
       ->willReturn($response->_embedded->items)
       ->shouldBeCalled();
 
     $cde = $response->_embedded->items[0];
-    $environments_response = $this->getMockResponseFromSpec('/environments/{environmentId}',
+    $environmentsResponse = $this->getMockResponseFromSpec('/environments/{environmentId}',
       'delete', 202);
     $this->clientProphecy->request('delete', "/environments/" . $cde->id)
-      ->willReturn($environments_response)
+      ->willReturn($environmentsResponse)
       ->shouldBeCalled();
 
     $this->executeCommand([],

--- a/tests/phpunit/src/Commands/Env/EnvMirrorCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvMirrorCommandTest.php
@@ -20,61 +20,61 @@ class EnvMirrorCommandTest extends CommandTestBase {
    * Tests the 'app:environment-mirror' command.
    */
   public function testEnvironmentMirror(): void {
-    $environment_response = $this->mockGetEnvironments();
-    $code_switch_response = $this->getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
-    $response = $code_switch_response->{'Switching code'}->value;
+    $environmentResponse = $this->mockGetEnvironments();
+    $codeSwitchResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
+    $response = $codeSwitchResponse->{'Switching code'}->value;
     $this->mockNotificationResponseFromObject($response);
     $response->links = $response->{'_links'};
     $this->clientProphecy->request('post',
-      "/environments/{$environment_response->id}/code/actions/switch", [
+      "/environments/{$environmentResponse->id}/code/actions/switch", [
         'form_params' => [
-          'branch' => $environment_response->vcs->path,
+          'branch' => $environmentResponse->vcs->path,
         ],
       ])
       ->willReturn($response)
       ->shouldBeCalled();
 
-    $databases_response = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
+    $databasesResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
     $this->clientProphecy->request('get',
-      "/environments/{$environment_response->id}/databases")
-      ->willReturn($databases_response->_embedded->items)
+      "/environments/{$environmentResponse->id}/databases")
+      ->willReturn($databasesResponse->_embedded->items)
       ->shouldBeCalled();
 
-    $db_copy_response = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
-    $response = $db_copy_response->{'Database being copied'}->value;
+    $dbCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
+    $response = $dbCopyResponse->{'Database being copied'}->value;
     $this->mockNotificationResponseFromObject($response);
     $response->links = $response->{'_links'};
-    $this->clientProphecy->request('post', "/environments/{$environment_response->id}/databases", [
+    $this->clientProphecy->request('post', "/environments/{$environmentResponse->id}/databases", [
       'json' => [
-        'name' => $databases_response->_embedded->items[0]->name,
-        'source' => $environment_response->id,
+        'name' => $databasesResponse->_embedded->items[0]->name,
+        'source' => $environmentResponse->id,
       ],
     ])
       ->willReturn($response)
       ->shouldBeCalled();
 
-    $files_copy_response = $this->getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
-    $response = $files_copy_response->{'Files queued for copying'}->value;
+    $filesCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
+    $response = $filesCopyResponse->{'Files queued for copying'}->value;
     $this->mockNotificationResponseFromObject($response);
     $response->links = $response->{'_links'};
-    $this->clientProphecy->request('post', "/environments/{$environment_response->id}/files", [
+    $this->clientProphecy->request('post', "/environments/{$environmentResponse->id}/files", [
       'json' => [
-        'source' => $environment_response->id,
+        'source' => $environmentResponse->id,
       ],
     ])
       ->willReturn($response)
       ->shouldBeCalled();
 
-    $environment_update_response = $this->getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
-    $this->clientProphecy->request('put', "/environments/{$environment_response->id}", Argument::type('array'))
-      ->willReturn($environment_update_response)
+    $environmentUpdateResponse = $this->getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
+    $this->clientProphecy->request('put', "/environments/{$environmentResponse->id}", Argument::type('array'))
+      ->willReturn($environmentUpdateResponse)
       ->shouldBeCalled();
-    $this->mockNotificationResponseFromObject($environment_update_response);
+    $this->mockNotificationResponseFromObject($environmentUpdateResponse);
 
     $this->executeCommand(
       [
-        'destination-environment' => $environment_response->id,
-        'source-environment' => $environment_response->id,
+        'destination-environment' => $environmentResponse->id,
+        'source-environment' => $environmentResponse->id,
       ],
       [
         // Are you sure that you want to overwrite everything ...
@@ -85,10 +85,10 @@ class EnvMirrorCommandTest extends CommandTestBase {
     $output = $this->getDisplay();
     $this->assertEquals(0, $this->getStatusCode());
     $this->assertStringContainsString('Are you sure that you want to overwrite everything on Dev (dev) and replace it with source data from Dev (dev)', $output);
-    $this->assertStringContainsString("Switching to {$environment_response->vcs->path}", $output);
-    $this->assertStringContainsString("Copying {$databases_response->_embedded->items[0]->name}", $output);
+    $this->assertStringContainsString("Switching to {$environmentResponse->vcs->path}", $output);
+    $this->assertStringContainsString("Copying {$databasesResponse->_embedded->items[0]->name}", $output);
     $this->assertStringContainsString("Copying PHP version, acpu memory limit, etc.", $output);
-    $this->assertStringContainsString("[OK] Done! {$environment_response->label} now matches {$environment_response->label}", $output);
+    $this->assertStringContainsString("[OK] Done! {$environmentResponse->label} now matches {$environmentResponse->label}", $output);
   }
 
 }

--- a/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
@@ -35,12 +35,12 @@ class IdeCreateCommandTest extends CommandTestBase {
     $response = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
     $this->clientProphecy->request('get', '/ides/1792767d-1ee3-4b5f-83a8-334dfdc2b8a3')->willReturn($response)->shouldBeCalled();
 
-    /** @var \Prophecy\Prophecy\ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzle_response */
-    $guzzle_response = $this->prophet->prophesize(Response::class);
-    $guzzle_response->getStatusCode()->willReturn(200);
-    $guzzle_client = $this->prophet->prophesize(Client::class);
-    $guzzle_client->request('GET', '/health')->willReturn($guzzle_response->reveal())->shouldBeCalled();
-    $this->command->setClient($guzzle_client->reveal());
+    /** @var \Prophecy\Prophecy\ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzleResponse */
+    $guzzleResponse = $this->prophet->prophesize(Response::class);
+    $guzzleResponse->getStatusCode()->willReturn(200);
+    $guzzleClient = $this->prophet->prophesize(Client::class);
+    $guzzleClient->request('GET', '/health')->willReturn($guzzleResponse->reveal())->shouldBeCalled();
+    $this->command->setClient($guzzleClient->reveal());
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?

--- a/tests/phpunit/src/Commands/Ide/IdeDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeDeleteCommandTest.php
@@ -38,13 +38,13 @@ class IdeDeleteCommandTest extends CommandTestBase {
     $this->mockApplicationRequest();
     $this->mockIdeListRequest();
 
-    $ide_uuid = '9a83c081-ef78-4dbd-8852-11cc3eb248f7';
-    $ide_delete_response = $this->mockIdeDeleteRequest($ide_uuid);
-    $ide_get_response = $this->mockGetIdeRequest($ide_uuid);
-    $ide = new IdeResponse((object) $ide_get_response);
-    $ssh_key_get_response = $this->mockListSshKeysRequestWithIdeKey($ide);
+    $ideUuid = '9a83c081-ef78-4dbd-8852-11cc3eb248f7';
+    $ideDeleteResponse = $this->mockIdeDeleteRequest($ideUuid);
+    $ideGetResponse = $this->mockGetIdeRequest($ideUuid);
+    $ide = new IdeResponse((object) $ideGetResponse);
+    $sshKeyGetResponse = $this->mockListSshKeysRequestWithIdeKey($ide);
 
-    $this->mockDeleteSshKeyRequest($ssh_key_get_response->{'_embedded'}->items[0]->uuid);
+    $this->mockDeleteSshKeyRequest($sshKeyGetResponse->{'_embedded'}->items[0]->uuid);
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -64,7 +64,7 @@ class IdeDeleteCommandTest extends CommandTestBase {
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString($ide_delete_response->{'De-provisioning IDE'}->value->message, $output);
+    $this->assertStringContainsString($ideDeleteResponse->{'De-provisioning IDE'}->value->message, $output);
   }
 
 }

--- a/tests/phpunit/src/Commands/Ide/IdeHelper.php
+++ b/tests/phpunit/src/Commands/Ide/IdeHelper.php
@@ -6,7 +6,7 @@ use Acquia\Cli\Tests\TestBase;
 
 class IdeHelper {
 
-  public static string $remote_ide_uuid = '215824ff-272a-4a8c-9027-df32ed1d68a9';
+  public static string $remoteIdeUuid = '215824ff-272a-4a8c-9027-df32ed1d68a9';
 
   public static function setCloudIdeEnvVars(): void {
     TestBase::setEnvVars(self::getEnvVars());
@@ -20,7 +20,7 @@ class IdeHelper {
     return [
       'ACQUIA_USER_UUID' => '4acf8956-45df-3cf4-5106-065b62cf1ac8',
       'AH_SITE_ENVIRONMENT' => 'IDE',
-      'REMOTEIDE_UUID' => self::$remote_ide_uuid,
+      'REMOTEIDE_UUID' => self::$remoteIdeUuid,
     ];
   }
 

--- a/tests/phpunit/src/Commands/Ide/IdeListCommandMineTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeListCommandMineTest.php
@@ -19,15 +19,15 @@ class IdeListCommandMineTest extends CommandTestBase {
    * Tests the 'ide:list-mine' commands.
    */
   public function testIdeListMineCommand(): void {
-    $applications_response = $this->getMockResponseFromSpec('/applications', 'get', '200');
-    $ides_response = $this->mockAccountIdeListRequest();
-    foreach ($ides_response->{'_embedded'}->items as $key => $ide) {
-      $application_response = $applications_response->{'_embedded'}->items[$key];
-      $app_url_parts = explode('/', $ide->_links->application->href);
-      $app_uuid = end($app_url_parts);
-      $application_response->uuid = $app_uuid;
-      $this->clientProphecy->request('get', '/applications/' . $app_uuid)
-        ->willReturn($application_response)
+    $applicationsResponse = $this->getMockResponseFromSpec('/applications', 'get', '200');
+    $idesResponse = $this->mockAccountIdeListRequest();
+    foreach ($idesResponse->{'_embedded'}->items as $key => $ide) {
+      $applicationResponse = $applicationsResponse->{'_embedded'}->items[$key];
+      $appUrlParts = explode('/', $ide->_links->application->href);
+      $appUuid = end($appUrlParts);
+      $applicationResponse->uuid = $appUuid;
+      $this->clientProphecy->request('get', '/applications/' . $appUuid)
+        ->willReturn($applicationResponse)
         ->shouldBeCalled();
     }
 

--- a/tests/phpunit/src/Commands/Ide/IdePhpVersionCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdePhpVersionCommandTest.php
@@ -40,18 +40,18 @@ class IdePhpVersionCommandTest extends CommandTestBase {
    * @dataProvider providerTestIdePhpVersionCommand
    */
   public function testIdePhpVersionCommand(string $version): void {
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->mockRestartPhp($local_machine_helper);
-    $mock_file_system = $this->mockGetFilesystem($local_machine_helper);
-    $php_filepath_prefix = $this->fs->tempnam(sys_get_temp_dir(), 'acli_php_stub_');
-    $php_stub_filepath = $php_filepath_prefix . $version;
-    $mock_file_system->exists($php_stub_filepath)->willReturn(TRUE);
-    $php_version_file_path = $this->fs->tempnam(sys_get_temp_dir(), 'acli_php_version_file_');
-    $mock_file_system->dumpFile($php_version_file_path, $version)->shouldBeCalled();
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->mockRestartPhp($localMachineHelper);
+    $mockFileSystem = $this->mockGetFilesystem($localMachineHelper);
+    $phpFilepathPrefix = $this->fs->tempnam(sys_get_temp_dir(), 'acli_php_stub_');
+    $phpStubFilepath = $phpFilepathPrefix . $version;
+    $mockFileSystem->exists($phpStubFilepath)->willReturn(TRUE);
+    $phpVersionFilePath = $this->fs->tempnam(sys_get_temp_dir(), 'acli_php_version_file_');
+    $mockFileSystem->dumpFile($phpVersionFilePath, $version)->shouldBeCalled();
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->command->setPhpVersionFilePath($php_version_file_path);
-    $this->command->setIdePhpFilePathPrefix($php_filepath_prefix);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
+    $this->command->setPhpVersionFilePath($phpVersionFilePath);
+    $this->command->setIdePhpFilePathPrefix($phpFilepathPrefix);
     $this->executeCommand([
       'version' => $version,
     ], []);
@@ -75,8 +75,8 @@ class IdePhpVersionCommandTest extends CommandTestBase {
    *
    * @dataProvider providerTestIdePhpVersionCommandFailure
    */
-  public function testIdePhpVersionCommandFailure(string $version, string $exception_class): void {
-    $this->expectException($exception_class);
+  public function testIdePhpVersionCommandFailure(string $version, string $exceptionClass): void {
+    $this->expectException($exceptionClass);
     $this->executeCommand([
       'version' => $version,
     ]);
@@ -94,11 +94,11 @@ class IdePhpVersionCommandTest extends CommandTestBase {
     ]);
   }
 
-  protected function mockRestartPhp(ObjectProphecy|LocalMachineHelper $local_machine_helper): ObjectProphecy {
+  protected function mockRestartPhp(ObjectProphecy|LocalMachineHelper $localMachineHelper): ObjectProphecy {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(0);
-    $local_machine_helper->execute([
+    $localMachineHelper->execute([
         'supervisorctl',
         'restart',
         'php-fpm',
@@ -109,11 +109,11 @@ class IdePhpVersionCommandTest extends CommandTestBase {
   /**
    * @return \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Filesystem\Filesystem
    */
-  protected function mockGetFilesystem(ObjectProphecy|LocalMachineHelper $local_machine_helper): ObjectProphecy|Filesystem {
-    $file_system = $this->prophet->prophesize(Filesystem::class);
-    $local_machine_helper->getFilesystem()->willReturn($file_system)->shouldBeCalled();
+  protected function mockGetFilesystem(ObjectProphecy|LocalMachineHelper $localMachineHelper): ObjectProphecy|Filesystem {
+    $fileSystem = $this->prophet->prophesize(Filesystem::class);
+    $localMachineHelper->getFilesystem()->willReturn($fileSystem)->shouldBeCalled();
 
-    return $file_system;
+    return $fileSystem;
   }
 
 }

--- a/tests/phpunit/src/Commands/Ide/IdeServiceRestartCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeServiceRestartCommandTest.php
@@ -22,9 +22,9 @@ class IdeServiceRestartCommandTest extends CommandTestBase {
    * Tests the 'ide:service-restart' command.
    */
   public function testIdeServiceRestartCommand(): void {
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->mockRestartPhp($local_machine_helper);
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->mockRestartPhp($localMachineHelper);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->executeCommand(['service' => 'php'], []);
 
     // Assert.
@@ -37,9 +37,9 @@ class IdeServiceRestartCommandTest extends CommandTestBase {
    * Tests the 'ide:service-restart' command with invalid choice.
    */
   public function testIdeServiceRestartCommandInvalid(): void {
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->mockRestartPhp($local_machine_helper);
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->mockRestartPhp($localMachineHelper);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->expectException(ValidatorException::class);
     $this->expectExceptionMessage('Specify a valid service name');
     $this->executeCommand(['service' => 'rambulator'], []);

--- a/tests/phpunit/src/Commands/Ide/IdeServiceStartCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeServiceStartCommandTest.php
@@ -22,9 +22,9 @@ class IdeServiceStartCommandTest extends CommandTestBase {
    * Tests the 'ide:service-start' command.
    */
   public function testIdeServiceStartCommand(): void {
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->mockStartPhp($local_machine_helper);
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->mockStartPhp($localMachineHelper);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->executeCommand(['service' => 'php'], []);
 
     // Assert.
@@ -37,9 +37,9 @@ class IdeServiceStartCommandTest extends CommandTestBase {
    * Tests the 'ide:service-start' command with invalid choice.
    */
   public function testIdeServiceStartCommandInvalid(): void {
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->mockStartPhp($local_machine_helper);
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->mockStartPhp($localMachineHelper);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->expectException(ValidatorException::class);
     $this->expectExceptionMessage('Specify a valid service name');
     $this->executeCommand(['service' => 'rambulator'], []);

--- a/tests/phpunit/src/Commands/Ide/IdeServiceStopCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeServiceStopCommandTest.php
@@ -22,9 +22,9 @@ class IdeServiceStopCommandTest extends CommandTestBase {
    * Tests the 'ide:service-stop' command.
    */
   public function testIdeServiceStopCommand(): void {
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->mockStopPhp($local_machine_helper);
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->mockStopPhp($localMachineHelper);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->executeCommand(['service' => 'php'], []);
 
     // Assert.
@@ -37,9 +37,9 @@ class IdeServiceStopCommandTest extends CommandTestBase {
    * Tests the 'ide:service-stop' command with invalid choice.
    */
   public function testIdeServiceStopCommandInvalid(): void {
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->mockStopPhp($local_machine_helper);
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->mockStopPhp($localMachineHelper);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->expectException(ValidatorException::class);
     $this->expectExceptionMessage('Specify a valid service name');
     $this->executeCommand(['service' => 'rambulator'], []);

--- a/tests/phpunit/src/Commands/Ide/IdeShareCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeShareCommandTest.php
@@ -42,8 +42,8 @@ class IdeShareCommandTest extends CommandTestBase {
    * Tests the 'ide:share' command.
    */
   public function testIdeShareCommand(): void {
-    $ide_get_response = $this->mockGetIdeRequest(IdeHelper::$remote_ide_uuid);
-    $ide = new IdeResponse((object) $ide_get_response);
+    $ideGetResponse = $this->mockGetIdeRequest(IdeHelper::$remoteIdeUuid);
+    $ide = new IdeResponse((object) $ideGetResponse);
     $this->executeCommand([], []);
 
     // Assert.
@@ -57,8 +57,8 @@ class IdeShareCommandTest extends CommandTestBase {
    * Tests the 'ide:share' command.
    */
   public function testIdeShareRegenerateCommand(): void {
-    $ide_get_response = $this->mockGetIdeRequest(IdeHelper::$remote_ide_uuid);
-    $ide = new IdeResponse((object) $ide_get_response);
+    $ideGetResponse = $this->mockGetIdeRequest(IdeHelper::$remoteIdeUuid);
+    $ide = new IdeResponse((object) $ideGetResponse);
     $this->executeCommand(['--regenerate' => TRUE], []);
 
     // Assert.

--- a/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
@@ -16,7 +16,7 @@ class IdeXdebugToggleCommandTest extends CommandTestBase {
 
   private string $xdebugFilePath;
 
-  public function setUpXdebug(string $php_version): void {
+  public function setUpXdebug(string $phpVersion): void {
     $this->xdebugFilePath = $this->fs->tempnam(sys_get_temp_dir(), 'acli_xdebug_ini_');
     $this->fs->copy($this->realFixtureDir . '/xdebug.ini', $this->xdebugFilePath, TRUE);
     $this->command->setXdebugIniFilepath($this->xdebugFilePath);
@@ -24,8 +24,8 @@ class IdeXdebugToggleCommandTest extends CommandTestBase {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(0);
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $local_machine_helper
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $localMachineHelper
       ->execute([
         'supervisorctl',
         'restart',
@@ -33,7 +33,7 @@ class IdeXdebugToggleCommandTest extends CommandTestBase {
       ], NULL, NULL, FALSE)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
   }
 
   protected function createCommand(): Command {
@@ -56,8 +56,8 @@ class IdeXdebugToggleCommandTest extends CommandTestBase {
    *
    * @dataProvider providerTestXdebugCommandEnable
    */
-  public function testXdebugCommandEnable($php_version): void {
-    $this->setUpXdebug($php_version);
+  public function testXdebugCommandEnable($phpVersion): void {
+    $this->setUpXdebug($phpVersion);
     $this->executeCommand([], []);
     $this->prophet->checkPredictions();
     $this->assertFileExists($this->xdebugFilePath);
@@ -71,8 +71,8 @@ class IdeXdebugToggleCommandTest extends CommandTestBase {
    *
    * @dataProvider providerTestXdebugCommandEnable
    */
-  public function testXdebugCommandDisable($php_version): void {
-    $this->setUpXdebug($php_version);
+  public function testXdebugCommandDisable($phpVersion): void {
+    $this->setUpXdebug($phpVersion);
     // Modify fixture to disable xdebug.
     file_put_contents($this->xdebugFilePath, str_replace(';zend_extension=xdebug.so', 'zend_extension=xdebug.so', file_get_contents($this->xdebugFilePath)));
     $this->executeCommand([], []);

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
@@ -17,12 +17,12 @@ class IdeWizardCreateSshKeyCommandTest extends IdeWizardTestBase {
 
   public function setUp($output = NULL): void {
     parent::setUp($output);
-    $application_response = $this->mockApplicationRequest();
+    $applicationResponse = $this->mockApplicationRequest();
     $this->mockListSshKeysRequest();
     $this->mockAccountRequest();
-    $this->mockPermissionsRequest($application_response);
+    $this->mockPermissionsRequest($applicationResponse);
     $this->ide = $this->mockIdeRequest();
-    $this->sshKeyFileName = IdeWizardCreateSshKeyCommand::getSshKeyFilename(IdeHelper::$remote_ide_uuid);
+    $this->sshKeyFileName = IdeWizardCreateSshKeyCommand::getSshKeyFilename(IdeHelper::$remoteIdeUuid);
   }
 
   /**
@@ -33,9 +33,9 @@ class IdeWizardCreateSshKeyCommandTest extends IdeWizardTestBase {
   }
 
   protected function mockIdeRequest(): IdeResponse {
-    $ide_response = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
-    $this->clientProphecy->request('get', '/ides/' . IdeHelper::$remote_ide_uuid)->willReturn($ide_response)->shouldBeCalled();
-    return new IdeResponse($ide_response);
+    $ideResponse = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
+    $this->clientProphecy->request('get', '/ides/' . IdeHelper::$remoteIdeUuid)->willReturn($ideResponse)->shouldBeCalled();
+    return new IdeResponse($ideResponse);
   }
 
   public function testCreate(): void {

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardDeleteSshKeyCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardDeleteSshKeyCommandTest.php
@@ -17,23 +17,23 @@ class IdeWizardDeleteSshKeyCommandTest extends IdeWizardTestBase {
    */
   public function testDelete(): void {
     // Request for IDE data.
-    $ide_response = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
-    $this->clientProphecy->request('get', '/ides/' . IdeHelper::$remote_ide_uuid)->willReturn($ide_response)->shouldBeCalled();
-    $ide = new IdeResponse((object) $ide_response);
-    $mock_body = $this->mockListSshKeysRequestWithIdeKey($ide);
+    $ideResponse = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
+    $this->clientProphecy->request('get', '/ides/' . IdeHelper::$remoteIdeUuid)->willReturn($ideResponse)->shouldBeCalled();
+    $ide = new IdeResponse((object) $ideResponse);
+    $mockBody = $this->mockListSshKeysRequestWithIdeKey($ide);
 
-    $this->mockDeleteSshKeyRequest($mock_body->{'_embedded'}->items[0]->uuid);
+    $this->mockDeleteSshKeyRequest($mockBody->{'_embedded'}->items[0]->uuid);
 
     // Create the file so it can be deleted.
-    $ssh_key_filename = $this->command::getSshKeyFilename(IdeHelper::$remote_ide_uuid);
-    $this->fs->touch($this->sshDir . '/' . $ssh_key_filename);
-    $this->fs->dumpFile($this->sshDir . '/' . $ssh_key_filename . '.pub', $mock_body->{'_embedded'}->items[0]->public_key);
+    $sshKeyFilename = $this->command::getSshKeyFilename(IdeHelper::$remoteIdeUuid);
+    $this->fs->touch($this->sshDir . '/' . $sshKeyFilename);
+    $this->fs->dumpFile($this->sshDir . '/' . $sshKeyFilename . '.pub', $mockBody->{'_embedded'}->items[0]->public_key);
 
     // Run it!
     $this->executeCommand([]);
 
     $this->prophet->checkPredictions();
-    $this->assertFileDoesNotExist($this->sshDir . '/' . $ssh_key_filename);
+    $this->assertFileDoesNotExist($this->sshDir . '/' . $sshKeyFilename);
   }
 
   /**

--- a/tests/phpunit/src/Commands/InferApplicationTest.php
+++ b/tests/phpunit/src/Commands/InferApplicationTest.php
@@ -25,16 +25,16 @@ class InferApplicationTest extends CommandTestBase {
 
   public function testInfer(): void {
 
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $environment_response = $this->getMockEnvironmentResponse();
+    $environmentResponse = $this->getMockEnvironmentResponse();
     // The searchApplicationEnvironmentsForGitUrl() method will only look
     // for a match of the vcs url on the prod env. So, we mock a prod env.
-    $environment_response2 = $environment_response;
-    $environment_response2->flags->production = TRUE;
+    $environmentResponse2 = $environmentResponse;
+    $environmentResponse2->flags->production = TRUE;
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
-      ->willReturn([$environment_response, $environment_response2])
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
+      ->willReturn([$environmentResponse, $environmentResponse2])
       ->shouldBeCalled();
 
     $this->executeCommand([], [
@@ -54,17 +54,17 @@ class InferApplicationTest extends CommandTestBase {
   }
 
   public function testInferFailure(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
 
-    $environment_response = $this->getMockEnvironmentResponse();
+    $environmentResponse = $this->getMockEnvironmentResponse();
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
-      ->willReturn([$environment_response, $environment_response])
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
+      ->willReturn([$environmentResponse, $environmentResponse])
       ->shouldBeCalled();
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[1]->uuid}/environments")
-      ->willReturn([$environment_response, $environment_response])
+      "/applications/{$applicationsResponse->{'_embedded'}->items[1]->uuid}/environments")
+      ->willReturn([$environmentResponse, $environmentResponse])
       ->shouldBeCalled();
 
     $this->executeCommand([], [

--- a/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
@@ -26,20 +26,20 @@ class PullCodeCommandTest extends PullCommandTestBase {
     $this->acliRepoRoot = '';
     $this->command = $this->createCommand();
     // Client responses.
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $environments_response = $this->mockEnvironmentsRequest($applications_response);
-    $selected_environment = $environments_response->_embedded->items[0];
-    $local_machine_helper = $this->mockReadIdePhpVersion();
+    $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
+    $selectedEnvironment = $environmentsResponse->_embedded->items[0];
+    $localMachineHelper = $this->mockReadIdePhpVersion();
     $process = $this->mockProcess();
     $dir = Path::join($this->vfsRoot->url(), 'empty-dir');
     mkdir($dir);
-    $local_machine_helper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
-    $this->mockExecuteGitClone($local_machine_helper, $selected_environment, $process, $dir);
-    $this->mockExecuteGitCheckout($local_machine_helper, $selected_environment->vcs->path, $dir, $process);
-    $local_machine_helper->getFinder()->willReturn(new Finder());
+    $localMachineHelper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
+    $this->mockExecuteGitClone($localMachineHelper, $selectedEnvironment, $process, $dir);
+    $this->mockExecuteGitCheckout($localMachineHelper, $selectedEnvironment->vcs->path, $dir, $process);
+    $localMachineHelper->getFinder()->willReturn(new Finder());
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
 
     $inputs = [
       // Would you like to clone a project into the current directory?
@@ -59,21 +59,21 @@ class PullCodeCommandTest extends PullCommandTestBase {
   }
 
   public function testPullCode(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $environments_response = $this->mockEnvironmentsRequest($applications_response);
-    $selected_environment = $environments_response->_embedded->items[0];
+    $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
+    $selectedEnvironment = $environmentsResponse->_embedded->items[0];
     $this->createMockGitConfigFile();
 
-    $local_machine_helper = $this->mockReadIdePhpVersion();
-    $local_machine_helper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
+    $localMachineHelper = $this->mockReadIdePhpVersion();
+    $localMachineHelper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
     $finder = $this->mockFinder();
-    $local_machine_helper->getFinder()->willReturn($finder->reveal());
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper->getFinder()->willReturn($finder->reveal());
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
 
     $process = $this->mockProcess();
-    $this->mockExecuteGitFetchAndCheckout($local_machine_helper, $process, $this->projectDir, $selected_environment->vcs->path);
-    $this->mockExecuteGitStatus(FALSE, $local_machine_helper, $this->projectDir);
+    $this->mockExecuteGitFetchAndCheckout($localMachineHelper, $process, $this->projectDir, $selectedEnvironment->vcs->path);
+    $this->mockExecuteGitStatus(FALSE, $localMachineHelper, $this->projectDir);
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -100,27 +100,27 @@ class PullCodeCommandTest extends PullCommandTestBase {
 
   public function testWithScripts(): void {
     touch(Path::join($this->projectDir, 'composer.json'));
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $environments_response = $this->mockEnvironmentsRequest($applications_response);
-    $selected_environment = $environments_response->_embedded->items[0];
+    $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
+    $selectedEnvironment = $environmentsResponse->_embedded->items[0];
     $this->createMockGitConfigFile();
 
-    $local_machine_helper = $this->mockReadIdePhpVersion();
-    $local_machine_helper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
+    $localMachineHelper = $this->mockReadIdePhpVersion();
+    $localMachineHelper->checkRequiredBinariesExist(["git"])->shouldBeCalled();
     $finder = $this->mockFinder();
-    $local_machine_helper->getFinder()->willReturn($finder->reveal());
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper->getFinder()->willReturn($finder->reveal());
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
 
     $process = $this->mockProcess();
-    $this->mockExecuteGitFetchAndCheckout($local_machine_helper, $process, $this->projectDir, $selected_environment->vcs->path);
-    $this->mockExecuteGitStatus(FALSE, $local_machine_helper, $this->projectDir);
+    $this->mockExecuteGitFetchAndCheckout($localMachineHelper, $process, $this->projectDir, $selectedEnvironment->vcs->path);
+    $this->mockExecuteGitStatus(FALSE, $localMachineHelper, $this->projectDir);
     $process = $this->mockProcess();
-    $this->mockExecuteComposerExists($local_machine_helper);
-    $this->mockExecuteComposerInstall($local_machine_helper, $process);
-    $this->mockExecuteDrushExists($local_machine_helper);
-    $this->mockExecuteDrushStatus($local_machine_helper, TRUE, $this->projectDir);
-    $this->mockExecuteDrushCacheRebuild($local_machine_helper, $process);
+    $this->mockExecuteComposerExists($localMachineHelper);
+    $this->mockExecuteComposerInstall($localMachineHelper, $process);
+    $this->mockExecuteDrushExists($localMachineHelper);
+    $this->mockExecuteDrushStatus($localMachineHelper, TRUE, $this->projectDir);
+    $this->mockExecuteDrushCacheRebuild($localMachineHelper, $process);
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -154,7 +154,7 @@ class PullCodeCommandTest extends PullCommandTestBase {
   /**
    * @dataProvider providerTestMatchPhpVersion
    */
-  public function testMatchPhpVersion(string $php_version): void {
+  public function testMatchPhpVersion(string $phpVersion): void {
     IdeHelper::setCloudIdeEnvVars();
     $this->application->addCommands([
       $this->injectCommand(IdePhpVersionCommand::class),
@@ -163,30 +163,30 @@ class PullCodeCommandTest extends PullCommandTestBase {
     $dir = '/home/ide/project';
     $this->createMockGitConfigFile();
 
-    $local_machine_helper = $this->mockReadIdePhpVersion($php_version);
-    $local_machine_helper->checkRequiredBinariesExist(["git"])
+    $localMachineHelper = $this->mockReadIdePhpVersion($phpVersion);
+    $localMachineHelper->checkRequiredBinariesExist(["git"])
       ->shouldBeCalled();
     $finder = $this->mockFinder();
-    $local_machine_helper->getFinder()->willReturn($finder->reveal());
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper->getFinder()->willReturn($finder->reveal());
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
 
     $process = $this->mockProcess();
-    $this->mockExecuteGitFetchAndCheckout($local_machine_helper, $process, $dir, 'master');
-    $this->mockExecuteGitStatus(FALSE, $local_machine_helper, $dir);
+    $this->mockExecuteGitFetchAndCheckout($localMachineHelper, $process, $dir, 'master');
+    $this->mockExecuteGitStatus(FALSE, $localMachineHelper, $dir);
 
-    $environment_response = $this->getMockEnvironmentResponse();
-    $environment_response->configuration->php->version = '7.1';
-    $environment_response->sshUrl = $environment_response->ssh_url;
+    $environmentResponse = $this->getMockEnvironmentResponse();
+    $environmentResponse->configuration->php->version = '7.1';
+    $environmentResponse->sshUrl = $environmentResponse->ssh_url;
     $this->clientProphecy->request('get',
-      "/environments/" . $environment_response->id)
-      ->willReturn($environment_response)
+      "/environments/" . $environmentResponse->id)
+      ->willReturn($environmentResponse)
       ->shouldBeCalled();
 
     $this->executeCommand([
       '--dir' => $dir,
       '--no-scripts' => TRUE,
       // @todo Execute ONLY match php aspect, not the code pull.
-      'environmentId' => $environment_response->id,
+      'environmentId' => $environmentResponse->id,
     ], [
       // Choose an Acquia environment:
       0,
@@ -196,8 +196,8 @@ class PullCodeCommandTest extends PullCommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
     IdeHelper::unsetCloudIdeEnvVars();
-    $message = "Would you like to change the PHP version on this IDE to match the PHP version on the {$environment_response->label} ({$environment_response->configuration->php->version}) environment?";
-    if ($php_version === '7.1') {
+    $message = "Would you like to change the PHP version on this IDE to match the PHP version on the {$environmentResponse->label} ({$environmentResponse->configuration->php->version}) environment?";
+    if ($phpVersion === '7.1') {
       $this->assertStringNotContainsString($message, $output);
     }
     else {
@@ -209,51 +209,51 @@ class PullCodeCommandTest extends PullCommandTestBase {
    * @param $dir
    */
   protected function mockExecuteGitClone(
-    ObjectProphecy $local_machine_helper,
-    object $environments_response,
+    ObjectProphecy $localMachineHelper,
+    object $environmentsResponse,
     ObjectProphecy $process,
                    $dir
   ): void {
     $command = [
       'git',
       'clone',
-      $environments_response->vcs->url,
+      $environmentsResponse->vcs->url,
       $dir,
     ];
-    $local_machine_helper->execute($command, Argument::type('callable'), NULL, TRUE, NULL, ['GIT_SSH_COMMAND' => 'ssh -o StrictHostKeyChecking=no'])
+    $localMachineHelper->execute($command, Argument::type('callable'), NULL, TRUE, NULL, ['GIT_SSH_COMMAND' => 'ssh -o StrictHostKeyChecking=no'])
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }
 
   /**
    * @param $cwd
-   * @param $vcs_path
+   * @param $vcsPath
    */
   protected function mockExecuteGitFetchAndCheckout(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process,
     $cwd,
-    $vcs_path
+    $vcsPath
   ): void {
-    $local_machine_helper->execute([
+    $localMachineHelper->execute([
       'git',
       'fetch',
       '--all',
     ], Argument::type('callable'), $cwd, FALSE)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
-    $this->mockExecuteGitCheckout($local_machine_helper, $vcs_path, $cwd, $process);
+    $this->mockExecuteGitCheckout($localMachineHelper, $vcsPath, $cwd, $process);
   }
 
   /**
-   * @param $vcs_path
+   * @param $vcsPath
    * @param $cwd
    */
-  protected function mockExecuteGitCheckout(ObjectProphecy $local_machine_helper, $vcs_path, $cwd, ObjectProphecy $process): void {
-    $local_machine_helper->execute([
+  protected function mockExecuteGitCheckout(ObjectProphecy $localMachineHelper, $vcsPath, $cwd, ObjectProphecy $process): void {
+    $localMachineHelper->execute([
       'git',
       'checkout',
-      $vcs_path,
+      $vcsPath,
     ], Argument::type('callable'), $cwd, FALSE)
       ->willReturn($process->reveal())
       ->shouldBeCalled();

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -18,28 +18,28 @@ abstract class PullCommandTestBase extends CommandTestBase {
   }
 
   protected function mockExecuteDrushExists(
-    ObjectProphecy $local_machine_helper
+    ObjectProphecy $localMachineHelper
   ): void {
-    $local_machine_helper
+    $localMachineHelper
       ->commandExists('drush')
       ->willReturn(TRUE)
       ->shouldBeCalled();
   }
 
   /**
-   * @param $has_connection
+   * @param $hasConnection
    */
   protected function mockExecuteDrushStatus(
-    ObjectProphecy $local_machine_helper,
-    $has_connection,
+    ObjectProphecy $localMachineHelper,
+    $hasConnection,
     string $dir = NULL
   ): void {
-    $drush_status_process = $this->prophet->prophesize(Process::class);
-    $drush_status_process->isSuccessful()->willReturn($has_connection);
-    $drush_status_process->getExitCode()->willReturn($has_connection ? 0 : 1);
-    $drush_status_process->getOutput()
+    $drushStatusProcess = $this->prophet->prophesize(Process::class);
+    $drushStatusProcess->isSuccessful()->willReturn($hasConnection);
+    $drushStatusProcess->getExitCode()->willReturn($hasConnection ? 0 : 1);
+    $drushStatusProcess->getOutput()
       ->willReturn(json_encode(['db-status' => 'Connected']));
-    $local_machine_helper
+    $localMachineHelper
       ->execute([
         'drush',
         'status',
@@ -47,15 +47,15 @@ abstract class PullCommandTestBase extends CommandTestBase {
         '--format=json',
         '--no-interaction',
       ], Argument::any(), $dir, FALSE)
-      ->willReturn($drush_status_process->reveal())
+      ->willReturn($drushStatusProcess->reveal())
       ->shouldBeCalled();
   }
 
   protected function mockExecuteDrushCacheRebuild(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process
   ): void {
-    $local_machine_helper
+    $localMachineHelper
       ->execute([
         'drush',
         'cache:rebuild',
@@ -68,10 +68,10 @@ abstract class PullCommandTestBase extends CommandTestBase {
   }
 
   protected function mockExecuteDrushSqlSanitize(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process
   ): void {
-    $local_machine_helper
+    $localMachineHelper
       ->execute([
         'drush',
         'sql:sanitize',
@@ -84,19 +84,19 @@ abstract class PullCommandTestBase extends CommandTestBase {
   }
 
   protected function mockExecuteComposerExists(
-    ObjectProphecy $local_machine_helper
+    ObjectProphecy $localMachineHelper
   ): void {
-    $local_machine_helper
+    $localMachineHelper
       ->commandExists('composer')
       ->willReturn(TRUE)
       ->shouldBeCalled();
   }
 
   protected function mockExecuteComposerInstall(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process
   ): void {
-    $local_machine_helper
+    $localMachineHelper
       ->execute([
         'composer',
         'install',
@@ -107,9 +107,9 @@ abstract class PullCommandTestBase extends CommandTestBase {
   }
 
   protected function mockDrupalSettingsRefresh(
-    ObjectProphecy $local_machine_helper
+    ObjectProphecy $localMachineHelper
   ): void {
-    $local_machine_helper
+    $localMachineHelper
       ->execute([
         '/ide/drupal-setup.sh',
       ]);
@@ -121,27 +121,27 @@ abstract class PullCommandTestBase extends CommandTestBase {
    */
   protected function mockExecuteGitStatus(
     $failed,
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     $cwd
   ): void {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(!$failed)->shouldBeCalled();
-    $local_machine_helper->executeFromCmd('git add . && git diff-index --cached --quiet HEAD', NULL, $cwd, FALSE)->willReturn($process->reveal())->shouldBeCalled();
+    $localMachineHelper->executeFromCmd('git add . && git diff-index --cached --quiet HEAD', NULL, $cwd, FALSE)->willReturn($process->reveal())->shouldBeCalled();
   }
 
   /**
    * @param $cwd
-   * @param $commit_hash
+   * @param $commitHash
    */
   protected function mockGetLocalCommitHash(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     $cwd,
-    $commit_hash
+    $commitHash
   ): void {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
-    $process->getOutput()->willReturn($commit_hash)->shouldBeCalled();
-    $local_machine_helper->execute([
+    $process->getOutput()->willReturn($commitHash)->shouldBeCalled();
+    $localMachineHelper->execute([
       'git',
       'rev-parse',
       'HEAD',

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -66,11 +66,11 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
   }
 
   public function testPullDatabasesIntoLando(): void {
-    $lando_info = LandoInfoHelper::getLandoInfo();
-    LandoInfoHelper::setLandoInfo($lando_info);
+    $landoInfo = LandoInfoHelper::getLandoInfo();
+    LandoInfoHelper::setLandoInfo($landoInfo);
     $this->dbUser = 'root';
     $this->dbPassword = '';
-    $this->dbHost = $lando_info->database->hostnames[0];
+    $this->dbHost = $landoInfo->database->hostnames[0];
     $this->setupPullDatabase(TRUE, TRUE, TRUE, TRUE, TRUE);
     $inputs = $this->getInputs();
     $this->executeCommand([
@@ -181,66 +181,66 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
   }
 
   /**
-   * @param $mysql_connect_successful *
+   * @param $mysqlConnectSuccessful *
    */
-  protected function setupPullDatabase($mysql_connect_successful, $mysql_drop_successful, $mysql_create_successful, $mysql_import_successful, $mock_ide_fs = FALSE, $on_demand = FALSE, $mock_get_acsf_sites = TRUE, $multidb = FALSE, int $curl_code = 0): void {
-    $applications_response = $this->mockApplicationsRequest();
+  protected function setupPullDatabase($mysqlConnectSuccessful, $mysqlDropSuccessful, $mysqlCreateSuccessful, $mysqlImportSuccessful, $mockIdeFs = FALSE, $onDemand = FALSE, $mockGetAcsfSites = TRUE, $multidb = FALSE, int $curlCode = 0): void {
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $environments_response = $this->mockAcsfEnvironmentsRequest($applications_response);
-    $selected_environment = $environments_response->_embedded->items[0];
+    $environmentsResponse = $this->mockAcsfEnvironmentsRequest($applicationsResponse);
+    $selectedEnvironment = $environmentsResponse->_embedded->items[0];
     $this->createMockGitConfigFile();
 
-    $databases_response = $this->mockAcsfDatabasesResponse($selected_environment);
-    $database_response = $databases_response[array_search('jxr5000596dev', array_column($databases_response, 'name'), TRUE)];
-    $selected_database = $this->mockDownloadBackup($database_response, $selected_environment, $curl_code);
+    $databasesResponse = $this->mockAcsfDatabasesResponse($selectedEnvironment);
+    $databaseResponse = $databasesResponse[array_search('jxr5000596dev', array_column($databasesResponse, 'name'), TRUE)];
+    $selectedDatabase = $this->mockDownloadBackup($databaseResponse, $selectedEnvironment, $curlCode);
 
     if ($multidb) {
-      $database_response_2 = $databases_response[array_search('profserv2', array_column($databases_response, 'name'), TRUE)];
-      $this->mockDownloadBackup($database_response_2, $selected_environment, $curl_code);
+      $databaseResponse2 = $databasesResponse[array_search('profserv2', array_column($databasesResponse, 'name'), TRUE)];
+      $this->mockDownloadBackup($databaseResponse2, $selectedEnvironment, $curlCode);
     }
 
-    $ssh_helper = $this->mockSshHelper();
-    if ($mock_get_acsf_sites) {
-      $this->mockGetAcsfSites($ssh_helper);
+    $sshHelper = $this->mockSshHelper();
+    if ($mockGetAcsfSites) {
+      $this->mockGetAcsfSites($sshHelper);
     }
 
-    if ($on_demand) {
-      $backup_response = $this->mockDatabaseBackupCreateResponse($selected_environment, $selected_database->name);
+    if ($onDemand) {
+      $backupResponse = $this->mockDatabaseBackupCreateResponse($selectedEnvironment, $selectedDatabase->name);
       // Cloud API does not provide the notification UUID as part of the backup response, so we must hardcode it.
-      $this->mockNotificationResponseFromObject($backup_response);
+      $this->mockNotificationResponseFromObject($backupResponse);
     }
 
     $fs = $this->prophet->prophesize(Filesystem::class);
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->mockExecuteMySqlConnect($local_machine_helper, $mysql_connect_successful);
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->mockExecuteMySqlConnect($localMachineHelper, $mysqlConnectSuccessful);
     // Set up file system.
-    $local_machine_helper->getFilesystem()->willReturn($fs)->shouldBeCalled();
+    $localMachineHelper->getFilesystem()->willReturn($fs)->shouldBeCalled();
 
     // Mock IDE filesystem.
-    if ($mock_ide_fs) {
-      $this->mockDrupalSettingsRefresh($local_machine_helper);
+    if ($mockIdeFs) {
+      $this->mockDrupalSettingsRefresh($localMachineHelper);
       $this->mockSettingsFiles($fs);
     }
 
     // Database.
-    $this->mockExecuteMySqlDropDb($local_machine_helper, $mysql_drop_successful);
-    $this->mockExecuteMySqlCreateDb($local_machine_helper, $mysql_create_successful);
-    $this->mockExecuteMySqlImport($local_machine_helper, $mysql_import_successful);
+    $this->mockExecuteMySqlDropDb($localMachineHelper, $mysqlDropSuccessful);
+    $this->mockExecuteMySqlCreateDb($localMachineHelper, $mysqlCreateSuccessful);
+    $this->mockExecuteMySqlImport($localMachineHelper, $mysqlImportSuccessful);
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->command->sshHelper = $ssh_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
+    $this->command->sshHelper = $sshHelper->reveal();
   }
 
   /**
-   * @param ObjectProphecy|\Acquia\Cli\Helpers\LocalMachineHelper $local_machine_helper
+   * @param ObjectProphecy|\Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
    */
   protected function mockExecuteMySqlConnect(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     bool $success
   ): void {
-    $local_machine_helper->checkRequiredBinariesExist(["mysql"])->shouldBeCalled();
+    $localMachineHelper->checkRequiredBinariesExist(["mysql"])->shouldBeCalled();
     $process = $this->mockProcess($success);
-    $local_machine_helper
+    $localMachineHelper
       ->execute([
         'mysql',
         '--host',
@@ -254,27 +254,27 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
   }
 
   protected function mockExecuteMySqlDropDb(
-    \Acquia\Cli\Helpers\LocalMachineHelper|ObjectProphecy $local_machine_helper,
+    \Acquia\Cli\Helpers\LocalMachineHelper|ObjectProphecy $localMachineHelper,
     bool $success
   ): void {
-    $local_machine_helper->checkRequiredBinariesExist(["mysql"])->shouldBeCalled();
+    $localMachineHelper->checkRequiredBinariesExist(["mysql"])->shouldBeCalled();
     $process = $this->mockProcess($success);
-    $local_machine_helper
+    $localMachineHelper
       ->execute(Argument::type('array'), Argument::type('callable'), NULL, FALSE, NULL, ['MYSQL_PWD' => $this->dbPassword])
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }
 
   /**
-   * @param ObjectProphecy|\Acquia\Cli\Helpers\LocalMachineHelper $local_machine_helper
+   * @param ObjectProphecy|\Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
    */
   protected function mockExecuteMySqlCreateDb(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     bool $success
   ): void {
-    $local_machine_helper->checkRequiredBinariesExist(["mysql"])->shouldBeCalled();
+    $localMachineHelper->checkRequiredBinariesExist(["mysql"])->shouldBeCalled();
     $process = $this->mockProcess($success);
-    $local_machine_helper
+    $localMachineHelper
       ->execute([
         'mysql',
         '--host',
@@ -290,17 +290,17 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
   }
 
   /**
-   * @param ObjectProphecy|\Acquia\Cli\Helpers\LocalMachineHelper $local_machine_helper
+   * @param ObjectProphecy|\Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
    */
   protected function mockExecuteMySqlImport(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     bool $success
   ): void {
-    $local_machine_helper->checkRequiredBinariesExist(['gunzip', 'mysql'])->shouldBeCalled();
-    $this->mockExecutePvExists($local_machine_helper);
+    $localMachineHelper->checkRequiredBinariesExist(['gunzip', 'mysql'])->shouldBeCalled();
+    $this->mockExecutePvExists($localMachineHelper);
     $process = $this->mockProcess($success);
     // MySQL import command.
-    $local_machine_helper
+    $localMachineHelper
       ->executeFromCmd(Argument::type('string'), Argument::type('callable'),
         NULL, TRUE, NULL)
       ->willReturn($process->reveal())
@@ -308,11 +308,11 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
   }
 
   /**
-   * @param ObjectProphecy|\Acquia\Cli\Helpers\LocalMachineHelper $local_machine_helper
+   * @param ObjectProphecy|\Acquia\Cli\Helpers\LocalMachineHelper $localMachineHelper
    */
-  protected function mockDownloadMySqlDump(ObjectProphecy $local_machine_helper, $success): void {
+  protected function mockDownloadMySqlDump(ObjectProphecy $localMachineHelper, $success): void {
     $process = $this->mockProcess($success);
-    $local_machine_helper->writeFile(
+    $localMachineHelper->writeFile(
       Argument::containingString("dev-profserv2-profserv201dev-something.sql.gz"),
       'backupfilecontents'
     )
@@ -356,37 +356,37 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $this->assertStringContainsString('100/100 [============================] 100%', $output->fetch());
   }
 
-  protected function mockDownloadBackup(DatabaseResponse $selected_database, object $selected_environment, int $curl_code = 0): DatabaseResponse {
-    $database_backups_response = $this->mockDatabaseBackupsResponse($selected_environment, $selected_database->name, 1);
-    $selected_backup = $database_backups_response->_embedded->items[0];
-    if ($curl_code) {
+  protected function mockDownloadBackup(DatabaseResponse $selectedDatabase, object $selectedEnvironment, int $curlCode = 0): DatabaseResponse {
+    $databaseBackupsResponse = $this->mockDatabaseBackupsResponse($selectedEnvironment, $selectedDatabase->name, 1);
+    $selectedBackup = $databaseBackupsResponse->_embedded->items[0];
+    if ($curlCode) {
       $this->prophet->prophesize(StreamInterface::class);
-      /** @var RequestException|ObjectProphecy $request_exception */
-      $request_exception = $this->prophet->prophesize(RequestException::class);
-      $request_exception->getHandlerContext()->willReturn(['errno' => $curl_code]);
-      $this->clientProphecy->stream('get', "/environments/{$selected_environment->id}/databases/{$selected_database->name}/backups/1/actions/download", [])
-        ->willThrow($request_exception->reveal())
+      /** @var RequestException|ObjectProphecy $requestException */
+      $requestException = $this->prophet->prophesize(RequestException::class);
+      $requestException->getHandlerContext()->willReturn(['errno' => $curlCode]);
+      $this->clientProphecy->stream('get', "/environments/{$selectedEnvironment->id}/databases/{$selectedDatabase->name}/backups/1/actions/download", [])
+        ->willThrow($requestException->reveal())
         ->shouldBeCalled();
       $response = $this->prophet->prophesize(ResponseInterface::class);
       $this->httpClientProphecy->request('GET', 'https://other.example.com/download-backup', Argument::type('array'))->willReturn($response->reveal())->shouldBeCalled();
-      $domains_response = $this->getMockResponseFromSpec('/environments/{environmentId}/domains', 'get', 200);
-      $this->clientProphecy->request('get', "/environments/{$selected_environment->id}/domains")->willReturn($domains_response->_embedded->items);
+      $domainsResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/domains', 'get', 200);
+      $this->clientProphecy->request('get', "/environments/{$selectedEnvironment->id}/domains")->willReturn($domainsResponse->_embedded->items);
       $this->command->setBackupDownloadUrl(new Uri( 'https://www.example.com/download-backup'));
     }
     else {
-      $this->mockDownloadBackupResponse($selected_environment, $selected_database->name, 1);
+      $this->mockDownloadBackupResponse($selectedEnvironment, $selectedDatabase->name, 1);
     }
-    $local_filepath = PullCommandBase::getBackupPath($selected_environment, $selected_database, $selected_backup);
-    $this->clientProphecy->addOption('sink', $local_filepath)->shouldBeCalled();
+    $localFilepath = PullCommandBase::getBackupPath($selectedEnvironment, $selectedDatabase, $selectedBackup);
+    $this->clientProphecy->addOption('sink', $localFilepath)->shouldBeCalled();
     $this->clientProphecy->addOption('curl.options', [
-      'CURLOPT_FILE' => $local_filepath,
+      'CURLOPT_FILE' => $localFilepath,
       'CURLOPT_RETURNTRANSFER' => FALSE,
 ])->shouldBeCalled();
     $this->clientProphecy->addOption('progress', Argument::type('Closure'))->shouldBeCalled();
     $this->clientProphecy->addOption('on_stats', Argument::type('Closure'))->shouldBeCalled();
     $this->clientProphecy->getOptions()->willReturn([]);
 
-    return $selected_database;
+    return $selectedDatabase;
   }
 
 }

--- a/tests/phpunit/src/Commands/Pull/PullScriptsCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullScriptsCommandTest.php
@@ -17,22 +17,22 @@ class PullScriptsCommandTest extends PullCommandTestBase {
 
   public function testRefreshScripts(): void {
     touch(Path::join($this->projectDir, 'composer.json'));
-    $local_machine_helper = $this->mockLocalMachineHelper();
+    $localMachineHelper = $this->mockLocalMachineHelper();
     $process = $this->mockProcess();
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
 
     // Composer.
-    $this->mockExecuteComposerExists($local_machine_helper);
-    $this->mockExecuteComposerInstall($local_machine_helper, $process);
+    $this->mockExecuteComposerExists($localMachineHelper);
+    $this->mockExecuteComposerInstall($localMachineHelper, $process);
 
     // Drush.
-    $drush_connection_exists = TRUE;
-    $this->mockExecuteDrushExists($local_machine_helper);
-    $this->mockExecuteDrushStatus($local_machine_helper, $drush_connection_exists, $this->projectDir);
-    if ($drush_connection_exists) {
-      $this->mockExecuteDrushCacheRebuild($local_machine_helper, $process);
-      $this->mockExecuteDrushSqlSanitize($local_machine_helper, $process);
+    $drushConnectionExists = TRUE;
+    $this->mockExecuteDrushExists($localMachineHelper);
+    $this->mockExecuteDrushStatus($localMachineHelper, $drushConnectionExists, $this->projectDir);
+    if ($drushConnectionExists) {
+      $this->mockExecuteDrushCacheRebuild($localMachineHelper, $process);
+      $this->mockExecuteDrushSqlSanitize($localMachineHelper, $process);
     }
 
     $inputs = [

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -24,12 +24,12 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     touch(Path::join($this->projectDir, 'composer.json'));
     mkdir(Path::join($this->projectDir, 'docroot'));
     $this->mockApplicationsRequest();
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $environments_response = $this->mockEnvironmentsRequest($applications_response);
-    $selected_environment = $environments_response->_embedded->items[0];
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->setUpPushArtifact($local_machine_helper, $selected_environment->vcs->path, [$selected_environment->vcs->url]);
+    $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
+    $selectedEnvironment = $environmentsResponse->_embedded->items[0];
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->setUpPushArtifact($localMachineHelper, $selectedEnvironment->vcs->path, [$selectedEnvironment->vcs->url]);
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
       'n',
@@ -54,15 +54,15 @@ class PushArtifactCommandTest extends PullCommandTestBase {
   public function testPushTagArtifact(): void {
     touch(Path::join($this->projectDir, 'composer.json'));
     mkdir(Path::join($this->projectDir, 'docroot'));
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $environments_response = $this->mockEnvironmentsRequest($applications_response);
-    $selected_environment = $environments_response->_embedded->items[0];
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->setUpPushArtifact($local_machine_helper, '1.2.0', [$selected_environment->vcs->url]);
-    $git_tag = '1.2.0-build';
-    $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
-    $this->mockGitTag($local_machine_helper, $git_tag, $artifact_dir);
+    $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
+    $selectedEnvironment = $environmentsResponse->_embedded->items[0];
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->setUpPushArtifact($localMachineHelper, '1.2.0', [$selectedEnvironment->vcs->url]);
+    $gitTag = '1.2.0-build';
+    $artifactDir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
+    $this->mockGitTag($localMachineHelper, $gitTag, $artifactDir);
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
       'n',
@@ -72,7 +72,7 @@ class PushArtifactCommandTest extends PullCommandTestBase {
       'n',
     ];
     $this->executeCommand([
-      '--destination-git-tag' => $git_tag,
+      '--destination-git-tag' => $gitTag,
       '--source-git-tag' => '1.2.0',
     ], $inputs);
     $this->prophet->checkPredictions();
@@ -87,15 +87,15 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     touch(Path::join($this->projectDir, 'composer.json'));
     mkdir(Path::join($this->projectDir, 'docroot'));
     $this->mockApplicationsRequest();
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
     $this->datastoreAcli->set('push.artifact.destination-git-urls', [
       'https://github.com/example1/cli.git',
       'https://github.com/example2/cli.git',
     ]);
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->setUpPushArtifact($local_machine_helper, 'master', $this->datastoreAcli->get('push.artifact.destination-git-urls'));
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->setUpPushArtifact($localMachineHelper, 'master', $this->datastoreAcli->get('push.artifact.destination-git-urls'));
     $this->executeCommand([
       '--destination-git-branch' => 'master',
     ], []);
@@ -110,18 +110,18 @@ class PushArtifactCommandTest extends PullCommandTestBase {
     touch(Path::join($this->projectDir, 'composer.json'));
     mkdir(Path::join($this->projectDir, 'docroot'));
     $this->mockApplicationsRequest();
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
-    $destination_git_urls = [
+    $this->mockEnvironmentsRequest($applicationsResponse);
+    $destinationGitUrls = [
       'https://github.com/example1/cli.git',
       'https://github.com/example2/cli.git',
     ];
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $this->setUpPushArtifact($local_machine_helper, 'master', $destination_git_urls);
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $this->setUpPushArtifact($localMachineHelper, 'master', $destinationGitUrls);
     $this->executeCommand([
       '--destination-git-branch' => 'master',
-      '--destination-git-urls' => $destination_git_urls,
+      '--destination-git-urls' => $destinationGitUrls,
     ], []);
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
@@ -131,93 +131,93 @@ class PushArtifactCommandTest extends PullCommandTestBase {
   }
 
   /**
-   * @param $local_machine_helper
-   * @param $vcs_path
-   * @param $vcs_urls
+   * @param $localMachineHelper
+   * @param $vcsPath
+   * @param $vcsUrls
    */
-  protected function setUpPushArtifact($local_machine_helper, $vcs_path, $vcs_urls): void {
-    $artifact_dir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
+  protected function setUpPushArtifact($localMachineHelper, $vcsPath, $vcsUrls): void {
+    $artifactDir = Path::join(sys_get_temp_dir(), 'acli-push-artifact');
     $this->createMockGitConfigFile();
     $finder = $this->mockFinder();
-    $local_machine_helper->getFinder()->willReturn($finder->reveal());
+    $localMachineHelper->getFinder()->willReturn($finder->reveal());
     $fs = $this->prophet->prophesize(Filesystem::class);
-    $local_machine_helper->getFilesystem()->willReturn($fs)->shouldBeCalled();
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper->getFilesystem()->willReturn($fs)->shouldBeCalled();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
 
-    $commit_hash = 'abc123';
-    $this->mockExecuteGitStatus(FALSE, $local_machine_helper, $this->projectDir);
-    $this->mockGetLocalCommitHash($local_machine_helper, $this->projectDir, $commit_hash);
-    $this->mockCloneShallow($local_machine_helper, $vcs_path, $vcs_urls[0], $artifact_dir);
-    $this->mockLocalGitConfig($local_machine_helper, $artifact_dir);
-    $this->mockComposerInstall($local_machine_helper, $artifact_dir);
-    $this->mockReadComposerJson($local_machine_helper, $artifact_dir);
-    $this->mockGitAddCommit($local_machine_helper, $artifact_dir, $commit_hash);
-    $this->mockGitPush($vcs_urls, $local_machine_helper, $vcs_path, $artifact_dir);
+    $commitHash = 'abc123';
+    $this->mockExecuteGitStatus(FALSE, $localMachineHelper, $this->projectDir);
+    $this->mockGetLocalCommitHash($localMachineHelper, $this->projectDir, $commitHash);
+    $this->mockCloneShallow($localMachineHelper, $vcsPath, $vcsUrls[0], $artifactDir);
+    $this->mockLocalGitConfig($localMachineHelper, $artifactDir);
+    $this->mockComposerInstall($localMachineHelper, $artifactDir);
+    $this->mockReadComposerJson($localMachineHelper, $artifactDir);
+    $this->mockGitAddCommit($localMachineHelper, $artifactDir, $commitHash);
+    $this->mockGitPush($vcsUrls, $localMachineHelper, $vcsPath, $artifactDir);
   }
 
   /**
-   * @param $vcs_path
-   * @param $vcs_url
-   * @param $artifact_dir
+   * @param $vcsPath
+   * @param $vcsUrl
+   * @param $artifactDir
    */
-  protected function mockCloneShallow(ObjectProphecy $local_machine_helper, $vcs_path, $vcs_url, $artifact_dir): void {
+  protected function mockCloneShallow(ObjectProphecy $localMachineHelper, $vcsPath, $vcsUrl, $artifactDir): void {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE)->shouldBeCalled();
-    $local_machine_helper->checkRequiredBinariesExist(['git'])->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'clone', '--depth=1', $vcs_url, $artifact_dir], Argument::type('callable'), NULL, TRUE)
+    $localMachineHelper->checkRequiredBinariesExist(['git'])->shouldBeCalled();
+    $localMachineHelper->execute(['git', 'clone', '--depth=1', $vcsUrl, $artifactDir], Argument::type('callable'), NULL, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'fetch', '--depth=1', $vcs_url, $vcs_path . ':' . $vcs_path], Argument::type('callable'), Argument::type('string'), TRUE)
+    $localMachineHelper->execute(['git', 'fetch', '--depth=1', $vcsUrl, $vcsPath . ':' . $vcsPath], Argument::type('callable'), Argument::type('string'), TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'checkout', $vcs_path], Argument::type('callable'), Argument::type('string'), TRUE)
+    $localMachineHelper->execute(['git', 'checkout', $vcsPath], Argument::type('callable'), Argument::type('string'), TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 
   /**
-   * @param $artifact_dir
+   * @param $artifactDir
    */
-  protected function mockLocalGitConfig(ObjectProphecy $local_machine_helper, $artifact_dir): void {
+  protected function mockLocalGitConfig(ObjectProphecy $localMachineHelper, $artifactDir): void {
     $process = $this->prophet->prophesize(Process::class);
-    $local_machine_helper->execute(['git', 'config', '--local', 'core.excludesFile', 'false'], Argument::type('callable'), $artifact_dir, TRUE)
+    $localMachineHelper->execute(['git', 'config', '--local', 'core.excludesFile', 'false'], Argument::type('callable'), $artifactDir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'config', '--local', 'core.fileMode', 'true'], Argument::type('callable'), $artifact_dir, TRUE)
+    $localMachineHelper->execute(['git', 'config', '--local', 'core.fileMode', 'true'], Argument::type('callable'), $artifactDir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 
   /**
-   * @param $artifact_dir
+   * @param $artifactDir
    */
-  protected function mockComposerInstall(ObjectProphecy $local_machine_helper, $artifact_dir): void {
-    $local_machine_helper->checkRequiredBinariesExist(['composer'])->shouldBeCalled();
+  protected function mockComposerInstall(ObjectProphecy $localMachineHelper, $artifactDir): void {
+    $localMachineHelper->checkRequiredBinariesExist(['composer'])->shouldBeCalled();
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
-    $local_machine_helper->execute(['composer', 'install', '--no-dev', '--no-interaction', '--optimize-autoloader'], Argument::type('callable'), $artifact_dir, TRUE)
+    $localMachineHelper->execute(['composer', 'install', '--no-dev', '--no-interaction', '--optimize-autoloader'], Argument::type('callable'), $artifactDir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 
   /**
-   * @param $artifact_dir
-   * @param $commit_hash
-   * @param $git_url
-   * @param $git_branch
+   * @param $artifactDir
+   * @param $commitHash
+   * @param $gitUrl
+   * @param $gitBranch
    */
-  protected function mockGitAddCommit(ObjectProphecy $local_machine_helper, $artifact_dir, $commit_hash): void {
+  protected function mockGitAddCommit(ObjectProphecy $localMachineHelper, $artifactDir, $commitHash): void {
     $process = $this->mockProcess();
-    $local_machine_helper->execute(['git', 'add', '-A'], Argument::type('callable'), $artifact_dir, TRUE)
+    $localMachineHelper->execute(['git', 'add', '-A'], Argument::type('callable'), $artifactDir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'add', '-f', 'docroot/index.php'], NULL, $artifact_dir, FALSE)
+    $localMachineHelper->execute(['git', 'add', '-f', 'docroot/index.php'], NULL, $artifactDir, FALSE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'add', '-f', 'docroot/autoload.php'], NULL, $artifact_dir, FALSE)
+    $localMachineHelper->execute(['git', 'add', '-f', 'docroot/autoload.php'], NULL, $artifactDir, FALSE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'add', '-f', 'docroot/core'], NULL, $artifact_dir, FALSE)
+    $localMachineHelper->execute(['git', 'add', '-f', 'docroot/core'], NULL, $artifactDir, FALSE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'add', '-f', 'vendor'], NULL, $artifact_dir, FALSE)
+    $localMachineHelper->execute(['git', 'add', '-f', 'vendor'], NULL, $artifactDir, FALSE)
       ->willReturn($process->reveal())->shouldBeCalled();
-    $local_machine_helper->execute(['git', 'commit', '-m', "Automated commit by Acquia CLI (source commit: $commit_hash)"], Argument::type('callable'), $artifact_dir, TRUE)
+    $localMachineHelper->execute(['git', 'commit', '-m', "Automated commit by Acquia CLI (source commit: $commitHash)"], Argument::type('callable'), $artifactDir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 
-  protected function mockReadComposerJson(ObjectProphecy $local_machine_helper, string $artifact_dir): void {
-    $composer_json = json_encode([
+  protected function mockReadComposerJson(ObjectProphecy $localMachineHelper, string $artifactDir): void {
+    $composerJson = json_encode([
       'extra' => [
         'drupal-scaffold' => [
           'file-mapping' => [
@@ -229,36 +229,36 @@ class PushArtifactCommandTest extends PullCommandTestBase {
         ],
 ],
     ]);
-    $local_machine_helper->readFile(Path::join($this->projectDir, 'composer.json'))
-      ->willReturn($composer_json);
-    $local_machine_helper->readFile(Path::join($artifact_dir, 'docroot', 'core', 'composer.json'))
-      ->willReturn($composer_json);
+    $localMachineHelper->readFile(Path::join($this->projectDir, 'composer.json'))
+      ->willReturn($composerJson);
+    $localMachineHelper->readFile(Path::join($artifactDir, 'docroot', 'core', 'composer.json'))
+      ->willReturn($composerJson);
   }
 
   /**
-   * @param $git_urls
-   * @param $git_branch
-   * @param $artifact_dir
+   * @param $gitUrls
+   * @param $gitBranch
+   * @param $artifactDir
    */
-  protected function mockGitPush($git_urls, ObjectProphecy $local_machine_helper, $git_branch, $artifact_dir): void {
+  protected function mockGitPush($gitUrls, ObjectProphecy $localMachineHelper, $gitBranch, $artifactDir): void {
     $process = $this->mockProcess();
-    foreach ($git_urls as $git_url) {
-      $local_machine_helper->execute(Argument::containing($git_url), Argument::type('callable'), $artifact_dir, TRUE)
+    foreach ($gitUrls as $gitUrl) {
+      $localMachineHelper->execute(Argument::containing($gitUrl), Argument::type('callable'), $artifactDir, TRUE)
         ->willReturn($process->reveal())->shouldBeCalled();
     }
   }
 
   /**
-   * @param $git_tag
-   * @param $artifact_dir
+   * @param $gitTag
+   * @param $artifactDir
    */
-  protected function mockGitTag(ObjectProphecy $local_machine_helper, $git_tag, $artifact_dir): void {
+  protected function mockGitTag(ObjectProphecy $localMachineHelper, $gitTag, $artifactDir): void {
     $process = $this->mockProcess();
-    $local_machine_helper->execute([
+    $localMachineHelper->execute([
       'git',
       'tag',
-      $git_tag,
-    ], Argument::type('callable'), $artifact_dir, TRUE)
+      $gitTag,
+    ], Argument::type('callable'), $artifactDir, TRUE)
       ->willReturn($process->reveal())->shouldBeCalled();
   }
 

--- a/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
@@ -19,26 +19,26 @@ class PushDatabaseCommandTest extends CommandTestBase {
   }
 
   public function testPushDatabase(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $environments_response = $this->mockAcsfEnvironmentsRequest($applications_response);
-    $selected_environment = $environments_response->_embedded->items[0];
+    $environmentsResponse = $this->mockAcsfEnvironmentsRequest($applicationsResponse);
+    $selectedEnvironment = $environmentsResponse->_embedded->items[0];
     $this->createMockGitConfigFile();
-    $this->mockAcsfDatabasesResponse($selected_environment);
-    $ssh_helper = $this->mockSshHelper();
-    $this->mockGetAcsfSites($ssh_helper);
+    $this->mockAcsfDatabasesResponse($selectedEnvironment);
+    $sshHelper = $this->mockSshHelper();
+    $this->mockGetAcsfSites($sshHelper);
     $process = $this->mockProcess();
 
-    $local_machine_helper = $this->mockLocalMachineHelper();
+    $localMachineHelper = $this->mockLocalMachineHelper();
 
     // Database.
-    $this->mockExecutePvExists($local_machine_helper);
-    $this->mockCreateMySqlDumpOnLocal($local_machine_helper);
-    $this->mockUploadDatabaseDump($local_machine_helper, $process);
-    $this->mockImportDatabaseDumpOnRemote($ssh_helper, $selected_environment, $process);
+    $this->mockExecutePvExists($localMachineHelper);
+    $this->mockCreateMySqlDumpOnLocal($localMachineHelper);
+    $this->mockUploadDatabaseDump($localMachineHelper, $process);
+    $this->mockImportDatabaseDumpOnRemote($sshHelper, $selectedEnvironment, $process);
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->command->sshHelper = $ssh_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
+    $this->command->sshHelper = $sshHelper->reveal();
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -70,10 +70,10 @@ class PushDatabaseCommandTest extends CommandTestBase {
   }
 
   protected function mockUploadDatabaseDump(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process
   ): void {
-    $local_machine_helper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
+    $localMachineHelper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
     $command = [
       'rsync',
       '-tDvPhe',
@@ -81,23 +81,23 @@ class PushDatabaseCommandTest extends CommandTestBase {
       sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz',
       'profserv2.01dev@profserv201dev.ssh.enterprise-g1.acquia-sites.com:/mnt/tmp/profserv2.dev/acli-mysql-dump-drupal.sql.gz',
     ];
-    $local_machine_helper->execute($command, Argument::type('callable'), NULL, TRUE, NULL)
+    $localMachineHelper->execute($command, Argument::type('callable'), NULL, TRUE, NULL)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }
 
   /**
-   * @param \Prophecy\Prophecy\ObjectProphecy $ssh_helper
-   * @param object $environments_response
+   * @param \Prophecy\Prophecy\ObjectProphecy $sshHelper
+   * @param object $environmentsResponse
    * @param $process
    */
   protected function mockImportDatabaseDumpOnRemote(
-    ObjectProphecy $ssh_helper,
-    object $environments_response,
+    ObjectProphecy $sshHelper,
+    object $environmentsResponse,
     $process
   ): void {
-    $ssh_helper->executeCommand(
-      new EnvironmentResponse($environments_response),
+    $sshHelper->executeCommand(
+      new EnvironmentResponse($environmentsResponse),
       ['pv /mnt/tmp/profserv2.dev/acli-mysql-dump-drupal.sql.gz --bytes --rate | gunzip | MYSQL_PWD=password mysql --host=fsdb-74.enterprise-g1.hosting.acquia.com.enterprise-g1.hosting.acquia.com --user=s164 profserv2db14390'],
       TRUE,
       NULL
@@ -107,11 +107,11 @@ class PushDatabaseCommandTest extends CommandTestBase {
   }
 
   protected function mockExecuteMySqlImport(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process
   ): void {
     // MySQL import command.
-    $local_machine_helper
+    $localMachineHelper
       ->executeFromCmd(Argument::type('string'), Argument::type('callable'),
         NULL, TRUE, NULL)
       ->willReturn($process->reveal())

--- a/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
@@ -19,17 +19,17 @@ class PushFilesCommandTest extends CommandTestBase {
   }
 
   public function testPushFilesAcsf(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockAcsfEnvironmentsRequest($applications_response);
-    $ssh_helper = $this->mockSshHelper();
-    $this->mockGetAcsfSites($ssh_helper);
-    $local_machine_helper = $this->mockLocalMachineHelper();
+    $this->mockAcsfEnvironmentsRequest($applicationsResponse);
+    $sshHelper = $this->mockSshHelper();
+    $this->mockGetAcsfSites($sshHelper);
+    $localMachineHelper = $this->mockLocalMachineHelper();
     $process = $this->mockProcess();
-    $this->mockExecuteAcsfRsync($local_machine_helper, $process);
+    $this->mockExecuteAcsfRsync($localMachineHelper, $process);
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->command->sshHelper = $ssh_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
+    $this->command->sshHelper = $sshHelper->reveal();
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -57,18 +57,18 @@ class PushFilesCommandTest extends CommandTestBase {
   }
 
   public function testPushFilesCloud(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $environments_response = $this->mockEnvironmentsRequest($applications_response);
-    $selected_environment = $environments_response->_embedded->items[0];
-    $ssh_helper = $this->mockSshHelper();
-    $this->mockGetCloudSites($ssh_helper, $selected_environment);
-    $local_machine_helper = $this->mockLocalMachineHelper();
+    $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
+    $selectedEnvironment = $environmentsResponse->_embedded->items[0];
+    $sshHelper = $this->mockSshHelper();
+    $this->mockGetCloudSites($sshHelper, $selectedEnvironment);
+    $localMachineHelper = $this->mockLocalMachineHelper();
     $process = $this->mockProcess();
-    $this->mockExecuteCloudRsync($local_machine_helper, $process, $selected_environment);
+    $this->mockExecuteCloudRsync($localMachineHelper, $process, $selectedEnvironment);
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->command->sshHelper = $ssh_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
+    $this->command->sshHelper = $sshHelper->reveal();
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -96,11 +96,11 @@ class PushFilesCommandTest extends CommandTestBase {
   }
 
   protected function mockExecuteCloudRsync(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process,
     $environment
   ): void {
-    $local_machine_helper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
+    $localMachineHelper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
     $sitegroup = CommandBase::getSiteGroupFromSshUrl($environment->ssh_url);
     $command = [
       'rsync',
@@ -109,16 +109,16 @@ class PushFilesCommandTest extends CommandTestBase {
       $this->projectDir . '/docroot/sites/default/files/',
       $environment->ssh_url . ':/mnt/files/' . $sitegroup . '.' . $environment->name . '/sites/bar/files',
     ];
-    $local_machine_helper->execute($command, Argument::type('callable'), NULL, TRUE, NULL)
+    $localMachineHelper->execute($command, Argument::type('callable'), NULL, TRUE, NULL)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }
 
   protected function mockExecuteAcsfRsync(
-    ObjectProphecy $local_machine_helper,
+    ObjectProphecy $localMachineHelper,
     ObjectProphecy $process
   ): void {
-    $local_machine_helper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
+    $localMachineHelper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
     $command = [
       'rsync',
       '-avPhze',
@@ -126,7 +126,7 @@ class PushFilesCommandTest extends CommandTestBase {
       $this->projectDir . '/docroot/sites/default/files/',
       'profserv2.01dev@profserv201dev.ssh.enterprise-g1.acquia-sites.com:/mnt/files/profserv2.dev/sites/g/files/jxr5000596dev/files',
     ];
-    $local_machine_helper->execute($command, Argument::type('callable'), NULL, TRUE, NULL)
+    $localMachineHelper->execute($command, Argument::type('callable'), NULL, TRUE, NULL)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
   }

--- a/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
@@ -42,36 +42,36 @@ class AliasesDownloadCommandTest extends CommandTestBase {
    *
    * @param array $inputs
    * @param array $args
-   * @param string|null $destination_dir
+   * @param string|null $destinationDir
    * @param bool $all
    *   Download aliases for all applications.
    * @dataProvider providerTestRemoteAliasesDownloadCommand
    */
-  public function testRemoteAliasesDownloadCommand(array $inputs, array $args, string $destination_dir = NULL, bool $all = FALSE): void {
-    $alias_version = $inputs[0];
+  public function testRemoteAliasesDownloadCommand(array $inputs, array $args, string $destinationDir = NULL, bool $all = FALSE): void {
+    $aliasVersion = $inputs[0];
 
-    $drush_aliases_fixture = Path::canonicalize(__DIR__ . '/../../../../fixtures/drush-aliases');
-    $drush_aliases_tarball_fixture_filepath = tempnam(sys_get_temp_dir(), 'AcquiaDrushAliases');
-    $archive_fixture = new PharData($drush_aliases_tarball_fixture_filepath . '.tar');
-    $archive_fixture->buildFromDirectory($drush_aliases_fixture);
-    $archive_fixture->compress(Phar::GZ);
+    $drushAliasesFixture = Path::canonicalize(__DIR__ . '/../../../../fixtures/drush-aliases');
+    $drushAliasesTarballFixtureFilepath = tempnam(sys_get_temp_dir(), 'AcquiaDrushAliases');
+    $archiveFixture = new PharData($drushAliasesTarballFixtureFilepath . '.tar');
+    $archiveFixture->buildFromDirectory($drushAliasesFixture);
+    $archiveFixture->compress(Phar::GZ);
 
-    $stream = Utils::streamFor(file_get_contents($drush_aliases_tarball_fixture_filepath . '.tar.gz'));
-    $this->clientProphecy->addQuery('version', $alias_version);
+    $stream = Utils::streamFor(file_get_contents($drushAliasesTarballFixtureFilepath . '.tar.gz'));
+    $this->clientProphecy->addQuery('version', $aliasVersion);
     $this->clientProphecy->stream('get', '/account/drush-aliases/download')->willReturn($stream);
-    $drush_archive_filepath = $this->command->getDrushArchiveTempFilepath();
+    $drushArchiveFilepath = $this->command->getDrushArchiveTempFilepath();
 
-    $destination_dir = $destination_dir ?? Path::join($this->acliRepoRoot, 'drush');
-    if ($alias_version === '8') {
-      $home_dir = $this->getTempDir();
-      putenv('HOME=' . $home_dir);
-      $destination_dir = Path::join($home_dir, '.drush');
+    $destinationDir = $destinationDir ?? Path::join($this->acliRepoRoot, 'drush');
+    if ($aliasVersion === '8') {
+      $homeDir = $this->getTempDir();
+      putenv('HOME=' . $homeDir);
+      $destinationDir = Path::join($homeDir, '.drush');
     }
-    if ($alias_version === '9' && !$all) {
-      $applications_response = $this->getMockResponseFromSpec('/applications', 'get', '200');
-      $cloud_application = $applications_response->{'_embedded'}->items[0];
-      $cloud_application_uuid = $cloud_application->uuid;
-      $this->createMockAcliConfigFile($cloud_application_uuid);
+    if ($aliasVersion === '9' && !$all) {
+      $applicationsResponse = $this->getMockResponseFromSpec('/applications', 'get', '200');
+      $cloudApplication = $applicationsResponse->{'_embedded'}->items[0];
+      $cloudApplicationUuid = $cloudApplication->uuid;
+      $this->createMockAcliConfigFile($cloudApplicationUuid);
       $this->mockApplicationRequest();
     }
 
@@ -81,9 +81,9 @@ class AliasesDownloadCommandTest extends CommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
 
-    $this->assertFileDoesNotExist($drush_archive_filepath);
-    $this->assertFileExists($destination_dir);
-    $this->assertStringContainsString('Cloud Platform Drush aliases installed into ' . $destination_dir, $output);
+    $this->assertFileDoesNotExist($drushArchiveFilepath);
+    $this->assertFileExists($destinationDir);
+    $this->assertStringContainsString('Cloud Platform Drush aliases installed into ' . $destinationDir, $output);
 
   }
 

--- a/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
@@ -19,9 +19,9 @@ class AliasesListCommandTest extends CommandTestBase {
    * Tests the 'remote:aliases:list' commands.
    */
   public function testRemoteAliasesListCommand(): void {
-    $applications_response = $this->mockApplicationsRequest();
+    $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applications_response);
+    $this->mockEnvironmentsRequest($applicationsResponse);
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?

--- a/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
@@ -46,9 +46,9 @@ class DrushCommandTest extends SshCommandTestBase {
   public function testRemoteDrushCommand(array $args): void {
     ClearCacheCommand::clearCaches();
     $this->mockForGetEnvironmentFromAliasArg();
-    [$process, $local_machine_helper] = $this->mockForExecuteCommand();
-    $local_machine_helper->checkRequiredBinariesExist(['ssh'])->shouldBeCalled();
-    $ssh_command = [
+    [$process, $localMachineHelper] = $this->mockForExecuteCommand();
+    $localMachineHelper->checkRequiredBinariesExist(['ssh'])->shouldBeCalled();
+    $sshCommand = [
       'ssh',
       'site.dev@sitedev.ssh.hosted.acquia-sites.com',
       '-t',
@@ -59,12 +59,12 @@ class DrushCommandTest extends SshCommandTestBase {
       'drush',
       'status --fields=db-status',
     ];
-    $local_machine_helper
-      ->execute($ssh_command, Argument::type('callable'), NULL, TRUE, NULL)
+    $localMachineHelper
+      ->execute($sshCommand, Argument::type('callable'), NULL, TRUE, NULL)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->command->sshHelper = new SshHelper($this->output, $local_machine_helper->reveal(), $this->logger);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
+    $this->command->sshHelper = new SshHelper($this->output, $localMachineHelper->reveal(), $this->logger);
     $this->executeCommand($args);
 
     // Assert.

--- a/tests/phpunit/src/Commands/Remote/SshCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTest.php
@@ -25,23 +25,23 @@ class SshCommandTest extends SshCommandTestBase {
   public function testRemoteAliasesDownloadCommand(): void {
     ClearCacheCommand::clearCaches();
     $this->mockForGetEnvironmentFromAliasArg();
-    [$process, $local_machine_helper] = $this->mockForExecuteCommand();
-    $local_machine_helper->checkRequiredBinariesExist(['ssh'])->shouldBeCalled();
-    $ssh_command = [
+    [$process, $localMachineHelper] = $this->mockForExecuteCommand();
+    $localMachineHelper->checkRequiredBinariesExist(['ssh'])->shouldBeCalled();
+    $sshCommand = [
       'ssh',
       'site.dev@sitedev.ssh.hosted.acquia-sites.com',
       '-t',
       '-o StrictHostKeyChecking=no',
       '-o AddressFamily inet',
       '-o LogLevel=ERROR',
-      'cd /var/www/html/devcloud2.dev; exec $SHELL -l',
+      'cd /var/www/html/devcloud2.dev; exec $sHELL -l',
     ];
-    $local_machine_helper
-      ->execute($ssh_command, Argument::type('callable'), NULL, TRUE, NULL)
+    $localMachineHelper
+      ->execute($sshCommand, Argument::type('callable'), NULL, TRUE, NULL)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
-    $this->command->sshHelper = new SshHelper($this->output, $local_machine_helper->reveal(), $this->logger);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
+    $this->command->sshHelper = new SshHelper($this->output, $localMachineHelper->reveal(), $this->logger);
 
     $args = [
       'alias' => 'devcloud2.dev',

--- a/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
@@ -9,8 +9,8 @@ use Symfony\Component\Process\Process;
 abstract class SshCommandTestBase extends CommandTestBase {
 
   protected function mockForGetEnvironmentFromAliasArg(): void {
-    $applications_response = $this->mockApplicationsRequest(1);
-    $this->mockEnvironmentsRequest($applications_response);
+    $applicationsResponse = $this->mockApplicationsRequest(1);
+    $this->mockEnvironmentsRequest($applicationsResponse);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockAccountRequest();
   }
@@ -22,9 +22,9 @@ abstract class SshCommandTestBase extends CommandTestBase {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(0);
-    $local_machine_helper = $this->prophet->prophesize(LocalMachineHelper::class);
-    $local_machine_helper->useTty()->willReturn(FALSE)->shouldBeCalled();
-    return [$process, $local_machine_helper];
+    $localMachineHelper = $this->prophet->prophesize(LocalMachineHelper::class);
+    $localMachineHelper->useTty()->willReturn(FALSE)->shouldBeCalled();
+    return [$process, $localMachineHelper];
   }
 
 }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyCreateCommandTest.php
@@ -66,19 +66,19 @@ class SshKeyCreateCommandTest extends CommandTestBase {
    *
    * @dataProvider providerTestCreate
    */
-  public function testCreate($ssh_add_success, $args, $inputs): void {
-    $ssh_key_filepath = Path::join($this->sshDir, '/' . $this->filename);
-    $this->fs->remove($ssh_key_filepath);
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $local_machine_helper->getLocalFilepath('~/.passphrase')->willReturn('~/.passphrase');
-    /** @var Filesystem|ObjectProphecy $file_system */
-    $file_system = $this->prophet->prophesize(Filesystem::class);
-    $this->mockAddSshKeyToAgent($local_machine_helper, $file_system);
-    $this->mockSshAgentList($local_machine_helper, $ssh_add_success);
-    $this->mockGenerateSshKey($local_machine_helper);
+  public function testCreate($sshAddSuccess, $args, $inputs): void {
+    $sshKeyFilepath = Path::join($this->sshDir, '/' . $this->filename);
+    $this->fs->remove($sshKeyFilepath);
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $localMachineHelper->getLocalFilepath('~/.passphrase')->willReturn('~/.passphrase');
+    /** @var Filesystem|ObjectProphecy $fileSystem */
+    $fileSystem = $this->prophet->prophesize(Filesystem::class);
+    $this->mockAddSshKeyToAgent($localMachineHelper, $fileSystem);
+    $this->mockSshAgentList($localMachineHelper, $sshAddSuccess);
+    $this->mockGenerateSshKey($localMachineHelper);
 
-    $local_machine_helper->getFilesystem()->willReturn($file_system->reveal())->shouldBeCalled();
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper->getFilesystem()->willReturn($fileSystem->reveal())->shouldBeCalled();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->executeCommand($args, $inputs);
   }
 

--- a/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
@@ -35,42 +35,42 @@ class SshKeyCreateUploadCommandTest extends CommandTestBase {
    * Tests the 'ssh-key:create-upload' command.
    */
   public function testCreateUpload(): void {
-    $mock_request_args = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+    $mockRequestArgs = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
 
     // Create.
-    $ssh_key_filename = 'id_rsa';
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    $local_machine_helper->getLocalFilepath('~/.passphrase')->willReturn('~/.passphrase');
-    /** @var Filesystem|ObjectProphecy $file_system */
-    $file_system = $this->prophet->prophesize(Filesystem::class);
-    $this->mockAddSshKeyToAgent($local_machine_helper, $file_system);
-    $this->mockSshAgentList($local_machine_helper);
-    $this->mockGenerateSshKey($local_machine_helper, $mock_request_args['public_key']);
+    $sshKeyFilename = 'id_rsa';
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $localMachineHelper->getLocalFilepath('~/.passphrase')->willReturn('~/.passphrase');
+    /** @var Filesystem|ObjectProphecy $fileSystem */
+    $fileSystem = $this->prophet->prophesize(Filesystem::class);
+    $this->mockAddSshKeyToAgent($localMachineHelper, $fileSystem);
+    $this->mockSshAgentList($localMachineHelper);
+    $this->mockGenerateSshKey($localMachineHelper, $mockRequestArgs['public_key']);
 
     // Upload.
     $this->mockUploadSshKey();
-    //$this->mockListSshKeyRequestWithUploadedKey($mock_request_args);
-    //$applications_response = $this->mockApplicationsRequest();
+    //$this->mockListSshKeyRequestWithUploadedKey($mockRequestArgs);
+    //$applicationsResponse = $this->mockApplicationsRequest();
     //$this->mockApplicationRequest();
-    $this->mockGetLocalSshKey($local_machine_helper, $file_system, $mock_request_args['public_key']);
-    //$this->mockEnvironmentsRequest($applications_response);
+    $this->mockGetLocalSshKey($localMachineHelper, $fileSystem, $mockRequestArgs['public_key']);
+    //$this->mockEnvironmentsRequest($applicationsResponse);
 
-    $local_machine_helper->getFilesystem()->willReturn($file_system->reveal())->shouldBeCalled();
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $localMachineHelper->getFilesystem()->willReturn($fileSystem->reveal())->shouldBeCalled();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->application->find(SshKeyCreateCommand::getDefaultName())->localMachineHelper = $this->command->localMachineHelper;
     $this->application->find(SshKeyUploadCommand::getDefaultName())->localMachineHelper = $this->command->localMachineHelper;
 
-    //$environments_response = $this->getMockEnvironmentsResponse();
-    //$ssh_helper = $this->mockPollCloudViaSsh($environments_response->_embedded->items[0]);
-    //$this->command->sshHelper = $ssh_helper->reveal();
+    //$environmentsResponse = $this->getMockEnvironmentsResponse();
+    //$sshHelper = $this->mockPollCloudViaSsh($environmentsResponse->_embedded->items[0]);
+    //$this->command->sshHelper = $sshHelper->reveal();
 
     $inputs = [
       // Enter a filename for your new local SSH key:
-      $ssh_key_filename,
+      $sshKeyFilename,
       // Enter a password for your SSH key:
       'acli123',
       // Label
-      $mock_request_args['label'],
+      $mockRequestArgs['label'],
     ];
     $this->executeCommand(['--no-wait' => ''], $inputs);
     $this->prophet->checkPredictions();

--- a/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
@@ -21,11 +21,11 @@ class SshKeyDeleteCommandTest extends CommandTestBase {
    */
   public function testDelete(): void {
 
-    $ssh_key_list_response = $this->mockListSshKeysRequest();
+    $sshKeyListResponse = $this->mockListSshKeysRequest();
     $response = $this->prophet->prophesize(ResponseInterface::class);
     $response->getStatusCode()->willReturn(202);
     $this->getMockResponseFromSpec('/account/ssh-keys/{sshKeyUuid}', 'delete', '202');
-    $this->clientProphecy->makeRequest('delete', '/account/ssh-keys/' . $ssh_key_list_response->_embedded->items[0]->uuid)->willReturn($response->reveal())->shouldBeCalled();
+    $this->clientProphecy->makeRequest('delete', '/account/ssh-keys/' . $sshKeyListResponse->_embedded->items[0]->uuid)->willReturn($response->reveal())->shouldBeCalled();
 
     $inputs = [
       // Choose key.
@@ -39,7 +39,7 @@ class SshKeyDeleteCommandTest extends CommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
     $this->assertStringContainsString('Choose an SSH key to delete from the Cloud Platform', $output);
-    $this->assertStringContainsString($ssh_key_list_response->_embedded->items[0]->label, $output);
+    $this->assertStringContainsString($sshKeyListResponse->_embedded->items[0]->label, $output);
   }
 
 }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -26,11 +26,11 @@ class SshKeyListCommandTest extends CommandTestBase {
    */
   public function testList(): void {
 
-    $mock_body = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
-    $this->clientProphecy->request('get', '/account/ssh-keys')->willReturn($mock_body->{'_embedded'}->items)->shouldBeCalled();
-    $mock_request_args = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
-    $temp_file_name = $this->createLocalSshKey($mock_request_args['public_key']);
-    $base_filename = basename($temp_file_name);
+    $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
+    $this->clientProphecy->request('get', '/account/ssh-keys')->willReturn($mockBody->{'_embedded'}->items)->shouldBeCalled();
+    $mockRequestArgs = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+    $tempFileName = $this->createLocalSshKey($mockRequestArgs['public_key']);
+    $baseFilename = basename($tempFileName);
     $this->executeCommand();
 
     // Assert.
@@ -39,10 +39,10 @@ class SshKeyListCommandTest extends CommandTestBase {
     $this->assertStringContainsString('Local filename', $output);
     $this->assertStringContainsString('Cloud Platform label', $output);
     $this->assertStringContainsString('Fingerprint', $output);
-    $this->assertStringContainsString($base_filename, $output);
-    $this->assertStringContainsString($mock_body->_embedded->items[0]->label, $output);
-    $this->assertStringContainsString($mock_body->_embedded->items[1]->label, $output);
-    $this->assertStringContainsString($mock_body->_embedded->items[2]->label, $output);
+    $this->assertStringContainsString($baseFilename, $output);
+    $this->assertStringContainsString($mockBody->_embedded->items[0]->label, $output);
+    $this->assertStringContainsString($mockBody->_embedded->items[1]->label, $output);
+    $this->assertStringContainsString($mockBody->_embedded->items[2]->label, $output);
   }
 
 }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -10,23 +10,14 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
-/**
- * @property SshKeyUploadCommand $command
- */
 class SshKeyUploadCommandTest extends CommandTestBase {
 
-  /**
-   * @var array
-   */
   private array $sshKeysRequestBody;
 
   protected function createCommand(): Command {
     return $this->injectCommand(SshKeyUploadCommand::class);
   }
 
-  /**
-   * @return array[]
-   */
   public function providerTestUpload(): array {
     $this->sshKeysRequestBody = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
     return [
@@ -75,26 +66,26 @@ class SshKeyUploadCommandTest extends CommandTestBase {
     $this->sshKeysRequestBody = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
     $this->mockUploadSshKey();
     $this->mockListSshKeyRequestWithUploadedKey($this->sshKeysRequestBody);
-    $applications_response = $this->mockApplicationsRequest();
-    $application_response = $this->mockApplicationRequest();
-    $this->mockPermissionsRequest($application_response, $perms);
+    $applicationsResponse = $this->mockApplicationsRequest();
+    $applicationResponse = $this->mockApplicationRequest();
+    $this->mockPermissionsRequest($applicationResponse, $perms);
 
-    $local_machine_helper = $this->mockLocalMachineHelper();
-    /** @var Filesystem|\Prophecy\Prophecy\ObjectProphecy $file_system */
-    $file_system = $this->prophet->prophesize(Filesystem::class);
-    $file_name = $this->mockGetLocalSshKey($local_machine_helper, $file_system, $this->sshKeysRequestBody['public_key']);
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    /** @var Filesystem|\Prophecy\Prophecy\ObjectProphecy $fileSystem */
+    $fileSystem = $this->prophet->prophesize(Filesystem::class);
+    $fileName = $this->mockGetLocalSshKey($localMachineHelper, $fileSystem, $this->sshKeysRequestBody['public_key']);
 
-    $local_machine_helper->getFilesystem()->willReturn($file_system);
-    $file_system->exists(Argument::type('string'))->willReturn(TRUE);
-    $local_machine_helper->getLocalFilepath(Argument::containingString('id_rsa'))->willReturn('id_rsa.pub');
-    $local_machine_helper->readFile(Argument::type('string'))->willReturn($this->sshKeysRequestBody['public_key']);
+    $localMachineHelper->getFilesystem()->willReturn($fileSystem);
+    $fileSystem->exists(Argument::type('string'))->willReturn(TRUE);
+    $localMachineHelper->getLocalFilepath(Argument::containingString('id_rsa'))->willReturn('id_rsa.pub');
+    $localMachineHelper->readFile(Argument::type('string'))->willReturn($this->sshKeysRequestBody['public_key']);
 
-    $this->command->localMachineHelper = $local_machine_helper->reveal();
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
 
     if ($perms) {
-      $environments_response = $this->mockEnvironmentsRequest($applications_response);
-      $ssh_helper = $this->mockPollCloudViaSsh($environments_response);
-      $this->command->sshHelper = $ssh_helper->reveal();
+      $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
+      $sshHelper = $this->mockPollCloudViaSsh($environmentsResponse);
+      $this->command->sshHelper = $sshHelper->reveal();
     }
 
     // Choose a local SSH key to upload to the Cloud Platform.
@@ -103,7 +94,7 @@ class SshKeyUploadCommandTest extends CommandTestBase {
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString("Uploaded $file_name to the Cloud Platform with label " . $this->sshKeysRequestBody['label'], $output);
+    $this->assertStringContainsString("Uploaded $fileName to the Cloud Platform with label " . $this->sshKeysRequestBody['label'], $output);
     $this->assertStringContainsString('Would you like to wait until your key is installed on all of your application\'s servers?', $output);
     $this->assertStringContainsString('Your SSH key is ready for use!', $output);
   }

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -88,8 +88,8 @@ class TelemetryCommandTest extends CommandTestBase {
     $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => NULL];
     $this->createMockConfigFiles();
     $this->fs->remove($this->legacyAcliConfigFilepath);
-    $legacy_acli_config = ['send_telemetry' => FALSE];
-    $contents = json_encode($legacy_acli_config);
+    $legacyAcliConfig = ['send_telemetry' => FALSE];
+    $contents = json_encode($legacyAcliConfig);
     $this->fs->dumpFile($this->legacyAcliConfigFilepath, $contents);
     $this->executeCommand();
     $this->prophet->checkPredictions();

--- a/tests/phpunit/src/Commands/UpdateCommandTest.php
+++ b/tests/phpunit/src/Commands/UpdateCommandTest.php
@@ -8,9 +8,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Symfony\Component\Console\Command\Command;
 
-/**
- * @property \Acquia\Cli\Command\HelloWorldCommand $command
- */
 class UpdateCommandTest extends CommandTestBase {
 
   protected function createCommand(): Command {
@@ -20,7 +17,7 @@ class UpdateCommandTest extends CommandTestBase {
   public function testSelfUpdate(): void {
     $this->setUpdateClient();
     $this->application->setVersion('2.8.4');
-    $this->executeCommand([], []);
+    $this->executeCommand();
     self::assertEquals(0, $this->getStatusCode());
     self::assertStringContainsString('Acquia CLI 2.8.5 is available', $this->getDisplay());
   }
@@ -28,18 +25,18 @@ class UpdateCommandTest extends CommandTestBase {
   public function testBadResponseFailsSilently(): void {
     $this->setUpdateClient(403);
     $this->application->setVersion('2.8.4');
-    $this->executeCommand([], []);
+    $this->executeCommand();
     self::assertEquals(0, $this->getStatusCode());
     self::assertStringNotContainsString('Acquia CLI 2.8.5 is available', $this->getDisplay());
   }
 
   public function testNetworkErrorFailsSilently(): void {
-    $guzzle_client = $this->prophet->prophesize(Client::class);
-    $guzzle_client->get('https://api.github.com/repos/acquia/cli/releases')
+    $guzzleClient = $this->prophet->prophesize(Client::class);
+    $guzzleClient->get('https://api.github.com/repos/acquia/cli/releases')
       ->willThrow(RequestException::class);
-    $this->command->setUpdateClient($guzzle_client->reveal());
+    $this->command->setUpdateClient($guzzleClient->reveal());
     $this->application->setVersion('2.8.4.9999s');
-    $this->executeCommand([], []);
+    $this->executeCommand();
     self::assertEquals(0, $this->getStatusCode());
     self::assertStringNotContainsString('Acquia CLI 2.8.5 is available', $this->getDisplay());
   }

--- a/tests/phpunit/src/Misc/ApiSpecTest.php
+++ b/tests/phpunit/src/Misc/ApiSpecTest.php
@@ -8,12 +8,12 @@ use Symfony\Component\Filesystem\Path;
 class ApiSpecTest extends TestCase {
 
   public function testApiSpec(): void {
-    $api_spec_file = Path::canonicalize(__DIR__ . '/../../../../assets/acquia-spec.yaml');
-    $this->assertFileExists($api_spec_file);
-    $api_spec = file_get_contents($api_spec_file);
-    $this->assertStringNotContainsString('x-internal', $api_spec);
-    $this->assertStringNotContainsString('cloud.acquia.dev', $api_spec);
-    $this->assertStringNotContainsString('network.acquia-sites.com', $api_spec);
+    $apiSpecFile = Path::canonicalize(__DIR__ . '/../../../../assets/acquia-spec.yaml');
+    $this->assertFileExists($apiSpecFile);
+    $apiSpec = file_get_contents($apiSpecFile);
+    $this->assertStringNotContainsString('x-internal', $apiSpec);
+    $this->assertStringNotContainsString('cloud.acquia.dev', $apiSpec);
+    $this->assertStringNotContainsString('network.acquia-sites.com', $apiSpec);
   }
 
 }

--- a/tests/phpunit/src/Misc/LandoInfoHelper.php
+++ b/tests/phpunit/src/Misc/LandoInfoHelper.php
@@ -4,8 +4,8 @@ namespace Acquia\Cli\Tests\Misc;
 
 class LandoInfoHelper {
 
-  public static function setLandoInfo($lando_info): void {
-    putenv('LANDO_INFO=' . json_encode($lando_info));
+  public static function setLandoInfo($landoInfo): void {
+    putenv('LANDO_INFO=' . json_encode($landoInfo));
     putenv('LANDO=ON');
   }
 

--- a/tests/phpunit/src/Misc/LandoInfoTest.php
+++ b/tests/phpunit/src/Misc/LandoInfoTest.php
@@ -13,13 +13,13 @@ class LandoInfoTest extends CommandTestBase {
   }
 
   public function testLandoInfoTest(): void {
-    $lando_info = LandoInfoHelper::getLandoInfo();
-    $lando_info->database->creds = [
+    $landoInfo = LandoInfoHelper::getLandoInfo();
+    $landoInfo->database->creds = [
       'database' => 'drupal9',
       'password' => 'drupal9',
       'user' => 'drupal9',
     ];
-    LandoInfoHelper::setLandoInfo($lando_info);
+    LandoInfoHelper::setLandoInfo($landoInfo);
     $this->assertEquals('drupal9', $this->command->getDefaultLocalDbPassword());
     $this->assertEquals('drupal9', $this->command->getDefaultLocalDbName());
     $this->assertEquals('drupal9', $this->command->getDefaultLocalDbUser());

--- a/tests/phpunit/src/Misc/LocalMachineHelperTest.php
+++ b/tests/phpunit/src/Misc/LocalMachineHelperTest.php
@@ -8,8 +8,8 @@ class LocalMachineHelperTest extends TestBase {
 
   public function testStartBrowser(): void {
     putenv('DISPLAY=1');
-    $local_machine_helper = $this->localMachineHelper;
-    $opened = $local_machine_helper->startBrowser('https://google.com', 'cat');
+    $localMachineHelper = $this->localMachineHelper;
+    $opened = $localMachineHelper->startBrowser('https://google.com', 'cat');
     $this->assertTrue($opened, 'Failed to open browser');
     putenv('DISPLAY');
   }
@@ -28,17 +28,17 @@ class LocalMachineHelperTest extends TestBase {
   /**
    * @dataProvider providerTestExecuteFromCmd()
    * @param $interactive
-   * @param $is_tty
-   * @param $print_output
+   * @param $isTty
+   * @param $printOutput
    */
-  public function testExecuteFromCmd($interactive, $is_tty, $print_output): void {
-    $local_machine_helper = $this->localMachineHelper;
-    $local_machine_helper->setIsTty($is_tty);
+  public function testExecuteFromCmd($interactive, $isTty, $printOutput): void {
+    $localMachineHelper = $this->localMachineHelper;
+    $localMachineHelper->setIsTty($isTty);
     $this->input->setInteractive($interactive);
-    $process = $local_machine_helper->executeFromCmd('echo "hello world"', NULL, NULL, $print_output);
+    $process = $localMachineHelper->executeFromCmd('echo "hello world"', NULL, NULL, $printOutput);
     $this->assertTrue($process->isSuccessful());
     $buffer = $this->output->fetch();
-    if ($print_output === FALSE) {
+    if ($printOutput === FALSE) {
       $this->assertEmpty($buffer);
     }
     else {
@@ -48,15 +48,15 @@ class LocalMachineHelperTest extends TestBase {
 
   public function testExecuteWithCwd(): void {
     $this->setupFsFixture();
-    $local_machine_helper = $this->localMachineHelper;
-    $process = $local_machine_helper->execute(['ls', '-lash'], NULL, $this->fixtureDir, FALSE);
+    $localMachineHelper = $this->localMachineHelper;
+    $process = $localMachineHelper->execute(['ls', '-lash'], NULL, $this->fixtureDir, FALSE);
     $this->assertTrue($process->isSuccessful());
     $this->assertStringContainsString('xdebug.ini', $process->getOutput());
   }
 
   public function testCommandExists(): void {
-    $local_machine_helper = $this->localMachineHelper;
-    $exists = $local_machine_helper->commandExists('cat');
+    $localMachineHelper = $this->localMachineHelper;
+    $exists = $localMachineHelper->commandExists('cat');
     $this->assertIsBool($exists);
   }
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -648,7 +648,12 @@ abstract class TestBase extends TestCase {
     $this->clientProphecy->request(
       'post',
       '/account/ssh-keys',
-      ['json' => ['label' => $label, 'public_key' => $request['public_key']]]
+      [
+        'json' => [
+          'label' => $label,
+          'public_key' => $request['public_key'],
+        ],
+      ]
     )->willReturn($response)
       ->shouldBecalled();
   }
@@ -679,7 +684,8 @@ abstract class TestBase extends TestCase {
   ): void {
     $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get',
       '200');
-    $mockBody->_embedded->items[3] = (object) $mockRequestArgs;
+    $newItem = array_merge((array) $mockBody->_embedded->items[2], $mockRequestArgs);
+    $mockBody->_embedded->items[3] = (object) $newItem;
     $this->clientProphecy->request('get', '/account/ssh-keys')
       ->willReturn($mockBody->{'_embedded'}->items)
       ->shouldBeCalled();

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -124,13 +124,13 @@ abstract class TestBase extends TestCase {
    *
    * @see CXAPI-9647
    */
-  public function filterApplicationsResponse(object $applications_response, int $count, bool $unique): object {
+  public function filterApplicationsResponse(object $applicationsResponse, int $count, bool $unique): object {
     if ($unique) {
-      $applications_response->{'_embedded'}->items[1]->hosting->id = 'devcloud:devcloud3';
+      $applicationsResponse->{'_embedded'}->items[1]->hosting->id = 'devcloud:devcloud3';
     }
-    $applications_response->total = $count;
-    $applications_response->{'_embedded'}->items = array_slice($applications_response->{'_embedded'}->items, 0, $count);
-    return $applications_response;
+    $applicationsResponse->total = $count;
+    $applicationsResponse->{'_embedded'}->items = array_slice($applicationsResponse->{'_embedded'}->items, 0, $count);
+    return $applicationsResponse;
   }
 
   /**
@@ -230,14 +230,14 @@ abstract class TestBase extends TestCase {
     return $path;
   }
 
-  public static function setEnvVars(array $env_vars): void {
-    foreach ($env_vars as $key => $value) {
+  public static function setEnvVars(array $envVars): void {
+    foreach ($envVars as $key => $value) {
       putenv($key . '=' . $value);
     }
   }
 
-  public static function unsetEnvVars($env_vars): void {
-    foreach ($env_vars as $key => $value) {
+  public static function unsetEnvVars($envVars): void {
+    foreach ($envVars as $key => $value) {
       putenv($key);
     }
   }
@@ -255,8 +255,8 @@ abstract class TestBase extends TestCase {
    * @param $method
    */
   protected function getResourceFromSpec($path, $method): mixed {
-    $acquia_cloud_spec = $this->getCloudApiSpec();
-    return $acquia_cloud_spec['paths'][$path][$method];
+    $acquiaCloudSpec = $this->getCloudApiSpec();
+    return $acquiaCloudSpec['paths'][$path][$method];
   }
 
   /**
@@ -267,32 +267,32 @@ abstract class TestBase extends TestCase {
    *
    * @param $path
    * @param $method
-   * @param $http_code
+   * @param $httpCode
    * @see CXAPI-7208
    */
-  public function getMockResponseFromSpec($path, $method, $http_code): object {
+  public function getMockResponseFromSpec($path, $method, $httpCode): object {
     $endpoint = $this->getResourceFromSpec($path, $method);
-    $response = $endpoint['responses'][$http_code];
+    $response = $endpoint['responses'][$httpCode];
     $content = $response['content']['application/json'];
 
     if (array_key_exists('example', $content)) {
-      $response_body = json_encode($content['example'], JSON_THROW_ON_ERROR);
+      $responseBody = json_encode($content['example'], JSON_THROW_ON_ERROR);
     }
     elseif (array_key_exists('examples', $content)) {
-      $response_body = json_encode($content['examples'], JSON_THROW_ON_ERROR);
+      $responseBody = json_encode($content['examples'], JSON_THROW_ON_ERROR);
     }
     elseif (array_key_exists('schema', $content)
       && array_key_exists('$ref', $content['schema'])) {
       $ref = $content['schema']['$ref'];
-      $param_key = str_replace('#/components/schemas/', '', $ref);
+      $paramKey = str_replace('#/components/schemas/', '', $ref);
       $spec = $this->getCloudApiSpec();
-      return (object) $spec['components']['schemas'][$param_key]['properties'];
+      return (object) $spec['components']['schemas'][$paramKey]['properties'];
     }
     else {
       return (object) [];
     }
 
-    return json_decode($response_body, FALSE, 512, JSON_THROW_ON_ERROR);
+    return json_decode($responseBody, FALSE, 512, JSON_THROW_ON_ERROR);
   }
 
   /**
@@ -331,70 +331,70 @@ abstract class TestBase extends TestCase {
   protected function getCloudApiSpec(): mixed {
     // We cache the yaml file because it's 20k+ lines and takes FOREVER
     // to parse when xDebug is enabled.
-    $acquia_cloud_spec_file = $this->apiSpecFixtureFilePath;
-    $acquia_cloud_spec_file_checksum = md5_file($acquia_cloud_spec_file);
+    $acquiaCloudSpecFile = $this->apiSpecFixtureFilePath;
+    $acquiaCloudSpecFileChecksum = md5_file($acquiaCloudSpecFile);
 
-    $cache_key = basename($acquia_cloud_spec_file);
-    $cache = new PhpArrayAdapter(__DIR__ . '/../../../var/cache/' . $cache_key . '.cache', new FilesystemAdapter());
-    $is_command_cache_valid = $this->isApiSpecCacheValid($cache, $cache_key, $acquia_cloud_spec_file_checksum);
-    $api_spec_cache_item = $cache->getItem($cache_key);
-    if ($is_command_cache_valid && $api_spec_cache_item->isHit()) {
-      return $api_spec_cache_item->get();
+    $cacheKey = basename($acquiaCloudSpecFile);
+    $cache = new PhpArrayAdapter(__DIR__ . '/../../../var/cache/' . $cacheKey . '.cache', new FilesystemAdapter());
+    $isCommandCacheValid = $this->isApiSpecCacheValid($cache, $cacheKey, $acquiaCloudSpecFileChecksum);
+    $apiSpecCacheItem = $cache->getItem($cacheKey);
+    if ($isCommandCacheValid && $apiSpecCacheItem->isHit()) {
+      return $apiSpecCacheItem->get();
     }
-    $api_spec = Yaml::parseFile($acquia_cloud_spec_file);
-    $this->saveApiSpecCacheItems($cache, $acquia_cloud_spec_file_checksum, $api_spec_cache_item, $api_spec);
+    $apiSpec = Yaml::parseFile($acquiaCloudSpecFile);
+    $this->saveApiSpecCacheItems($cache, $acquiaCloudSpecFileChecksum, $apiSpecCacheItem, $apiSpec);
 
-    return $api_spec;
+    return $apiSpec;
   }
 
-  private function isApiSpecCacheValid(PhpArrayAdapter $cache, $cache_key, string $acquia_cloud_spec_file_checksum): bool {
-    $api_spec_checksum_item = $cache->getItem($cache_key . '.checksum');
+  private function isApiSpecCacheValid(PhpArrayAdapter $cache, $cacheKey, string $acquiaCloudSpecFileChecksum): bool {
+    $apiSpecChecksumItem = $cache->getItem($cacheKey . '.checksum');
     // If there's an invalid entry OR there's no entry, return false.
-    return !(!$api_spec_checksum_item->isHit() || ($api_spec_checksum_item->isHit()
-        && $api_spec_checksum_item->get() !== $acquia_cloud_spec_file_checksum));
+    return !(!$apiSpecChecksumItem->isHit() || ($apiSpecChecksumItem->isHit()
+        && $apiSpecChecksumItem->get() !== $acquiaCloudSpecFileChecksum));
   }
 
   /**
-   * @param $api_spec
+   * @param $apiSpec
    */
   private function saveApiSpecCacheItems(
     PhpArrayAdapter $cache,
-    string $acquia_cloud_spec_file_checksum,
-    CacheItem $api_spec_cache_item,
-    $api_spec
+    string $acquiaCloudSpecFileChecksum,
+    CacheItem $apiSpecCacheItem,
+    $apiSpec
   ): void {
-    $api_spec_checksum_item = $cache->getItem('api_spec.checksum');
-    $api_spec_checksum_item->set($acquia_cloud_spec_file_checksum);
-    $cache->save($api_spec_checksum_item);
-    $api_spec_cache_item->set($api_spec);
-    $cache->save($api_spec_cache_item);
+    $apiSpecChecksumItem = $cache->getItem('api_spec.checksum');
+    $apiSpecChecksumItem->set($acquiaCloudSpecFileChecksum);
+    $cache->save($apiSpecChecksumItem);
+    $apiSpecCacheItem->set($apiSpec);
+    $cache->save($apiSpecCacheItem);
   }
 
   /**
    * @param $contents
    */
   protected function createLocalSshKey($contents): string {
-    $private_key_filepath = $this->fs->tempnam($this->sshDir, 'acli');
-    $this->fs->touch($private_key_filepath);
-    $public_key_filepath = $private_key_filepath . '.pub';
-    $this->fs->dumpFile($public_key_filepath, $contents);
+    $privateKeyFilepath = $this->fs->tempnam($this->sshDir, 'acli');
+    $this->fs->touch($privateKeyFilepath);
+    $publicKeyFilepath = $privateKeyFilepath . '.pub';
+    $this->fs->dumpFile($publicKeyFilepath, $contents);
 
-    return $public_key_filepath;
+    return $publicKeyFilepath;
   }
 
   protected function createMockConfigFiles(): void {
     $this->createMockCloudConfigFile();
 
-    $default_values = [];
-    $acli_config = array_merge($default_values, $this->acliConfig);
-    $contents = json_encode($acli_config, JSON_THROW_ON_ERROR);
+    $defaultValues = [];
+    $acliConfig = array_merge($defaultValues, $this->acliConfig);
+    $contents = json_encode($acliConfig, JSON_THROW_ON_ERROR);
     $filepath = $this->acliConfigFilepath;
     $this->fs->dumpFile($filepath, $contents);
   }
 
-  protected function createMockCloudConfigFile($default_values = []): void {
-    if (!$default_values) {
-      $default_values = [
+  protected function createMockCloudConfigFile($defaultValues = []): void {
+    if (!$defaultValues) {
+      $defaultValues = [
         'acli_key' => $this->key,
         'keys' => [
           (string) ($this->key) => [
@@ -406,14 +406,14 @@ abstract class TestBase extends TestCase {
         DataStoreContract::SEND_TELEMETRY => FALSE,
       ];
     }
-    $cloud_config = array_merge($default_values, $this->cloudConfig);
-    $contents = json_encode($cloud_config, JSON_THROW_ON_ERROR);
+    $cloudConfig = array_merge($defaultValues, $this->cloudConfig);
+    $contents = json_encode($cloudConfig, JSON_THROW_ON_ERROR);
     $filepath = $this->cloudConfigFilepath;
     $this->fs->dumpFile($filepath, $contents);
   }
 
-  protected function createMockAcliConfigFile($cloud_app_uuid): void {
-    $this->datastoreAcli->set('cloud_app_uuid', $cloud_app_uuid);
+  protected function createMockAcliConfigFile($cloudAppUuid): void {
+    $this->datastoreAcli->set('cloud_app_uuid', $cloudAppUuid);
   }
 
   /**
@@ -422,13 +422,13 @@ abstract class TestBase extends TestCase {
    */
   public function mockApplicationsRequest(int $count = 2, bool $unique = TRUE): object {
     // Request for applications.
-    $applications_response = $this->getMockResponseFromSpec('/applications',
+    $applicationsResponse = $this->getMockResponseFromSpec('/applications',
       'get', '200');
-    $applications_response = $this->filterApplicationsResponse($applications_response, $count, $unique);
+    $applicationsResponse = $this->filterApplicationsResponse($applicationsResponse, $count, $unique);
     $this->clientProphecy->request('get', '/applications')
-      ->willReturn($applications_response->{'_embedded'}->items)
+      ->willReturn($applicationsResponse->{'_embedded'}->items)
       ->shouldBeCalled();
-    return $applications_response;
+    return $applicationsResponse;
   }
 
   public function mockUnauthorizedRequest(): void {
@@ -459,46 +459,46 @@ abstract class TestBase extends TestCase {
   }
 
   protected function mockApplicationRequest(): object {
-    $applications_response = $this->getMockResponseFromSpec('/applications',
+    $applicationsResponse = $this->getMockResponseFromSpec('/applications',
       'get', '200');
-    $application_response = $applications_response->{'_embedded'}->items[0];
+    $applicationResponse = $applicationsResponse->{'_embedded'}->items[0];
     $this->clientProphecy->request('get',
-      '/applications/' . $applications_response->{'_embedded'}->items[0]->uuid)
-      ->willReturn($application_response)
+      '/applications/' . $applicationsResponse->{'_embedded'}->items[0]->uuid)
+      ->willReturn($applicationResponse)
       ->shouldBeCalled();
 
-    return $application_response;
+    return $applicationResponse;
   }
 
-  protected function mockPermissionsRequest($application_response, $perms = TRUE): object {
-    $permissions_response = $this->getMockResponseFromSpec("/applications/{applicationUuid}/permissions",
+  protected function mockPermissionsRequest($applicationResponse, $perms = TRUE): object {
+    $permissionsResponse = $this->getMockResponseFromSpec("/applications/{applicationUuid}/permissions",
       'get', '200');
     if (!$perms) {
-      $delete_perms = [
+      $deletePerms = [
         'add ssh key to git',
         'add ssh key to non-prod',
         'add ssh key to prod',
       ];
-      foreach ($permissions_response->_embedded->items as $index => $item) {
-        if (in_array($item->name, $delete_perms, TRUE)) {
-          unset($permissions_response->_embedded->items[$index]);
+      foreach ($permissionsResponse->_embedded->items as $index => $item) {
+        if (in_array($item->name, $deletePerms, TRUE)) {
+          unset($permissionsResponse->_embedded->items[$index]);
         }
       }
     }
     $this->clientProphecy->request('get',
-      '/applications/' . $application_response->uuid . '/permissions')
-      ->willReturn($permissions_response->_embedded->items)
+      '/applications/' . $applicationResponse->uuid . '/permissions')
+      ->willReturn($permissionsResponse->_embedded->items)
       ->shouldBeCalled();
 
-    return $permissions_response;
+    return $permissionsResponse;
   }
 
   public function mockEnvironmentsRequest(
-    object $applications_response
+    object $applicationsResponse
   ): object {
     $response = $this->getMockEnvironmentsResponse();
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/environments")
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
       ->willReturn($response->_embedded->items)
       ->shouldBeCalled();
 
@@ -506,11 +506,11 @@ abstract class TestBase extends TestCase {
   }
 
   public function mockApplicationCodeRequest(
-    object $applications_response
+    object $applicationsResponse
   ): object {
     $response = $this->getApplicationCodeResponse();
     $this->clientProphecy->request('get',
-      "/applications/{$applications_response->{'_embedded'}->items[0]->uuid}/code")
+      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/code")
       ->willReturn($response->_embedded->items)
       ->shouldBeCalled();
 
@@ -537,9 +537,9 @@ abstract class TestBase extends TestCase {
     $this->clientProphecy->request('get', '/account')->willReturn($account);
   }
 
-  protected function getMockEnvironmentResponse(string $method = 'get', string $http_code = '200'): object {
+  protected function getMockEnvironmentResponse(string $method = 'get', string $httpCode = '200'): object {
     return $this->getMockResponseFromSpec('/environments/{environmentId}',
-      $method, $http_code);
+      $method, $httpCode);
   }
 
   protected function getMockEnvironmentsResponse(): object {
@@ -558,18 +558,18 @@ abstract class TestBase extends TestCase {
     return $response;
   }
 
-  protected function mockGetIdeRequest(string $ide_uuid): object {
-    $ide_response = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
-    $this->clientProphecy->request('get', '/ides/' . $ide_uuid)->willReturn($ide_response)->shouldBeCalled();
-    return $ide_response;
+  protected function mockGetIdeRequest(string $ideUuid): object {
+    $ideResponse = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
+    $this->clientProphecy->request('get', '/ides/' . $ideUuid)->willReturn($ideResponse)->shouldBeCalled();
+    return $ideResponse;
   }
 
-  protected function mockIdeDeleteRequest(string $ide_uuid): object {
-    $ide_delete_response = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'delete', '202');
-    $this->clientProphecy->request('delete', '/ides/' . $ide_uuid)
-      ->willReturn($ide_delete_response->{'De-provisioning IDE'}->value)
+  protected function mockIdeDeleteRequest(string $ideUuid): object {
+    $ideDeleteResponse = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'delete', '202');
+    $this->clientProphecy->request('delete', '/ides/' . $ideUuid)
+      ->willReturn($ideDeleteResponse->{'De-provisioning IDE'}->value)
       ->shouldBeCalled();
-    return $ide_delete_response;
+    return $ideDeleteResponse;
   }
 
   protected function mockLogStreamRequest(): object {
@@ -593,49 +593,49 @@ abstract class TestBase extends TestCase {
   }
 
   protected function mockListSshKeysRequestWithIdeKey(IdeResponse $ide): object {
-    $mock_body = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
-    $mock_body->{'_embedded'}->items[0]->label = SshKeyCommandBase::getIdeSshKeyLabel($ide);
+    $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
+    $mockBody->{'_embedded'}->items[0]->label = SshKeyCommandBase::getIdeSshKeyLabel($ide);
     $this->clientProphecy->request('get', '/account/ssh-keys')
-      ->willReturn($mock_body->{'_embedded'}->items)
+      ->willReturn($mockBody->{'_embedded'}->items)
       ->shouldBeCalled();
-    return $mock_body;
+    return $mockBody;
   }
 
-  protected function mockGenerateSshKey(ObjectProphecy|LocalMachineHelper $local_machine_helper, ?string $key_contents = NULL): void {
-    $key_contents = $key_contents ?: 'thekey!';
-    $public_key_path = 'id_rsa.pub';
+  protected function mockGenerateSshKey(ObjectProphecy|LocalMachineHelper $localMachineHelper, ?string $keyContents = NULL): void {
+    $keyContents = $keyContents ?: 'thekey!';
+    $publicKeyPath = 'id_rsa.pub';
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
-    $process->getOutput()->willReturn($key_contents);
-    $local_machine_helper->checkRequiredBinariesExist(["ssh-keygen"])->shouldBeCalled();
-    $local_machine_helper->execute(Argument::withEntry(0, 'ssh-keygen'), NULL, NULL, FALSE)
+    $process->getOutput()->willReturn($keyContents);
+    $localMachineHelper->checkRequiredBinariesExist(["ssh-keygen"])->shouldBeCalled();
+    $localMachineHelper->execute(Argument::withEntry(0, 'ssh-keygen'), NULL, NULL, FALSE)
       ->willReturn($process->reveal())
       ->shouldBeCalled();
-    $local_machine_helper->readFile($public_key_path)->willReturn($key_contents);
-    $local_machine_helper->readFile(Argument::containingString('id_rsa'))->willReturn($key_contents);
+    $localMachineHelper->readFile($publicKeyPath)->willReturn($keyContents);
+    $localMachineHelper->readFile(Argument::containingString('id_rsa'))->willReturn($keyContents);
   }
 
   /**
-   * @param $local_machine_helper
+   * @param $localMachineHelper
    */
-  protected function mockAddSshKeyToAgent($local_machine_helper, $file_system): void {
+  protected function mockAddSshKeyToAgent($localMachineHelper, $fileSystem): void {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
-    $local_machine_helper->executeFromCmd(Argument::containingString('SSH_PASS'), NULL, NULL, FALSE)->willReturn($process->reveal());
-    $file_system->tempnam(Argument::type('string'), 'acli')->willReturn('something');
-    $file_system->chmod('something', 493)->shouldBeCalled();
-    $file_system->remove('something')->shouldBeCalled();
-    $local_machine_helper->writeFile('something', Argument::type('string'))->shouldBeCalled();
+    $localMachineHelper->executeFromCmd(Argument::containingString('SSH_PASS'), NULL, NULL, FALSE)->willReturn($process->reveal());
+    $fileSystem->tempnam(Argument::type('string'), 'acli')->willReturn('something');
+    $fileSystem->chmod('something', 493)->shouldBeCalled();
+    $fileSystem->remove('something')->shouldBeCalled();
+    $localMachineHelper->writeFile('something', Argument::type('string'))->shouldBeCalled();
   }
 
-  protected function mockSshAgentList(ObjectProphecy|LocalMachineHelper $local_machine_helper, bool $success = FALSE): void {
+  protected function mockSshAgentList(ObjectProphecy|LocalMachineHelper $localMachineHelper, bool $success = FALSE): void {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn($success);
     $process->getExitCode()->willReturn($success ? 0 : 1);
     $process->getOutput()->willReturn('thekey!');
-    $local_machine_helper->getLocalFilepath($this->passphraseFilepath)
+    $localMachineHelper->getLocalFilepath($this->passphraseFilepath)
       ->willReturn('/tmp/.passphrase');
-    $local_machine_helper->execute([
+    $localMachineHelper->execute([
       'ssh-add',
       '-L',
     ], NULL, NULL, FALSE)->shouldBeCalled()->willReturn($process->reveal());
@@ -654,42 +654,42 @@ abstract class TestBase extends TestCase {
   }
 
   protected function mockGetIdeSshKeyRequest(IdeResponse $ide): void {
-    $mock_body = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
-    $mock_body->{'_embedded'}->items[0]->label = SshKeyCommandBase::getIdeSshKeyLabel($ide);
-    $this->clientProphecy->request('get', '/account/ssh-keys/' . $mock_body->{'_embedded'}->items[0]->uuid)
-      ->willReturn($mock_body->{'_embedded'}->items[0])
+    $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
+    $mockBody->{'_embedded'}->items[0]->label = SshKeyCommandBase::getIdeSshKeyLabel($ide);
+    $this->clientProphecy->request('get', '/account/ssh-keys/' . $mockBody->{'_embedded'}->items[0]->uuid)
+      ->willReturn($mockBody->{'_embedded'}->items[0])
       ->shouldBeCalled();
   }
 
-  protected function mockDeleteSshKeyRequest(string $key_uuid): void {
+  protected function mockDeleteSshKeyRequest(string $keyUuid): void {
     // Request ssh key deletion.
-    $ssh_key_delete_response = $this->prophet->prophesize(ResponseInterface::class);
-    $ssh_key_delete_response->getStatusCode()->willReturn(202);
+    $sshKeyDeleteResponse = $this->prophet->prophesize(ResponseInterface::class);
+    $sshKeyDeleteResponse->getStatusCode()->willReturn(202);
     $this->clientProphecy->makeRequest('delete',
-      '/account/ssh-keys/' . $key_uuid)
-      ->willReturn($ssh_key_delete_response->reveal())
+      '/account/ssh-keys/' . $keyUuid)
+      ->willReturn($sshKeyDeleteResponse->reveal())
       ->shouldBeCalled();
   }
 
   /**
-   * @param $mock_request_args
+   * @param $mockRequestArgs
    */
   protected function mockListSshKeyRequestWithUploadedKey(
-    $mock_request_args
+    $mockRequestArgs
   ): void {
-    $mock_body = $this->getMockResponseFromSpec('/account/ssh-keys', 'get',
+    $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get',
       '200');
-    $mock_body->_embedded->items[3] = (object) $mock_request_args;
+    $mockBody->_embedded->items[3] = (object) $mockRequestArgs;
     $this->clientProphecy->request('get', '/account/ssh-keys')
-      ->willReturn($mock_body->{'_embedded'}->items)
+      ->willReturn($mockBody->{'_embedded'}->items)
       ->shouldBeCalled();
   }
 
-  protected function mockStartPhp(ObjectProphecy|LocalMachineHelper $local_machine_helper): ObjectProphecy {
+  protected function mockStartPhp(ObjectProphecy|LocalMachineHelper $localMachineHelper): ObjectProphecy {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(0);
-    $local_machine_helper->execute([
+    $localMachineHelper->execute([
       'supervisorctl',
       'start',
       'php-fpm',
@@ -697,11 +697,11 @@ abstract class TestBase extends TestCase {
     return $process;
   }
 
-  protected function mockStopPhp(ObjectProphecy|LocalMachineHelper $local_machine_helper): ObjectProphecy {
+  protected function mockStopPhp(ObjectProphecy|LocalMachineHelper $localMachineHelper): ObjectProphecy {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(0);
-    $local_machine_helper->execute([
+    $localMachineHelper->execute([
       'supervisorctl',
       'stop',
       'php-fpm',
@@ -709,11 +709,11 @@ abstract class TestBase extends TestCase {
     return $process;
   }
 
-  protected function mockRestartPhp(ObjectProphecy|LocalMachineHelper $local_machine_helper): ObjectProphecy {
+  protected function mockRestartPhp(ObjectProphecy|LocalMachineHelper $localMachineHelper): ObjectProphecy {
     $process = $this->prophet->prophesize(Process::class);
     $process->isSuccessful()->willReturn(TRUE);
     $process->getExitCode()->willReturn(0);
-    $local_machine_helper->execute([
+    $localMachineHelper->execute([
       'supervisorctl',
       'restart',
       'php-fpm',
@@ -724,8 +724,8 @@ abstract class TestBase extends TestCase {
   /**
    * @return \Prophecy\Prophecy\ObjectProphecy|\Symfony\Component\Filesystem\Filesystem
    */
-  protected function mockGetFilesystem(ObjectProphecy|LocalMachineHelper $local_machine_helper): ObjectProphecy|Filesystem {
-    $local_machine_helper->getFilesystem()->willReturn($this->fs)->shouldBeCalled();
+  protected function mockGetFilesystem(ObjectProphecy|LocalMachineHelper $localMachineHelper): ObjectProphecy|Filesystem {
+    $localMachineHelper->getFilesystem()->willReturn($this->fs)->shouldBeCalled();
 
     return $this->fs;
   }
@@ -751,26 +751,26 @@ abstract class TestBase extends TestCase {
     $stream->getContents()->willReturn(json_encode($releases));
     $response = $this->prophet->prophesize(Response::class);
     $response->getBody()->willReturn($stream->reveal());
-    $guzzle_client = $this->prophet->prophesize(\GuzzleHttp\Client::class);
-    $guzzle_client->request('GET', Argument::containingString('https://api.github.com/repos'), Argument::type('array'))
+    $guzzleClient = $this->prophet->prophesize(\GuzzleHttp\Client::class);
+    $guzzleClient->request('GET', Argument::containingString('https://api.github.com/repos'), Argument::type('array'))
       ->willReturn($response->reveal());
 
     $stream = $this->prophet->prophesize(StreamInterface::class);
-    $phar_contents = file_get_contents(Path::join($this->fixtureDir, 'test.phar'));
-    $stream->getContents()->willReturn($phar_contents);
+    $pharContents = file_get_contents(Path::join($this->fixtureDir, 'test.phar'));
+    $stream->getContents()->willReturn($pharContents);
     $response = $this->prophet->prophesize(Response::class);
     $response->getBody()->willReturn($stream->reveal());
-    $guzzle_client->request('GET', 'https://github.com/acquia/cli/releases/download/v1.0.0-beta3/acli.phar',
+    $guzzleClient->request('GET', 'https://github.com/acquia/cli/releases/download/v1.0.0-beta3/acli.phar',
       Argument::type('array'))->willReturn($response->reveal());
 
-    return $guzzle_client;
+    return $guzzleClient;
   }
 
-  protected function setClientProphecies($client_service_class = ClientService::class): void {
+  protected function setClientProphecies($clientServiceClass = ClientService::class): void {
     $this->clientProphecy = $this->prophet->prophesize(Client::class);
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN']);
     $this->clientProphecy->addOption('debug', Argument::type(OutputInterface::class));
-    $this->clientServiceProphecy = $this->prophet->prophesize($client_service_class);
+    $this->clientServiceProphecy = $this->prophet->prophesize($clientServiceClass);
     $this->clientServiceProphecy->getClient()
       ->willReturn($this->clientProphecy->reveal());
     $this->clientServiceProphecy->isMachineAuthenticated()


### PR DESCRIPTION
I'd like to be able to add this to our phpcs standard:

```
  <rule ref="Squiz.NamingConventions.ValidVariableName"/>
  <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
    <severity>0</severity>
  </rule>
```

Unfortunately because upstream libraries use snake case, any references to those objects and methods get flagged as false positives, and I don't know how to exclude them en masse.