### PR TITLE
CLI-1101: Set exit code 1 when a task waited command fails

### DIFF
--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -28,8 +28,13 @@ class TaskWaitCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $notificationUuid = $this->getNotificationUuid($input);
-    $this->waitForNotificationToComplete($this->cloudApiClientService->getClient(), $notificationUuid, "Waiting for task $notificationUuid to complete");
-    return Command::SUCCESS;
+    $success = $this->waitForNotificationToComplete($this->cloudApiClientService->getClient(), $notificationUuid, "Waiting for task $notificationUuid to complete");
+    if ($success) {
+      return Command::SUCCESS;
+    }
+    else {
+      return Command::FAILURE;
+    }
   }
 
   private function getNotificationUuid(InputInterface $input): string {

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1436,7 +1436,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     }
   }
 
-  protected function waitForNotificationToComplete(Client $acquiaCloudClient, string $uuid, string $message, callable $success = NULL): void {
+  protected function waitForNotificationToComplete(Client $acquiaCloudClient, string $uuid, string $message, callable $success = NULL): bool {
     $notificationsResource = new Notifications($acquiaCloudClient);
     $notification = NULL;
     $checkNotificationStatus = static function () use ($notificationsResource, &$notification, $uuid): bool {
@@ -1449,6 +1449,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       };
     }
     LoopHelper::getLoopy($this->output, $this->io, $this->logger, $message, $checkNotificationStatus, $success);
+    return $notification->status === 'completed';
   }
 
   private function writeCompletedMessage(NotificationResponse $notification): void {

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -21,7 +21,7 @@ class TaskWaitCommandTest extends CommandTestBase {
   /**
    * @dataProvider providerTestTaskWaitCommand
    */
-  public function testTaskWaitCommand(string $status, string $message): void {
+  public function testTaskWaitCommand(string $status, string $message, int $statusCode): void {
     $notificationUuid = '94835c3e-b112-4660-a14d-d541906c205b';
     $this->mockNotificationResponse($notificationUuid, $status);
     $this->executeCommand([
@@ -36,6 +36,7 @@ class TaskWaitCommandTest extends CommandTestBase {
     $this->assertStringContainsString('Completed: Mon Jul 29 20:47:13 UTC 2019', $output);
     $this->assertStringContainsString('Task type: Application added to recents list', $output);
     $this->assertStringContainsString('Duration: 0 seconds', $output);
+    $this->assertEquals($statusCode, $this->getStatusCode());
   }
 
   /**
@@ -46,10 +47,12 @@ class TaskWaitCommandTest extends CommandTestBase {
       [
         'completed',
         ' [OK] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 completed',
+        Command::SUCCESS,
       ],
       [
         'failed',
         ' [ERROR] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 failed',
+        Command::FAILURE,
       ],
     ];
   }


### PR DESCRIPTION
**Motivation**

Fixes #1556 

**Proposed changes**

Returns an exit code `1` when a notification executed via `task-wait` has any status other than `completed`.

**Alternatives considered**

One could alternatively retrieve the notification UUID from the initial command response, run `task-wait` with that, and then use `api:notifications:find` to confirm task completed.

**Testing steps**

From `main` attempt to `code-switch` an environment to a non-existent branch. Observe the notification fails and the exit code is `0`.

```
> acli -nq app:task-wait "$(acli -n api:environments:code-switch "$ACQUIA_SITE_GROUP".prod "$RELEASE_TAG")"
Acquia CLI 2.12.3 is available. Run acli self-update to update.
    ✔ Waiting for task d109e8f6-bed1-4fa4-bc28-4b57f5030a36 to complete

                                                                                                                        
 [ERROR] The task with notification uuid d109e8f6-bed1-4fa4-bc28-4b57f5030a36 failed                                    
                                                                                                                        

Progress: 0
Completed: Wed Jun 28 19:43:55 UTC 2023
Task type: Code switched
Duration: 17 seconds
> echo $?
0
```

From this branch attempt the same operation. Observe the notification fails and the exit code is `1`:

```
> ./bin/acli -nq app:task-wait "$(acli -n api:environments:code-switch "$ACQUIA_SITE_GROUP".test "$RELEASE_TAG")"
    ✔ Waiting for task 4005fa35-a16f-40bd-8a3b-4556e8db267f to complete

                                                                                                                        
 [ERROR] The task with notification uuid 4005fa35-a16f-40bd-8a3b-4556e8db267f failed                                    
                                                                                                                        

Progress: 0
Completed: Fri Jun 30 16:52:37 UTC 2023
Task type: Code switched
Duration: 16 seconds
> echo $?
1
```

Also test with a valid branch. Observe the notification completes and the exit code is `0`:

```
> ./bin/acli -nq app:task-wait "$(acli -n api:environments:code-switch "$ACQUIA_SITE_GROUP".test "$RELEASE_TAG")"
    ✔ Waiting for task 3843c64c-3eb3-4c0d-afdb-b1c3e4a7a278 to complete

                                                                                                                        
 [OK] The task with notification uuid 3843c64c-3eb3-4c0d-afdb-b1c3e4a7a278 completed                                    
                                                                                                                        

Progress: 100
Completed: Fri Jun 30 16:56:53 UTC 2023
Task type: Code switched
Duration: 16 seconds
> echo $?
0
```
