### PR TITLE
CLI-1072: [push:artifact] source and dest branches must be different

### DIFF
--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -79,6 +79,10 @@ class PushArtifactCommand extends PullCommandBase {
     $destinationGitRef = $this->determineDestinationGitRef();
     $sourceGitBranch = $this->determineSourceGitRef();
 
+    if ($destinationGitRef === $sourceGitBranch) {
+      throw new AcquiaCliException('Source and destination Git branches must be different');
+    }
+
     $destinationGitUrlsString = implode(',', $destinationGitUrls);
     $refType = $this->input->getOption('destination-git-tag') ? 'tag' : 'branch';
     $this->io->note([


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->

Using the same source and dest Git branches produces an error: `Could not checkout master branch locally: fatal: a branch named 'master' already exists`

This is not a supported use case. `push:artifact` builds from a source branch and pushes to an artifact branch. If the branches are the same, they are in conflict.

If the source and destination repos are different but the branch names are the same, this might create a false positive. I don't know what should happen in that case.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
