### PR TITLE
Throw exception if userAlias not found

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1064,7 +1064,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
     // If there are no members.
     if (count($orgMembers) === 0) {
-      return $userAlias;
+      throw new AcquiaCliException('Organization has no members');
     }
 
     foreach ($orgMembers as $member) {
@@ -1074,7 +1074,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       }
     }
 
-    return $userAlias;
+    throw new AcquiaCliException('No matching user found in this organization');
   }
 
   protected function convertApplicationAliasToUuid(InputInterface $input): void {


### PR DESCRIPTION
Right now if you pass an email address as user alias and that email doesn't match someone in the org you get a confusing error message from the API:

```
{
    "error": "invalid_id",
    "message": "\"somebody@danepowell.com\" is not a valid v4 UUID."
}
```

ACLI should not pass an argument to the API that it knows to be invalid (i.e., not a UUID).

@joshirohit100 would you mind reviewing since you wrote this?