### PR TITLE
CLI-1054: Support pull commands outside of IDEs

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
         convertDeprecationsToExceptions="true"
-        bootstrap="tests/phpunit/bootstrap.php"
 >
   <php>
     <env name="AMPLITUDE_KEY" value=""/>

--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Cli\Command\App;
 
 use Acquia\Cli\Command\CommandBase;
+use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\LocalMachineHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,11 +16,13 @@ class AppOpenCommand extends CommandBase {
   protected function configure(): void {
     $this->setDescription('Opens your browser to view a given Cloud application')
       ->acceptApplicationUuid()
-      ->setHidden(!LocalMachineHelper::isBrowserAvailable())
       ->setAliases(['open', 'o']);
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
+    if (!LocalMachineHelper::isBrowserAvailable()) {
+      throw new AcquiaCliException('No browser is available on this machine');
+    }
     $applicationUuid = $this->determineCloudApplication();
     $this->localMachineHelper->startBrowser('https://cloud.acquia.com/a/applications/' . $applicationUuid);
 

--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -6,7 +6,6 @@ namespace Acquia\Cli\Command\App;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
-use Acquia\Cli\Helpers\LocalMachineHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,7 +25,7 @@ class AppOpenCommand extends CommandBase {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    if (!LocalMachineHelper::isBrowserAvailable()) {
+    if (!$this->localMachineHelper->isBrowserAvailable()) {
       throw new AcquiaCliException('No browser is available on this machine');
     }
     $applicationUuid = $this->determineCloudApplication();

--- a/src/Command/Archive/ArchiveExportCommand.php
+++ b/src/Command/Archive/ArchiveExportCommand.php
@@ -28,15 +28,17 @@ class ArchiveExportCommand extends CommandBase {
 
   private const PUBLIC_FILES_DIR = '/docroot/sites/default/files';
 
+  protected function commandRequiresDatabase(): bool {
+    return TRUE;
+  }
+
   protected function configure(): void {
     $this->setName('archive:export');
-    $this->setDescription('Generate an archive of the Drupal application')
+    $this->setDescription('Export an archive of the Drupal application including code, files, and database')
       ->addArgument('destination-dir', InputArgument::REQUIRED, 'The destination directory for the archive file')
       ->addOption('source-dir', 'dir', InputOption::VALUE_REQUIRED, 'The directory containing the Drupal project to be pushed')
       ->addOption('no-files', NULL, InputOption::VALUE_NONE, 'Exclude public files directory from archive')
-      ->addOption('no-database', 'no-db', InputOption::VALUE_NONE, 'Exclude database dump from archive')
-      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv())
-      ->setHelp('Export an archive of the current Drupal application, including code, files, and database');
+      ->addOption('no-database', 'no-db', InputOption::VALUE_NONE, 'Exclude database dump from archive');
   }
 
   protected function initialize(InputInterface $input, OutputInterface $output): void {

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\CodeStudio;
 
 use Acquia\Cli\Command\WizardCommandBase;
-use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
 use AcquiaCloudApi\Endpoints\Account;
 use Gitlab\Exception\ValidationFailedException;
@@ -225,22 +224,6 @@ class CodeStudioWizardCommand extends WizardCommandBase {
         $this->io->warning("Failed to upload project avatar");
       }
     }
-  }
-
-  /**
-   * Gets the default branch name for the deployment artifact.
-   */
-  protected function getCurrentBranchName(): string {
-    $process = $this->localMachineHelper->execute([
-      'git',
-      'rev-parse',
-      '--abbrev-ref',
-      'HEAD',
-    ], NULL, NULL, FALSE);
-    if (!$process->isSuccessful()) {
-      throw new AcquiaCliException("Could not determine current git branch");
-    }
-    return trim($process->getOutput());
   }
 
 }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -85,7 +85,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected string $localDbPassword = 'drupal';
   protected string $localDbName = 'drupal';
   protected string $localDbHost = 'localhost';
-
   protected bool $drushHasActiveDatabaseConnection;
   protected \GuzzleHttp\Client $updateClient;
 
@@ -109,6 +108,19 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->setLocalDbName();
     $this->setLocalDbHost();
     parent::__construct();
+    if ($this->commandRequiresAuthentication()) {
+      $this->appendHelp('This command requires authentication via the Cloud Platform API.');
+    }
+    if ($this->commandRequiresDatabase()) {
+      $this->appendHelp('This command requires an active database connection. Set the following environment variables prior to running this command: '
+        . 'ACLI_DB_HOST, ACLI_DB_NAME, ACLI_DB_USER, ACLI_DB_PASSWORD');
+    }
+  }
+
+  public function appendHelp(string $helpText): void {
+    $currentHelp = $this->getHelp();
+    $helpText = $currentHelp ? $currentHelp . "\n" . $helpText : $currentHelp . $helpText;
+    $this->setHelp($helpText);
   }
 
   protected static function getUuidRegexConstraint(): Regex {
@@ -199,7 +211,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->convertEnvironmentAliasToUuid($input, 'source');
 
     if ($latest = $this->checkForNewVersion()) {
-      $this->output->writeln("Acquia CLI {$latest} is available. Run <options=bold>acli self-update</> to update.");
+      $this->output->writeln("Acquia CLI $latest is available. Run <options=bold>acli self-update</> to update.");
     }
   }
 
@@ -294,6 +306,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected function commandRequiresAuthentication(): bool {
     // Assume commands require authentication unless they opt out by overriding this method.
     return TRUE;
+  }
+
+  protected function commandRequiresDatabase(): bool {
+    return FALSE;
   }
 
   /**

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Cli\Command\Pull;
 
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,13 +12,16 @@ class PullCodeCommand extends PullCommandBase {
 
   protected static $defaultName = 'pull:code';
 
+  protected function commandRequiresDatabase(): bool {
+    return TRUE;
+  }
+
   protected function configure(): void {
     $this->setDescription('Copy code from a Cloud Platform environment')
       ->acceptEnvironmentId()
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,
-        'Do not run any additional scripts after code is pulled. E.g., composer install , drush cache-rebuild, etc.')
-      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
+        'Do not run any additional scripts after code is pulled. E.g., composer install , drush cache-rebuild, etc.');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Cli\Command\Pull;
 
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,6 +11,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 class PullCommand extends PullCommandBase {
 
   protected static $defaultName = 'pull:all';
+
+  protected function commandRequiresDatabase(): bool {
+    return TRUE;
+  }
 
   protected function configure(): void {
     $this->setAliases(['refresh', 'pull'])
@@ -27,8 +30,7 @@ class PullCommand extends PullCommandBase {
             NULL,
             InputOption::VALUE_NONE,
             'Do not run any additional scripts after code and database are copied. E.g., composer install , drush cache-rebuild, etc.'
-        )
-      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
+        );
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -767,7 +767,7 @@ abstract class PullCommandBase extends CommandBase {
     $databaseBackups = new DatabaseBackups($acquiaCloudClient);
     $backupsResponse = $databaseBackups->getAll($environment->uuid, $database->name);
     if (!count($backupsResponse)) {
-      $this->logger->warning('No existing backups found, creating an on-demand backup now. This will take some time depending on the size of the database.');
+      $this->io->warning('No existing backups found, creating an on-demand backup now. This will take some time depending on the size of the database.');
       $this->createBackup($environment, $database, $acquiaCloudClient);
       $backupsResponse = $databaseBackups->getAll($environment->uuid,
         $database->name);

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Cli\Command\Pull;
 
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -11,6 +10,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 class PullDatabaseCommand extends PullCommandBase {
 
   protected static $defaultName = 'pull:database';
+
+  protected function commandRequiresDatabase(): bool {
+    return TRUE;
+  }
 
   protected function configure(): void {
     $this->setDescription('Import database backup from a Cloud Platform environment')
@@ -25,8 +28,7 @@ class PullDatabaseCommand extends PullCommandBase {
       ->addOption('no-import', NULL, InputOption::VALUE_NONE,
       'Download the backup but do not import it (implies --no-scripts)')
       ->addOption('multiple-dbs', NULL, InputOption::VALUE_NONE,
-        'Download multiple dbs. Defaults to FALSE.')
-      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
+        'Download multiple dbs. Defaults to FALSE.');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Cli\Command\Pull;
 
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,8 +13,7 @@ class PullFilesCommand extends PullCommandBase {
   protected function configure(): void {
     $this->setDescription('Copy files from a Cloud Platform environment')
       ->acceptEnvironmentId()
-      ->acceptSite()
-      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
+      ->acceptSite();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Cli\Command\Pull;
 
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,8 +14,7 @@ class PullScriptsCommand extends PullCommandBase {
   protected function configure(): void {
     $this->setDescription('Execute post pull scripts')
       ->acceptEnvironmentId()
-      ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
-      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
+      ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed');
   }
 
   protected function commandRequiresAuthentication(): bool {

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -5,7 +5,6 @@ namespace Acquia\Cli\Command\Push;
 use Acquia\Cli\Command\Pull\PullCommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Response\DatabaseResponse;
 use AcquiaCloudApi\Response\EnvironmentResponse;
 use Symfony\Component\Console\Command\Command;
@@ -16,12 +15,15 @@ class PushDatabaseCommand extends PullCommandBase {
 
   protected static $defaultName = 'push:database';
 
+  protected function commandRequiresDatabase(): bool {
+    return TRUE;
+  }
+
   protected function configure(): void {
-    $this->setDescription('Push a database from your IDE to a Cloud Platform environment')
+    $this->setDescription('Push a database from your local environment to a Cloud Platform environment')
       ->setAliases(['push:db'])
       ->acceptEnvironmentId()
-      ->acceptSite()
-      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
+      ->acceptSite();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -4,7 +4,6 @@ namespace Acquia\Cli\Command\Push;
 
 use Acquia\Cli\Command\Pull\PullCommandBase;
 use Acquia\Cli\Output\Checklist;
-use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Response\EnvironmentResponse;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,10 +14,9 @@ class PushFilesCommand extends PullCommandBase {
   protected static $defaultName = 'push:files';
 
   protected function configure(): void {
-    $this->setDescription('Push Drupal files from your IDE to a Cloud Platform environment')
+    $this->setDescription('Push Drupal files from your local environment to a Cloud Platform environment')
       ->acceptEnvironmentId()
-      ->acceptSite()
-      ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
+      ->acceptSite();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -334,7 +334,7 @@ class LocalMachineHelper {
    * @return bool
    *   TRUE if a browser is available.
    */
-  public static function isBrowserAvailable(): bool {
+  public function isBrowserAvailable(): bool {
     if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv()) {
       return FALSE;
     }
@@ -363,7 +363,7 @@ class LocalMachineHelper {
   public function startBrowser(mixed $uri = NULL, string $browser = NULL): bool {
     // We can only open a browser if we have a DISPLAY environment variable on
     // POSIX or are running Windows or OS X.
-    if (!self::isBrowserAvailable()) {
+    if (!$this->isBrowserAvailable()) {
       $this->logger->info('No graphical display appears to be available, not starting browser.');
       return FALSE;
     }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,8 +1,0 @@
-<?php
-
-declare(strict_types = 1);
-
-use Symfony\Component\Filesystem\Filesystem;
-
-// ensure a fresh cache when debug mode is disabled
-(new Filesystem())->remove(__DIR__ . '/../../var/cache/dev');

--- a/tests/phpunit/src/Application/KernelTest.php
+++ b/tests/phpunit/src/Application/KernelTest.php
@@ -21,7 +21,8 @@ class KernelTest extends ApplicationTestBase {
   }
 
   private function getStart(): string {
-    return "Console Tool
+    return <<<EOD
+Console Tool
 
 Usage:
   command [options] [arguments]
@@ -45,13 +46,17 @@ Available commands:
  app
   app:link                 [link] Associate your project with a Cloud Platform application
   app:log:tail             [tail|log:tail] Tail the logs from your environments
-  app:new:local            [new] Create a new Drupal or Next.js project";
+  app:new:local            [new] Create a new Drupal or Next.js project
+EOD;
   }
 
   private function getEnd(): string {
-    return "app:task-wait            Wait for a task to complete
+    return <<<EOD
+  app:task-wait            Wait for a task to complete
   app:unlink               [unlink] Remove local association between your project and a Cloud Platform application
   app:vcs:info             Get all branches and tags of the application with the deployment status
+ archive
+  archive:export           Export an archive of the Drupal application including code, files, and database
  auth
   auth:acsf-login          Register your Site Factory API key and secret to use API functionality
   auth:acsf-logout         Remove your Site Factory key and secret from your local machine.
@@ -76,8 +81,16 @@ Available commands:
   ide:list:app             [ide:list] List available Cloud IDEs belonging to a given application
   ide:list:mine            List Cloud IDEs belonging to you
   ide:open                 Open a Cloud IDE in your browser
+ pull
+  pull:all                 [refresh|pull] Copy code, database, and files from a Cloud Platform environment
+  pull:code                Copy code from a Cloud Platform environment
+  pull:database            [pull:db] Import database backup from a Cloud Platform environment
+  pull:files               Copy files from a Cloud Platform environment
+  pull:run-scripts         Execute post pull scripts
  push
   push:artifact            Build and push a code artifact to a Cloud Platform environment
+  push:database            [push:db] Push a database from your local environment to a Cloud Platform environment
+  push:files               Push Drupal files from your local environment to a Cloud Platform environment
  remote
   remote:aliases:download  Download Drush aliases for the Cloud Platform
   remote:aliases:list      [aliases|sa] List all aliases for the Cloud Platform environments
@@ -96,7 +109,8 @@ Available commands:
   ssh-key:info             Print information about an SSH key
   ssh-key:list             List your local and remote SSH keys
   ssh-key:upload           Upload a local SSH key to the Cloud Platform
-";
+
+EOD;
   }
 
 }

--- a/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
+++ b/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
@@ -18,6 +18,7 @@ class AppOpenCommandTest extends CommandTestBase {
   }
 
   public function testAppOpenCommand(): void {
+    putenv('DISPLAY=1');
     $applicationUuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
     $localMachineHelper = $this->mockLocalMachineHelper();
     $localMachineHelper->startBrowser('https://cloud.acquia.com/a/applications/' . $applicationUuid)->shouldBeCalled();
@@ -29,6 +30,7 @@ class AppOpenCommandTest extends CommandTestBase {
     // Assert.
     $this->prophet->checkPredictions();
     $this->getDisplay();
+    putenv('DISPLAY');
   }
 
 }

--- a/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
+++ b/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Tests\Commands\App;
 
 use Acquia\Cli\Command\App\AppOpenCommand;
+use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 
@@ -18,19 +19,27 @@ class AppOpenCommandTest extends CommandTestBase {
   }
 
   public function testAppOpenCommand(): void {
-    putenv('DISPLAY=1');
     $applicationUuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
     $localMachineHelper = $this->mockLocalMachineHelper();
     $localMachineHelper->startBrowser('https://cloud.acquia.com/a/applications/' . $applicationUuid)->shouldBeCalled();
+    $localMachineHelper->isBrowserAvailable()->willReturn(TRUE);
     $this->command->localMachineHelper = $localMachineHelper->reveal();
     $this->createMockAcliConfigFile($applicationUuid);
     $this->mockApplicationRequest();
     $this->executeCommand();
-
-    // Assert.
     $this->prophet->checkPredictions();
-    $this->getDisplay();
-    putenv('DISPLAY');
+  }
+
+  public function testAppOpenNoBrowser(): void {
+    $applicationUuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $localMachineHelper->isBrowserAvailable()->willReturn(FALSE);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
+    $this->mockApplicationRequest();
+    $this->createMockAcliConfigFile($applicationUuid);
+    $this->expectException(AcquiaCliException::class);
+    $this->expectExceptionMessage('No browser is available on this machine');
+    $this->executeCommand();
   }
 
 }

--- a/tests/phpunit/src/Commands/App/AppVcsInfoTest.php
+++ b/tests/phpunit/src/Commands/App/AppVcsInfoTest.php
@@ -22,13 +22,13 @@ class AppVcsInfoTest extends CommandTestBase {
    * Test when no environment available for the app.
    */
   public function testNoEnvAvailableCommand(): void {
-    $applicationsResponse = $this->mockApplicationsRequest();
-    $this->mockApplicationRequest();
+    $applications = $this->mockRequest('getApplications');
+    $application = $this->mockRequest('getApplicationByUuid', $applications[self::$INPUT_DEFAULT_CHOICE]->uuid);
     $this->clientProphecy->request('get',
-      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
+      "/applications/{$application->uuid}/environments")
       ->willReturn([])
       ->shouldBeCalled();
-    $this->mockApplicationCodeRequest($applicationsResponse);
+    $this->mockRequest('getCodeByApplicationUuid', $application->uuid);
 
     $this->expectException(AcquiaCliException::class);
     $this->expectExceptionMessage('There are no environments available with this application.');
@@ -66,10 +66,10 @@ class AppVcsInfoTest extends CommandTestBase {
    * Test the list of the VCS details of the application.
    */
   public function testShowVcsListCommand(): void {
-    $applicationsResponse = $this->mockApplicationsRequest();
-    $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applicationsResponse);
-    $this->mockApplicationCodeRequest($applicationsResponse);
+    $applications = $this->mockRequest('getApplications');
+    $application = $this->mockRequest('getApplicationByUuid', $applications[self::$INPUT_DEFAULT_CHOICE]->uuid);
+    $this->mockRequest('getApplicationEnvironments', $application->uuid);
+    $this->mockRequest('getCodeByApplicationUuid', $application->uuid);
 
     $this->executeCommand(
       [
@@ -110,7 +110,7 @@ EOD;
       "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/environments")
       ->willReturn($response->_embedded->items)
       ->shouldBeCalled();
-    $this->mockApplicationCodeRequest($applicationsResponse);
+    $this->mockRequest('getCodeByApplicationUuid', $applicationsResponse->{'_embedded'}->items[0]->uuid);
 
     $this->expectException(AcquiaCliException::class);
     $this->expectExceptionMessage('No branch or tag is deployed on any of the environment of this application.');
@@ -126,10 +126,10 @@ EOD;
    * Test the list of the only deployed VCS.
    */
   public function testListOnlyDeployedVcs(): void {
-    $applicationsResponse = $this->mockApplicationsRequest();
-    $this->mockApplicationRequest();
-    $this->mockEnvironmentsRequest($applicationsResponse);
-    $this->mockApplicationCodeRequest($applicationsResponse);
+    $applications = $this->mockRequest('getApplications');
+    $application = $this->mockRequest('getApplicationByUuid', $applications[self::$INPUT_DEFAULT_CHOICE]->uuid);
+    $this->mockRequest('getApplicationEnvironments', $application->uuid);
+    $this->mockRequest('getCodeByApplicationUuid', $application->uuid);
 
     $this->executeCommand(
       [

--- a/tests/phpunit/src/Commands/ClearCacheCommandTest.php
+++ b/tests/phpunit/src/Commands/ClearCacheCommandTest.php
@@ -37,7 +37,7 @@ class ClearCacheCommandTest extends CommandTestBase {
 
     $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')->shouldBeCalled();
     $this->mockApplicationRequest();
-    $this->mockIdeListRequest();
+    $this->mockRequest('getApplicationIdes', 'a47ac10b-58cc-4372-a567-0e02b2c3d470');
     $this->mockRequest('getAccount');
 
     $alias = 'devcloud2';

--- a/tests/phpunit/src/Commands/CommandBaseTest.php
+++ b/tests/phpunit/src/Commands/CommandBaseTest.php
@@ -39,16 +39,8 @@ class CommandBaseTest extends CommandTestBase {
 
   public function testCloudAppFromLocalConfig(): void {
     $this->command = $this->injectCommand(IdeListCommand::class);
-    $this->mockApplicationRequest();
-    $this->mockIdeListRequest();
-    $inputs = [
-      // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
-      'n',
-      // Select the application.
-      0,
-      // Would you like to link the project at ... ?
-      'y',
-    ];
+    $application = $this->mockRequest('getApplicationByUuid', 'a47ac10b-58cc-4372-a567-0e02b2c3d470');
+    $this->mockRequest('getApplicationIdes', $application->uuid);
     $this->createMockAcliConfigFile('a47ac10b-58cc-4372-a567-0e02b2c3d470');
     $this->executeCommand();
     $this->prophet->checkPredictions();

--- a/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
@@ -29,16 +29,13 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Select a Cloud Platform subscription
       0,
     ];
-    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
-    $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
-      ->shouldBeCalledTimes(1);
+    $subscriptions = $this->mockRequest('getSubscriptions');
 
     $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
     // duplicating the request to ensure there is at least one domain with a successful, pending, and failed health code
     $getDomainsResponse2 = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
     $totalDomainsList = array_merge($getDomainsResponse->_embedded->items, $getDomainsResponse2->_embedded->items);
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($totalDomainsList);
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions[0]->uuid}/domains")->willReturn($totalDomainsList);
 
     $totalDomainsList[2]->domain_name = 'example3.com';
     $totalDomainsList[2]->health->code = '200';
@@ -48,7 +45,7 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
 
     $applicationsResponse = $this->mockApplicationsRequest();
 
-    $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
+    $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptions[0]->uuid;
 
     $getAppDomainsResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
     // duplicating the request to ensure added domains are included in association list
@@ -83,13 +80,10 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Select a Cloud Platform subscription
       0,
     ];
-    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
-    $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
-      ->shouldBeCalledTimes(1);
+    $subscriptions = $this->mockRequest('getSubscriptions');
 
     $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
     $this->mockApplicationsRequest();
 
@@ -105,22 +99,19 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Do you wish to continue?
       'no',
     ];
-    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
-    $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
-      ->shouldBeCalledTimes(1);
+    $subscriptions = $this->mockRequest('getSubscriptions');
 
     $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
     $applicationsResponse = $this->getMockResponseFromSpec('/applications', 'get', '200');
-    $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
-    $applicationsResponse->_embedded->items[1]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
+    $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptions[0]->uuid;
+    $applicationsResponse->_embedded->items[1]->subscription->uuid = $subscriptions[0]->uuid;
 
     $app = $this->getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
     for ($i = 2; $i < 101; $i++) {
       $applicationsResponse->_embedded->items[$i] = $app;
-      $applicationsResponse->_embedded->items[$i]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
+      $applicationsResponse->_embedded->items[$i]->subscription->uuid = $subscriptions[0]->uuid;
     }
 
     $this->clientProphecy->request('get', '/applications')->willReturn($applicationsResponse->_embedded->items);
@@ -140,12 +131,9 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Select a Cloud Platform subscription
       0,
     ];
-    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
-    $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
-      ->shouldBeCalledTimes(1);
+    $subscriptions = $this->mockRequest('getSubscriptions');
 
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn([]);
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions[0]->uuid}/domains")->willReturn([]);
 
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
@@ -157,23 +145,33 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase {
       // Select a Cloud Platform subscription
       0,
     ];
-    $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
-    $this->clientProphecy->request('get', '/subscriptions')
-      ->willReturn($subscriptionsResponse->{'_embedded'}->items)
-      ->shouldBeCalledTimes(1);
+    $subscriptions = $this->mockRequest('getSubscriptions');
 
     $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
-    $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
+    $this->clientProphecy->request('get', "/subscriptions/{$subscriptions[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
     $applicationsResponse = $this->mockApplicationsRequest();
 
-    $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
+    $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptions[0]->uuid;
 
     $this->clientProphecy->request('get', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains")->willReturn([]);
 
     $this->executeCommand([], $inputs);
     $output = $this->getDisplay();
     $this->assertStringContainsString('No domains eligible', $output);
+  }
+
+  public function testEmailInfoForSubscriptionNoSubscriptions(): void {
+    $inputs = [
+      // Select a Cloud Platform subscription
+      0,
+    ];
+    $this->clientProphecy->request('get', '/subscriptions')
+      ->willReturn([])
+      ->shouldBeCalledTimes(1);
+    $this->expectException(AcquiaCliException::class);
+    $this->expectExceptionMessage('You have no Cloud subscriptions.');
+    $this->executeCommand([], $inputs);
   }
 
 }

--- a/tests/phpunit/src/Commands/Ide/IdeDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeDeleteCommandTest.php
@@ -32,14 +32,11 @@ class IdeDeleteCommandTest extends CommandTestBase {
   }
 
   public function testIdeDeleteCommand(): void {
-
-    $this->mockRequest('getApplications');
-    $this->mockApplicationRequest();
-    $this->mockIdeListRequest();
-
-    $ideUuid = '9a83c081-ef78-4dbd-8852-11cc3eb248f7';
-    $ideDeleteResponse = $this->mockIdeDeleteRequest($ideUuid);
-    $ideGetResponse = $this->mockGetIdeRequest($ideUuid);
+    $applications = $this->mockRequest('getApplications');
+    $this->mockRequest('getApplicationByUuid', $applications[0]->uuid);
+    $ides = $this->mockRequest('getApplicationIdes', $applications[0]->uuid);
+    $this->mockRequest('deleteIde', $ides[0]->uuid, NULL, 'De-provisioning IDE');
+    $ideGetResponse = $this->mockRequest('getIde', $ides[0]->uuid);
     $ide = new IdeResponse((object) $ideGetResponse);
     $sshKeyGetResponse = $this->mockListSshKeysRequestWithIdeKey($ide);
 
@@ -63,7 +60,7 @@ class IdeDeleteCommandTest extends CommandTestBase {
     // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    $this->assertStringContainsString($ideDeleteResponse->{'De-provisioning IDE'}->value->message, $output);
+    $this->assertStringContainsString('The Cloud IDE is being deleted.', $output);
   }
 
 }

--- a/tests/phpunit/src/Commands/Ide/IdeInfoCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeInfoCommandTest.php
@@ -18,11 +18,10 @@ class IdeInfoCommandTest extends CommandTestBase {
   }
 
   public function testIdeInfoCommand(): void {
-
-    $this->mockRequest('getApplications');
-    $this->mockApplicationRequest();
-    $response = $this->mockIdeListRequest();
-    $this->mockGetIdeRequest($response->_embedded->items[0]->uuid);
+    $applications = $this->mockRequest('getApplications');
+    $this->mockRequest('getApplicationByUuid', $applications[0]->uuid);
+    $ides = $this->mockRequest('getApplicationIdes', $applications[0]->uuid);
+    $this->mockRequest('getIde', $ides[0]->uuid);
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
       'n',

--- a/tests/phpunit/src/Commands/Ide/IdeListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeListCommandTest.php
@@ -18,14 +18,14 @@ class IdeListCommandTest extends CommandTestBase {
   }
 
   public function testIdeListCommand(): void {
-    $this->mockRequest('getApplications');
-    $this->mockApplicationRequest();
-    $this->mockIdeListRequest();
+    $applications = $this->mockRequest('getApplications');
+    $application = $this->mockRequest('getApplicationByUuid', $applications[self::$INPUT_DEFAULT_CHOICE]->uuid);
+    $this->mockRequest('getApplicationIdes', $application->uuid);
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
       'n',
       // Select the application.
-      0,
+      self::$INPUT_DEFAULT_CHOICE,
       // Would you like to link the project at ... ?
       'y',
     ];
@@ -57,7 +57,7 @@ class IdeListCommandTest extends CommandTestBase {
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
       'n',
       // Select the application.
-      0,
+      self::$INPUT_DEFAULT_CHOICE,
       // Would you like to link the project at ... ?
       'y',
     ];

--- a/tests/phpunit/src/Commands/Ide/IdeOpenCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeOpenCommandTest.php
@@ -17,21 +17,14 @@ class IdeOpenCommandTest extends CommandTestBase {
     return $this->injectCommand(IdeOpenCommand::class);
   }
 
-  public function setUp(mixed $output = NULL): void {
-    parent::setUp();
-    putenv('DISPLAY=1');
-  }
-
-  public function tearDown(): void {
-    parent::tearDown();
-    putenv('DISPLAY');
-  }
-
   public function testIdeOpenCommand(): void {
-
-    $this->mockRequest('getApplications');
-    $this->mockApplicationRequest();
-    $this->mockIdeListRequest();
+    $applications = $this->mockRequest('getApplications');
+    $this->mockRequest('getApplicationByUuid', $applications[0]->uuid);
+    $this->mockRequest('getApplicationIdes', $applications[0]->uuid);
+    $localMachineHelper = $this->mockLocalMachineHelper();
+    $localMachineHelper->isBrowserAvailable()->willReturn(TRUE);
+    $localMachineHelper->startBrowser('https://9a83c081-ef78-4dbd-8852-11cc3eb248f7.ides.acquia.com')->willReturn(TRUE);
+    $this->command->localMachineHelper = $localMachineHelper->reveal();
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?

--- a/tests/phpunit/src/Commands/Ide/IdeShareCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeShareCommandTest.php
@@ -41,7 +41,7 @@ class IdeShareCommandTest extends CommandTestBase {
   }
 
   public function testIdeShareCommand(): void {
-    $ideGetResponse = $this->mockGetIdeRequest(IdeHelper::$remoteIdeUuid);
+    $ideGetResponse = $this->mockRequest('getIde', IdeHelper::$remoteIdeUuid);
     $ide = new IdeResponse((object) $ideGetResponse);
     $this->executeCommand();
 
@@ -53,7 +53,7 @@ class IdeShareCommandTest extends CommandTestBase {
   }
 
   public function testIdeShareRegenerateCommand(): void {
-    $ideGetResponse = $this->mockGetIdeRequest(IdeHelper::$remoteIdeUuid);
+    $ideGetResponse = $this->mockRequest('getIde', IdeHelper::$remoteIdeUuid);
     $ide = new IdeResponse((object) $ideGetResponse);
     $this->executeCommand(['--regenerate' => TRUE], []);
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -547,23 +547,6 @@ abstract class TestBase extends TestCase {
     return $response;
   }
 
-  public function mockApplicationCodeRequest(
-    object $applicationsResponse
-  ): object {
-    $response = $this->getApplicationCodeResponse();
-    $this->clientProphecy->request('get',
-      "/applications/{$applicationsResponse->{'_embedded'}->items[0]->uuid}/code")
-      ->willReturn($response->_embedded->items)
-      ->shouldBeCalled();
-
-    return $response;
-  }
-
-  protected function getApplicationCodeResponse(): object {
-    return $this->getMockResponseFromSpec('/applications/{applicationUuid}/code',
-      'get', 200);
-  }
-
   protected function getMockEnvironmentResponse(string $method = 'get', string $httpCode = '200'): object {
     return $this->getMockResponseFromSpec('/environments/{environmentId}',
       $method, $httpCode);
@@ -572,31 +555,6 @@ abstract class TestBase extends TestCase {
   protected function getMockEnvironmentsResponse(): object {
     return $this->getMockResponseFromSpec('/applications/{applicationUuid}/environments',
       'get', 200);
-  }
-
-  protected function mockIdeListRequest(): object {
-    $response = $this->getMockResponseFromSpec('/applications/{applicationUuid}/ides',
-      'get', '200');
-    $this->clientProphecy->request('get',
-      '/applications/a47ac10b-58cc-4372-a567-0e02b2c3d470/ides')
-      ->willReturn($response->{'_embedded'}->items)
-      ->shouldBeCalled();
-
-    return $response;
-  }
-
-  protected function mockGetIdeRequest(string $ideUuid): object {
-    $ideResponse = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
-    $this->clientProphecy->request('get', '/ides/' . $ideUuid)->willReturn($ideResponse)->shouldBeCalled();
-    return $ideResponse;
-  }
-
-  protected function mockIdeDeleteRequest(string $ideUuid): object {
-    $ideDeleteResponse = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'delete', '202');
-    $this->clientProphecy->request('delete', '/ides/' . $ideUuid)
-      ->willReturn($ideDeleteResponse->{'De-provisioning IDE'}->value)
-      ->shouldBeCalled();
-    return $ideDeleteResponse;
   }
 
   protected function mockLogStreamRequest(): object {


### PR DESCRIPTION
Fix #1386 

@mikemadison13 @anavarre any opinions about this as a solution to avoiding confusion about documented commands?

Most of the hidden commands (i.e., `pull:files`) were only hidden because they required a db connection that was only set in an IDE. But we now have environment variables like ACLI_DB_HOST that anyone could set locally if they really wanted.

This unhides those commands and instead advises via help text that these variables should be set:
![Screenshot 2023-05-31 at 10 50 51 AM](https://github.com/acquia/cli/assets/1984514/1d3ff811-5215-42c8-9c61-1bca24af0daf)

We still hide truly IDE-specific commands (i.e., `ide:service-restart`). Hopefully the reason is obvious enough that people aren't still confused.