### PR TITLE
Refactor mock methods

### DIFF
--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -28,7 +28,7 @@ class ExceptionApplicationTest extends ApplicationTestBase {
       Path::join($this->projectDir, 'composer.json'),
       json_encode($json, JSON_THROW_ON_ERROR)
     );
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->setInput([
           'command' => 'hello-world',
       ]);
@@ -51,7 +51,7 @@ class ExceptionApplicationTest extends ApplicationTestBase {
       Path::join($this->projectDir, 'composer.json'),
       json_encode($json, JSON_THROW_ON_ERROR)
     );
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->setInput([
           'command' => 'hello-world',
       ]);
@@ -114,7 +114,7 @@ class ExceptionApplicationTest extends ApplicationTestBase {
    * @group serial
    */
   public function testInvalidEnvironmentUuid(): void {
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->mockApplicationsRequest();
     $this->setInput([
       'command' => 'log:tail',
@@ -139,7 +139,7 @@ class ExceptionApplicationTest extends ApplicationTestBase {
    * @group serial
    */
   public function testInvalidApplicationUuid(): void {
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->mockApplicationsRequest();
     $this->setInput([
       'applicationUuid' => 'aoeuthao',

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -28,7 +28,7 @@ class ExceptionApplicationTest extends ApplicationTestBase {
       Path::join($this->projectDir, 'composer.json'),
       json_encode($json, JSON_THROW_ON_ERROR)
     );
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->setInput([
           'command' => 'hello-world',
       ]);
@@ -51,7 +51,7 @@ class ExceptionApplicationTest extends ApplicationTestBase {
       Path::join($this->projectDir, 'composer.json'),
       json_encode($json, JSON_THROW_ON_ERROR)
     );
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->setInput([
           'command' => 'hello-world',
       ]);
@@ -114,7 +114,7 @@ class ExceptionApplicationTest extends ApplicationTestBase {
    * @group serial
    */
   public function testInvalidEnvironmentUuid(): void {
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->mockApplicationsRequest();
     $this->setInput([
       'command' => 'log:tail',
@@ -139,7 +139,7 @@ class ExceptionApplicationTest extends ApplicationTestBase {
    * @group serial
    */
   public function testInvalidApplicationUuid(): void {
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->mockApplicationsRequest();
     $this->setInput([
       'applicationUuid' => 'aoeuthao',

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -40,8 +40,10 @@ abstract class CommandTestBase extends TestBase {
   /**
    * The command tester.
    */
-  private \Symfony\Component\Console\Tester\CommandTester $commandTester;
+  private CommandTester $commandTester;
 
+  // Select the application.
+  protected static int $INPUT_APP = 0;
   protected Command $command;
 
   protected string $apiCommandPrefix = 'api';

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -42,8 +42,9 @@ abstract class CommandTestBase extends TestBase {
    */
   private CommandTester $commandTester;
 
-  // Select the application.
-  protected static int $INPUT_APP = 0;
+  // Select the application / SSH key / etc.
+  protected static int $INPUT_DEFAULT_CHOICE = 0;
+
   protected Command $command;
 
   protected string $apiCommandPrefix = 'api';

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -167,7 +167,7 @@ class ApiCommandTest extends CommandTestBase {
         $response->flags->support = TRUE;
       };
     }
-    $this->mockRequest('/account', [], 'get', NULL, NULL, $tamper);
+    $this->mockRequest('getAccount', NULL, NULL, NULL, $tamper);
 
     $this->executeCommand(['applicationUuid' => $alias], [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -187,7 +187,7 @@ class ApiCommandTest extends CommandTestBase {
   public function testConvertInvalidApplicationAliasToUuidArgument(): void {
     $this->mockApplicationsRequest(0);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:invalidalias')->shouldBeCalled();
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->command = $this->getApiCommandByName('api:applications:find');
     $alias = 'invalidalias';
     $this->expectException(AcquiaCliException::class);
@@ -203,7 +203,7 @@ class ApiCommandTest extends CommandTestBase {
     ClearCacheCommand::clearCaches();
     $this->mockApplicationsRequest(2, FALSE);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->command = $this->getApiCommandByName('api:applications:find');
     $alias = 'devcloud2';
     $this->expectException(AcquiaCliException::class);
@@ -219,7 +219,7 @@ class ApiCommandTest extends CommandTestBase {
     $this->mockApplicationsRequest(1, FALSE);
     $this->clientProphecy->addQuery('filter', 'hosting=@devcloud:devcloud2')->shouldBeCalled();
     $this->mockApplicationRequest();
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->command = $this->getApiCommandByName('api:applications:find');
     $alias = 'devcloud:devcloud2';
     $this->executeCommand(['applicationUuid' => $alias], []);
@@ -234,7 +234,7 @@ class ApiCommandTest extends CommandTestBase {
     $applicationsResponse = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockEnvironmentsRequest($applicationsResponse);
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
 
     $response = $this->getMockEnvironmentResponse();
     $this->clientProphecy->request('get', '/environments/24-a47ac10b-58cc-4372-a567-0e02b2c3d470')->willReturn($response)->shouldBeCalled();
@@ -265,7 +265,7 @@ class ApiCommandTest extends CommandTestBase {
     $applicationsResponse = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockEnvironmentsRequest($applicationsResponse);
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->command = $this->getApiCommandByName('api:environments:find');
     $alias = 'devcloud2.invalid';
     $this->expectException(AcquiaCliException::class);

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -160,7 +160,14 @@ class ApiCommandTest extends CommandTestBase {
     $this->mockApplicationRequest();
     $this->command = $this->getApiCommandByName('api:applications:find');
     $alias = 'devcloud2';
-    $this->mockAccountRequest($support);
+    $tamper = NULL;
+    if ($support) {
+      $this->clientProphecy->addQuery('all', 'true')->shouldBeCalled();
+      $tamper = function ($response) {
+        $response->flags->support = TRUE;
+      };
+    }
+    $this->mockRequest('/account', [], 'get', NULL, NULL, $tamper);
 
     $this->executeCommand(['applicationUuid' => $alias], [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -187,7 +187,7 @@ class ApiCommandTest extends CommandTestBase {
   public function testConvertInvalidApplicationAliasToUuidArgument(): void {
     $this->mockApplicationsRequest(0);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:invalidalias')->shouldBeCalled();
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->command = $this->getApiCommandByName('api:applications:find');
     $alias = 'invalidalias';
     $this->expectException(AcquiaCliException::class);
@@ -203,7 +203,7 @@ class ApiCommandTest extends CommandTestBase {
     ClearCacheCommand::clearCaches();
     $this->mockApplicationsRequest(2, FALSE);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->command = $this->getApiCommandByName('api:applications:find');
     $alias = 'devcloud2';
     $this->expectException(AcquiaCliException::class);
@@ -219,7 +219,7 @@ class ApiCommandTest extends CommandTestBase {
     $this->mockApplicationsRequest(1, FALSE);
     $this->clientProphecy->addQuery('filter', 'hosting=@devcloud:devcloud2')->shouldBeCalled();
     $this->mockApplicationRequest();
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->command = $this->getApiCommandByName('api:applications:find');
     $alias = 'devcloud:devcloud2';
     $this->executeCommand(['applicationUuid' => $alias], []);
@@ -234,7 +234,7 @@ class ApiCommandTest extends CommandTestBase {
     $applicationsResponse = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockEnvironmentsRequest($applicationsResponse);
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
 
     $response = $this->getMockEnvironmentResponse();
     $this->clientProphecy->request('get', '/environments/24-a47ac10b-58cc-4372-a567-0e02b2c3d470')->willReturn($response)->shouldBeCalled();
@@ -265,7 +265,7 @@ class ApiCommandTest extends CommandTestBase {
     $applicationsResponse = $this->mockApplicationsRequest(1);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockEnvironmentsRequest($applicationsResponse);
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->command = $this->getApiCommandByName('api:environments:find');
     $alias = 'devcloud2.invalid';
     $this->expectException(AcquiaCliException::class);

--- a/tests/phpunit/src/Commands/ClearCacheCommandTest.php
+++ b/tests/phpunit/src/Commands/ClearCacheCommandTest.php
@@ -36,7 +36,7 @@ class ClearCacheCommandTest extends CommandTestBase {
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockApplicationRequest();
     $this->mockIdeListRequest();
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
 
     $alias = 'devcloud2';
     $args = ['applicationUuid' => $alias];

--- a/tests/phpunit/src/Commands/ClearCacheCommandTest.php
+++ b/tests/phpunit/src/Commands/ClearCacheCommandTest.php
@@ -36,7 +36,7 @@ class ClearCacheCommandTest extends CommandTestBase {
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockApplicationRequest();
     $this->mockIdeListRequest();
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
 
     $alias = 'devcloud2';
     $args = ['applicationUuid' => $alias];

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -86,7 +86,7 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase {
     $this->mockGitlabGetToken($localMachineHelper, $this->gitLabToken, $this->gitLabHost);
     $gitlabClient = $this->prophet->prophesize(Client::class);
     $this->mockGitLabUsersMe($gitlabClient);
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->mockGitLabPermissionsRequest($this::$applicationUuid);
     $projects = $this->mockGetGitLabProjects($this::$applicationUuid, $this->gitLabProjectId, $mockedGitlabProjects);
     $projects->variables($this->gitLabProjectId)->willReturn(CodeStudioCiCdVariables::getDefaults());

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -86,7 +86,7 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase {
     $this->mockGitlabGetToken($localMachineHelper, $this->gitLabToken, $this->gitLabHost);
     $gitlabClient = $this->prophet->prophesize(Client::class);
     $this->mockGitLabUsersMe($gitlabClient);
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->mockGitLabPermissionsRequest($this::$applicationUuid);
     $projects = $this->mockGetGitLabProjects($this::$applicationUuid, $this->gitLabProjectId, $mockedGitlabProjects);
     $projects->variables($this->gitLabProjectId)->willReturn(CodeStudioCiCdVariables::getDefaults());

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -150,7 +150,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $environmentsResponse = $this->getMockEnvironmentsResponse();
     $selectedEnvironment = $environmentsResponse->_embedded->items[0];
     $this->clientProphecy->request('get', "/applications/{$this::$applicationUuid}/environments")->willReturn($environmentsResponse->_embedded->items)->shouldBeCalled();
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->mockGitLabPermissionsRequest($this::$applicationUuid);
 
     $gitlabClient = $this->prophet->prophesize(Client::class);

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -150,7 +150,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $environmentsResponse = $this->getMockEnvironmentsResponse();
     $selectedEnvironment = $environmentsResponse->_embedded->items[0];
     $this->clientProphecy->request('get', "/applications/{$this::$applicationUuid}/environments")->willReturn($environmentsResponse->_embedded->items)->shouldBeCalled();
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->mockGitLabPermissionsRequest($this::$applicationUuid);
 
     $gitlabClient = $this->prophet->prophesize(Client::class);

--- a/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
@@ -17,21 +17,20 @@ class IdeCreateCommandTest extends CommandTestBase {
    * Tests the 'ide:create' command.
    */
   public function testCreate(): void {
-    $applicationsResponse = $this->mockRequest('/applications');
+    $applicationsResponse = $this->mockRequest('getApplications');
     $applicationUuid = $applicationsResponse[self::$INPUT_APP]->uuid;
-    $this->mockRequest('/applications/{applicationUuid}', ['{applicationUuid}' => $applicationUuid]);
-    $this->mockRequest('/account');
+    $this->mockRequest('getApplicationByUuid', $applicationUuid);
+    $this->mockRequest('getAccount');
     $ideResponse = $this->mockRequest(
-      '/applications/{applicationUuid}/ides',
-      ['{applicationUuid}' => $applicationUuid],
-      'post',
+      'postApplicationsIde',
+      $applicationUuid,
       ['json' => ['label' => 'Example IDE']],
       'IDE created'
     );
     $cloudApiIdeUrl = $ideResponse->_links->self->href;
     $urlParts = explode('/', $cloudApiIdeUrl);
     $ideUuid = end($urlParts);
-    $this->mockRequest('/ides/{ideUuid}', ['{ideUuid}' => $ideUuid]);
+    $this->mockRequest('getIde', $ideUuid);
 
     /** @var \Prophecy\Prophecy\ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzleResponse */
     $guzzleResponse = $this->prophet->prophesize(Response::class);

--- a/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
@@ -18,7 +18,7 @@ class IdeCreateCommandTest extends CommandTestBase {
    */
   public function testCreate(): void {
     $applicationsResponse = $this->mockRequest('getApplications');
-    $applicationUuid = $applicationsResponse[self::$INPUT_APP]->uuid;
+    $applicationUuid = $applicationsResponse[self::$INPUT_DEFAULT_CHOICE]->uuid;
     $this->mockRequest('getApplicationByUuid', $applicationUuid);
     $this->mockRequest('getAccount');
     $ideResponse = $this->mockRequest(
@@ -44,7 +44,7 @@ class IdeCreateCommandTest extends CommandTestBase {
       // Would you like to link the project at ... ?
       'n',
       0,
-      self::$INPUT_APP,
+      self::$INPUT_DEFAULT_CHOICE,
       // Enter a label for your Cloud IDE:
       'Example IDE',
     ];

--- a/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
@@ -17,23 +17,21 @@ class IdeCreateCommandTest extends CommandTestBase {
    * Tests the 'ide:create' command.
    */
   public function testCreate(): void {
-
-    $this->mockApplicationsRequest();
-    $this->mockApplicationRequest();
-    $this->mockAccountRequest();
-
-    // Request to create IDE.
-    $response = $this->getMockResponseFromSpec('/applications/{applicationUuid}/ides', 'post', '202');
-    $this->clientProphecy->request(
-          'post',
-          // @todo Consider replacing path parameter with Argument::containingString('/ides') or something.
-          '/applications/a47ac10b-58cc-4372-a567-0e02b2c3d470/ides',
-          ['json' => ['label' => 'Example IDE']]
-      )->willReturn($response->{'IDE created'}->value);
-
-    // Request for IDE data.
-    $response = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
-    $this->clientProphecy->request('get', '/ides/1792767d-1ee3-4b5f-83a8-334dfdc2b8a3')->willReturn($response)->shouldBeCalled();
+    $applicationsResponse = $this->mockRequest('/applications');
+    $applicationUuid = $applicationsResponse[self::$INPUT_APP]->uuid;
+    $this->mockRequest('/applications/{applicationUuid}', ['{applicationUuid}' => $applicationUuid]);
+    $this->mockRequest('/account');
+    $ideResponse = $this->mockRequest(
+      '/applications/{applicationUuid}/ides',
+      ['{applicationUuid}' => $applicationUuid],
+      'post',
+      ['json' => ['label' => 'Example IDE']],
+      'IDE created'
+    );
+    $cloudApiIdeUrl = $ideResponse->_links->self->href;
+    $urlParts = explode('/', $cloudApiIdeUrl);
+    $ideUuid = end($urlParts);
+    $this->mockRequest('/ides/{ideUuid}', ['{ideUuid}' => $ideUuid]);
 
     /** @var \Prophecy\Prophecy\ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzleResponse */
     $guzzleResponse = $this->prophet->prophesize(Response::class);
@@ -47,8 +45,7 @@ class IdeCreateCommandTest extends CommandTestBase {
       // Would you like to link the project at ... ?
       'n',
       0,
-      // Select the application for which you'd like to create a new IDE
-      0,
+      self::$INPUT_APP,
       // Enter a label for your Cloud IDE:
       'Example IDE',
     ];

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
@@ -19,7 +19,7 @@ class IdeWizardCreateSshKeyCommandTest extends IdeWizardTestBase {
     parent::setUp($output);
     $applicationResponse = $this->mockApplicationRequest();
     $this->mockListSshKeysRequest();
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->mockPermissionsRequest($applicationResponse);
     $this->ide = $this->mockIdeRequest();
     $this->sshKeyFileName = IdeWizardCreateSshKeyCommand::getSshKeyFilename(IdeHelper::$remoteIdeUuid);

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
@@ -19,7 +19,7 @@ class IdeWizardCreateSshKeyCommandTest extends IdeWizardTestBase {
     parent::setUp($output);
     $applicationResponse = $this->mockApplicationRequest();
     $this->mockListSshKeysRequest();
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->mockPermissionsRequest($applicationResponse);
     $this->ide = $this->mockIdeRequest();
     $this->sshKeyFileName = IdeWizardCreateSshKeyCommand::getSshKeyFilename(IdeHelper::$remoteIdeUuid);

--- a/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
@@ -12,7 +12,7 @@ abstract class SshCommandTestBase extends CommandTestBase {
     $applicationsResponse = $this->mockApplicationsRequest(1);
     $this->mockEnvironmentsRequest($applicationsResponse);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
   }
 
   /**

--- a/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
@@ -12,7 +12,7 @@ abstract class SshCommandTestBase extends CommandTestBase {
     $applicationsResponse = $this->mockApplicationsRequest(1);
     $this->mockEnvironmentsRequest($applicationsResponse);
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
   }
 
   /**

--- a/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
@@ -47,8 +47,14 @@ class SshKeyCreateUploadCommandTest extends CommandTestBase {
     $this->mockSshAgentList($localMachineHelper);
     $this->mockGenerateSshKey($localMachineHelper, $mockRequestArgs['public_key']);
 
+    $body = [
+      'json' => [
+        'label' => $mockRequestArgs['label'],
+        'public_key' => $mockRequestArgs['public_key'],
+      ],
+    ];
     // Upload.
-    $this->mockUploadSshKey();
+    $this->mockRequest('postAccountSshKeys', NULL, $body);
     //$this->mockListSshKeyRequestWithUploadedKey($mockRequestArgs);
     //$applicationsResponse = $this->mockApplicationsRequest();
     //$this->mockApplicationRequest();

--- a/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
@@ -1,8 +1,5 @@
 <?php
 
-/**
- * @file
- */
 namespace Acquia\Cli\Tests\Commands\Ssh;
 
 use Acquia\Cli\Command\Ssh\SshKeyCreateCommand;
@@ -31,17 +28,12 @@ class SshKeyCreateUploadCommandTest extends CommandTestBase {
     return $this->injectCommand(SshKeyCreateUploadCommand::class);
   }
 
-  /**
-   * Tests the 'ssh-key:create-upload' command.
-   */
   public function testCreateUpload(): void {
     $mockRequestArgs = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
 
-    // Create.
     $sshKeyFilename = 'id_rsa';
     $localMachineHelper = $this->mockLocalMachineHelper();
     $localMachineHelper->getLocalFilepath('~/.passphrase')->willReturn('~/.passphrase');
-    /** @var Filesystem|ObjectProphecy $fileSystem */
     $fileSystem = $this->prophet->prophesize(Filesystem::class);
     $this->mockAddSshKeyToAgent($localMachineHelper, $fileSystem);
     $this->mockSshAgentList($localMachineHelper);
@@ -53,22 +45,13 @@ class SshKeyCreateUploadCommandTest extends CommandTestBase {
         'public_key' => $mockRequestArgs['public_key'],
       ],
     ];
-    // Upload.
     $this->mockRequest('postAccountSshKeys', NULL, $body);
-    //$this->mockListSshKeyRequestWithUploadedKey($mockRequestArgs);
-    //$applicationsResponse = $this->mockApplicationsRequest();
-    //$this->mockApplicationRequest();
     $this->mockGetLocalSshKey($localMachineHelper, $fileSystem, $mockRequestArgs['public_key']);
-    //$this->mockEnvironmentsRequest($applicationsResponse);
 
     $localMachineHelper->getFilesystem()->willReturn($fileSystem->reveal())->shouldBeCalled();
     $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->application->find(SshKeyCreateCommand::getDefaultName())->localMachineHelper = $this->command->localMachineHelper;
     $this->application->find(SshKeyUploadCommand::getDefaultName())->localMachineHelper = $this->command->localMachineHelper;
-
-    //$environmentsResponse = $this->getMockEnvironmentsResponse();
-    //$sshHelper = $this->mockPollCloudViaSsh($environmentsResponse->_embedded->items[0]);
-    //$this->command->sshHelper = $sshHelper->reveal();
 
     $inputs = [
       // Enter a filename for your new local SSH key:

--- a/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
@@ -4,7 +4,6 @@ namespace Acquia\Cli\Tests\Commands\Ssh;
 
 use Acquia\Cli\Command\Ssh\SshKeyDeleteCommand;
 use Acquia\Cli\Tests\CommandTestBase;
-use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -16,20 +15,13 @@ class SshKeyDeleteCommandTest extends CommandTestBase {
     return $this->injectCommand(SshKeyDeleteCommand::class);
   }
 
-  /**
-   * Tests the 'ssh-key:upload' command.
-   */
   public function testDelete(): void {
-
     $sshKeyListResponse = $this->mockListSshKeysRequest();
-    $response = $this->prophet->prophesize(ResponseInterface::class);
-    $response->getStatusCode()->willReturn(202);
-    $this->getMockResponseFromSpec('/account/ssh-keys/{sshKeyUuid}', 'delete', '202');
-    $this->clientProphecy->makeRequest('delete', '/account/ssh-keys/' . $sshKeyListResponse->_embedded->items[0]->uuid)->willReturn($response->reveal())->shouldBeCalled();
+    $this->mockRequest('deleteAccountSshKey', $sshKeyListResponse[self::$INPUT_DEFAULT_CHOICE]->uuid, NULL, 'Removed key');
 
     $inputs = [
       // Choose key.
-      '0',
+      self::$INPUT_DEFAULT_CHOICE,
       // Do you also want to delete the corresponding local key files?
       'n',
     ];
@@ -39,7 +31,7 @@ class SshKeyDeleteCommandTest extends CommandTestBase {
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
     $this->assertStringContainsString('Choose an SSH key to delete from the Cloud Platform', $output);
-    $this->assertStringContainsString($sshKeyListResponse->_embedded->items[0]->label, $output);
+    $this->assertStringContainsString($sshKeyListResponse[self::$INPUT_DEFAULT_CHOICE]->label, $output);
   }
 
 }

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -32,7 +32,7 @@ class TelemetryCommandTest extends CommandTestBase {
    * Tests the 'telemetry' command.
    */
   public function testTelemetryCommand(): void {
-    $this->mockRequest('/account');
+    $this->mockRequest('getAccount');
     $this->executeCommand();
     $output = $this->getDisplay();
     $this->assertStringContainsString('Telemetry has been enabled.', $output);

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -32,7 +32,7 @@ class TelemetryCommandTest extends CommandTestBase {
    * Tests the 'telemetry' command.
    */
   public function testTelemetryCommand(): void {
-    $this->mockAccountRequest();
+    $this->mockRequest('/account');
     $this->executeCommand();
     $output = $this->getDisplay();
     $this->assertStringContainsString('Telemetry has been enabled.', $output);

--- a/tests/phpunit/src/Commands/WizardTestBase.php
+++ b/tests/phpunit/src/Commands/WizardTestBase.php
@@ -52,8 +52,13 @@ abstract class WizardTestBase extends CommandTestBase {
     $this->clientProphecy->request('get', "/applications/{$this::$applicationUuid}/environments")->willReturn($environmentsResponse->_embedded->items)->shouldBeCalled();
     $request = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
 
-    // List uploaded keys.
-    $this->mockUploadSshKey('IDE_ExampleIDE_215824ff272a4a8c9027df32ed1d68a9');
+    $body = [
+      'json' => [
+        'label' => 'IDE_ExampleIDE_215824ff272a4a8c9027df32ed1d68a9',
+        'public_key' => $request['public_key'],
+      ],
+    ];
+    $this->mockRequest('postAccountSshKeys', NULL, $body);
 
     $localMachineHelper = $this->mockLocalMachineHelper();
 
@@ -113,8 +118,13 @@ abstract class WizardTestBase extends CommandTestBase {
 
     $localMachineHelper = $this->mockLocalMachineHelper();
 
-    // List uploaded keys.
-    $this->mockUploadSshKey('IDE_ExampleIDE_215824ff272a4a8c9027df32ed1d68a9');
+    $body = [
+      'json' => [
+        'label' => 'IDE_ExampleIDE_215824ff272a4a8c9027df32ed1d68a9',
+        'public_key' => $mockRequestArgs['public_key'],
+      ],
+    ];
+    $this->mockRequest('postAccountSshKeys', NULL, $body);
 
     // Poll Cloud.
     $sshHelper = $this->mockPollCloudViaSsh($environmentsResponse);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -542,10 +542,6 @@ abstract class TestBase extends TestCase {
       'get', 200);
   }
 
-  protected function mockAccountRequest(): void {
-    $this->mockRequest('/account');
-  }
-
   protected function getMockEnvironmentResponse(string $method = 'get', string $httpCode = '200'): object {
     return $this->getMockResponseFromSpec('/environments/{environmentId}',
       $method, $httpCode);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -647,23 +647,6 @@ abstract class TestBase extends TestCase {
     ], NULL, NULL, FALSE)->shouldBeCalled()->willReturn($process->reveal());
   }
 
-  protected function mockUploadSshKey(?string $label = NULL): void {
-    $request = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
-    $label = $label ?: $request['label'];
-    $response = $this->getMockResponseFromSpec('/account/ssh-keys', 'post', '202');
-    $this->clientProphecy->request(
-      'post',
-      '/account/ssh-keys',
-      [
-        'json' => [
-          'label' => $label,
-          'public_key' => $request['public_key'],
-        ],
-      ]
-    )->willReturn($response)
-      ->shouldBecalled();
-  }
-
   protected function mockGetIdeSshKeyRequest(IdeResponse $ide): void {
     $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
     $mockBody->{'_embedded'}->items[0]->label = SshKeyCommandBase::getIdeSshKeyLabel($ide);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -28,7 +28,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophet;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
@@ -592,13 +591,8 @@ abstract class TestBase extends TestCase {
     return $response;
   }
 
-  protected function mockListSshKeysRequest(): object {
-    $response = $this->getMockResponseFromSpec('/account/ssh-keys', 'get',
-      '200');
-    $this->clientProphecy->request('get', '/account/ssh-keys')
-      ->willReturn($response->{'_embedded'}->items)
-      ->shouldBeCalled();
-    return $response;
+  protected function mockListSshKeysRequest(): array {
+    return $this->mockRequest('getAccountSshKeys');
   }
 
   protected function mockListSshKeysRequestWithIdeKey(IdeResponse $ide): object {
@@ -647,22 +641,8 @@ abstract class TestBase extends TestCase {
     ], NULL, NULL, FALSE)->shouldBeCalled()->willReturn($process->reveal());
   }
 
-  protected function mockGetIdeSshKeyRequest(IdeResponse $ide): void {
-    $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
-    $mockBody->{'_embedded'}->items[0]->label = SshKeyCommandBase::getIdeSshKeyLabel($ide);
-    $this->clientProphecy->request('get', '/account/ssh-keys/' . $mockBody->{'_embedded'}->items[0]->uuid)
-      ->willReturn($mockBody->{'_embedded'}->items[0])
-      ->shouldBeCalled();
-  }
-
   protected function mockDeleteSshKeyRequest(string $keyUuid): void {
-    // Request ssh key deletion.
-    $sshKeyDeleteResponse = $this->prophet->prophesize(ResponseInterface::class);
-    $sshKeyDeleteResponse->getStatusCode()->willReturn(202);
-    $this->clientProphecy->makeRequest('delete',
-      '/account/ssh-keys/' . $keyUuid)
-      ->willReturn($sshKeyDeleteResponse->reveal())
-      ->shouldBeCalled();
+    $this->mockRequest('deleteAccountSshKey', $keyUuid, NULL, 'Removed key');
   }
 
   protected function mockListSshKeyRequestWithUploadedKey(


### PR DESCRIPTION
The mock methods are basically all boilerplate, and they are a bit magical and inconsistent in how they handle requests, parameters, and responses.

It might be a little more code, but I'd prefer to reduce the amount of abstraction and have just a single mockRequest method.