### PR TITLE
Fixes output of usage example for task-wait command

### DIFF
--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -17,7 +17,7 @@ class TaskWaitCommand extends CommandBase {
     $this->setDescription('Wait for a task to complete')
       ->addArgument('notification-uuid', InputArgument::REQUIRED, 'The task notification UUID or Cloud Platform API response containing a linked notification')
       ->setHelp('Accepts either a notification UUID or Cloud Platform API response as JSON string. The JSON string must contain the _links->notification->href property.')
-      ->addUsage('acli app:task-wait "$(api:environments:domain-clear-caches [environmentId] [domain])"');
+      ->addUsage(self::getDefaultName() . ' "$(api:environments:domain-clear-caches [environmentId] [domain])"');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {


### PR DESCRIPTION
**Motivation**
The example usage help output for `app:task-wait` is wrong - it repeats the command separated by `acli`.

Currently (note the second example):
```
Usage:
  app:task-wait <notification-uuid>
  app:task-wait acli app:task-wait "$(api:environments:domain-clear-caches [environmentId] [domain])"
```

**Proposed changes**
This is due to the hard-coded argument zero (/command name) being passed to `Command::addUsage`. From the `addUsage` method comments:

> Add a command usage example, **it'll be prefixed with the command name**.


**Testing steps**
Compare the output of `acli help app:task-wait` before and after applying this patch.

Before:
```
app:task-wait acli app:task-wait "$(api:environments:domain-clear-caches [environmentId] [domain])"
```

After:
```
app:task-wait "$(api:environments:domain-clear-caches [environmentId] [domain])"
```
