### PR TITLE
CLI-1103: Fix #1558: Notification arg formats

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1533,7 +1533,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       self::validateUuid($matches[1]);
       return $matches[1];
     }
-    throw new AcquiaCliException('Notification UUID not found in URL: {url}', ['url' => $notificationUrl]);
+    throw new AcquiaCliException('Notification UUID not found in URL');
   }
 
   protected function validateRequiredCloudPermissions(Client $acquiaCloudClient, ?string $cloudApplicationUuid, AccountResponse $account, array $requiredPermissions): void {

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1048,7 +1048,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return $userUuidArgument;
   }
 
-  private function getNotificationUuid(string $notification): string {
+  private static function getNotificationUuid(string $notification): string {
     // Greedily hope this is already a UUID.
     try {
       self::validateUuid($notification);
@@ -1120,7 +1120,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected function convertNotificationToUuid(InputInterface $input, string $argumentName): void {
     if ($input->hasArgument($argumentName) && $input->getArgument($argumentName)) {
       $notificationArgument = $input->getArgument($argumentName);
-      $notificationUuid = $this->getNotificationUuid($notificationArgument);
+      $notificationUuid = CommandBase::getNotificationUuid($notificationArgument);
       $input->setArgument($argumentName, $notificationUuid);
     }
   }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1059,7 +1059,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
 
     // Not a UUID, maybe a JSON object?
     try {
-      $json = json_decode($notification, FALSE, 512, JSON_THROW_ON_ERROR);
+      $json = json_decode($notification, NULL, 4, JSON_THROW_ON_ERROR);
       return CommandBase::getNotificationUuidFromResponse($json);
     }
     catch (JsonException | AcquiaCliException) {
@@ -1274,7 +1274,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
         '--no-interaction',
       ], $outputCallback, $this->dir, FALSE);
       if ($process->isSuccessful()) {
-        $drushStatusReturnOutput = json_decode($process->getOutput(), TRUE, 512);
+        $drushStatusReturnOutput = json_decode($process->getOutput(), TRUE);
         if (is_array($drushStatusReturnOutput) && array_key_exists('db-status', $drushStatusReturnOutput) && $drushStatusReturnOutput['db-status'] === 'Connected') {
           $this->drushHasActiveDatabaseConnection = TRUE;
           return $this->drushHasActiveDatabaseConnection;

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1527,7 +1527,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     throw new AcquiaCliException('JSON object must contain the _links.notification.href property');
   }
 
-  public static function getNotificationUuidFromUrl(string $notificationUrl): string {
+  private static function getNotificationUuidFromUrl(string $notificationUrl): string {
     $notificationUrlPattern = '/^https:\/\/cloud.acquia.com\/api\/notifications\/([\w-]*)$/';
     if (preg_match($notificationUrlPattern, $notificationUrl, $matches)) {
       self::validateUuid($matches[1]);

--- a/src/Command/Env/EnvCertCreateCommand.php
+++ b/src/Command/Env/EnvCertCreateCommand.php
@@ -52,7 +52,7 @@ class EnvCertCreateCommand extends CommandBase {
       $csrId,
       $legacy
     );
-    $notificationUuid = $this->getNotificationUuidFromResponse($response);
+    $notificationUuid = CommandBase::getNotificationUuidFromResponse($response);
     $this->waitForNotificationToComplete($acquiaCloudClient, $notificationUuid, 'Installing certificate');
     return Command::SUCCESS;
   }

--- a/src/Command/Env/EnvCreateCommand.php
+++ b/src/Command/Env/EnvCreateCommand.php
@@ -46,7 +46,7 @@ class EnvCreateCommand extends CommandBase {
 
     $this->checklist->addItem("Initiating environment creation");
     $response = $environmentsResource->create($cloudAppUuid, $label, $branch, $databaseNames);
-    $notificationUuid = $this->getNotificationUuidFromResponse($response);
+    $notificationUuid = CommandBase::getNotificationUuidFromResponse($response);
     $this->checklist->completePreviousItem();
 
     $success = function () use ($environmentsResource, $cloudAppUuid, $label): void {

--- a/src/Command/Env/EnvMirrorCommand.php
+++ b/src/Command/Env/EnvMirrorCommand.php
@@ -80,16 +80,16 @@ class EnvMirrorCommand extends CommandBase {
     }
 
     if (isset($codeCopyResponse)) {
-      $this->waitForNotificationToComplete($acquiaCloudClient, $this->getNotificationUuidFromResponse($codeCopyResponse), 'Waiting for code copy to complete');
+      $this->waitForNotificationToComplete($acquiaCloudClient, CommandBase::getNotificationUuidFromResponse($codeCopyResponse), 'Waiting for code copy to complete');
     }
     if (isset($dbCopyResponse)) {
-      $this->waitForNotificationToComplete($acquiaCloudClient, $this->getNotificationUuidFromResponse($dbCopyResponse), 'Waiting for database copy to complete');
+      $this->waitForNotificationToComplete($acquiaCloudClient, CommandBase::getNotificationUuidFromResponse($dbCopyResponse), 'Waiting for database copy to complete');
     }
     if (isset($filesCopyResponse)) {
-      $this->waitForNotificationToComplete($acquiaCloudClient, $this->getNotificationUuidFromResponse($filesCopyResponse), 'Waiting for files copy to complete');
+      $this->waitForNotificationToComplete($acquiaCloudClient, CommandBase::getNotificationUuidFromResponse($filesCopyResponse), 'Waiting for files copy to complete');
     }
     if (isset($configCopyResponse)) {
-      $this->waitForNotificationToComplete($acquiaCloudClient, $this->getNotificationUuidFromResponse($configCopyResponse), 'Waiting for config copy to complete');
+      $this->waitForNotificationToComplete($acquiaCloudClient, CommandBase::getNotificationUuidFromResponse($configCopyResponse), 'Waiting for config copy to complete');
     }
 
     $this->io->success([

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -344,20 +344,9 @@ abstract class CommandTestBase extends TestBase {
     return $backupCreateResponse;
   }
 
-  protected function mockNotificationResponseFromObject(object $responseWithNotificationLink): mixed {
-    return $this->mockNotificationResponse(substr($responseWithNotificationLink->_links->notification->href, -36));
-  }
-
-  protected function mockNotificationResponse(string $notificationUuid, string $status = NULL): mixed {
-    $notificationResponse = $this->getMockResponseFromSpec('/notifications/{notificationUuid}', 'get', 200);
-    if ($status) {
-      $notificationResponse->status = $status;
-    }
-    $this->clientProphecy->request('get', "/notifications/$notificationUuid")
-      ->willReturn($notificationResponse)
-      ->shouldBeCalled();
-
-    return $notificationResponse;
+  protected function mockNotificationResponseFromObject(object $responseWithNotificationLink): array|object {
+    $uuid = substr($responseWithNotificationLink->_links->notification->href, -36);
+    return $this->mockRequest('getNotificationByUuid', $uuid);
   }
 
   protected function mockCreateMySqlDumpOnLocal(ObjectProphecy $localMachineHelper): void {

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
@@ -79,7 +79,7 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
         // Arguments.
         [],
         // Output to assert.
-        "Acquia CLI is now logged in to {$this->acsfCurrentFactoryUrl} as {$this->acsfUsername}",
+        "Acquia CLI is now logged in to $this->acsfCurrentFactoryUrl as $this->acsfUsername",
         // $config.
         $this->getAcsfCredentialsFileContents(),
       ],
@@ -88,14 +88,9 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase {
 
   /**
    * @dataProvider providerTestAuthLoginCommand
-   * @param $machineIsAuthenticated
-   * @param $inputs
-   * @param $args
-   * @param $outputToAssert
-   * @param array $config
    * @requires OS linux|darwin
    */
-  public function testAcsfAuthLoginCommand(mixed $machineIsAuthenticated, mixed $inputs, mixed $args, mixed $outputToAssert, array $config = []): void {
+  public function testAcsfAuthLoginCommand(bool $machineIsAuthenticated, array $inputs, array $args, string $outputToAssert, array $config = []): void {
     if (!$machineIsAuthenticated) {
       $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
       $this->removeMockCloudConfigFile();

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -56,6 +56,8 @@ class TaskWaitCommandTest extends CommandTestBase {
   }
 
   /**
+   * Valid notifications.
+   *
    * @return (string|int)[][]
    */
   public function providerTestTaskWaitCommand(): array {
@@ -93,10 +95,32 @@ EOT,
     $this->prophet->checkPredictions();
   }
 
-  public function testTaskWaitCommandWithInvalidJson(): void {
+  public function testTaskWaitCommandWithInvalidUrl(): void {
+    $this->expectException(AcquiaCliException::class);
+    $this->expectExceptionMessage('Notification format is not one of UUID, JSON response, or URL');
+    $this->executeCommand(['notification-uuid' => 'https://cloud.acquia.com/api/notifications/foo']);
+
+    // Assert.
+    $this->prophet->checkPredictions();
+  }
+
+  /**
+   * @dataProvider providerTestTaskWaitCommandWithInvalidJson
+   */
+  public function testTaskWaitCommandWithInvalidJson(string $notification): void {
     $this->expectException(AcquiaCliException::class);
     $this->executeCommand([
-      'notification-uuid' => <<<'EOT'
+      'notification-uuid' => $notification,
+    ]);
+  }
+
+  /**
+   * @return string[]
+   */
+  public function providerTestTaskWaitCommandWithInvalidJson(): array {
+    return [
+      [
+      <<<'EOT'
 {
   "message": "Caches are being cleared.",
   "_links": {
@@ -112,7 +136,18 @@ EOT,
   }
 }
 EOT,
-    ]);
+      <<<'EOT'
+{
+  "message": "Caches are being cleared.",
+  "_links": {
+    "self": {
+      "href": "https://cloud.acquia.com/api/environments/12-d314739e-296f-11e9-b210-d663bd873d93/domains/example.com/actions/clear-caches"
+    }
+  }
+}
+EOT,
+        ],
+    ];
   }
 
 }

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -120,7 +120,7 @@ EOT,
   public function providerTestTaskWaitCommandWithInvalidJson(): array {
     return [
       [
-      <<<'EOT'
+        <<<'EOT'
 {
   "message": "Caches are being cleared.",
   "_links": {
@@ -136,7 +136,9 @@ EOT,
   }
 }
 EOT,
-      <<<'EOT'
+      ],
+      [
+        <<<'EOT'
 {
   "message": "Caches are being cleared.",
   "_links": {
@@ -146,7 +148,7 @@ EOT,
   }
 }
 EOT,
-        ],
+      ],
     ];
   }
 

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -84,12 +84,35 @@ EOT,
     ];
   }
 
-  public function testTaskWaitCommandWithInvalidInput(): void {
+  public function testTaskWaitCommandWithEmptyJson(): void {
     $this->expectException(AcquiaCliException::class);
+    $this->expectExceptionMessage('Notification format is not one of UUID, JSON response, or URL');
     $this->executeCommand(['notification-uuid' => '{}']);
 
     // Assert.
     $this->prophet->checkPredictions();
+  }
+
+  public function testTaskWaitCommandWithInvalidJson(): void {
+    $this->expectException(AcquiaCliException::class);
+    $this->executeCommand([
+      'notification-uuid' => <<<'EOT'
+{
+  "message": "Caches are being cleared.",
+  "_links": {
+    "self": {
+      "href": "https://cloud.acquia.com/api/environments/12-d314739e-296f-11e9-b210-d663bd873d93/domains/example.com/actions/clear-caches",
+      "invalid": {
+        "too-deep": "5"
+      }
+    },
+    "notification": {
+      "href": "https://cloud.acquia.com/api/notifications/1bd3487e-71d1-4fca-a2d9-5f969b3d35c1"
+    }
+  }
+}
+EOT,
+    ]);
   }
 
 }

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -21,50 +21,67 @@ class TaskWaitCommandTest extends CommandTestBase {
   /**
    * @dataProvider providerTestTaskWaitCommand
    */
-  public function testTaskWaitCommand(string $status, string $message, int $statusCode): void {
-    $notificationUuid = '94835c3e-b112-4660-a14d-d541906c205b';
-    $this->mockNotificationResponse($notificationUuid, $status);
+  public function testTaskWaitCommand(string $notification): void {
+    $notificationUuid = '1bd3487e-71d1-4fca-a2d9-5f969b3d35c1';
+    $this->mockRequest('getNotificationByUuid', $notificationUuid);
     $this->executeCommand([
-      'notification-uuid' => $notificationUuid,
+      'notification-uuid' => $notification,
     ]);
-
-    // Assert.
     $this->prophet->checkPredictions();
     $output = $this->getDisplay();
-    self::assertStringContainsString($message, $output);
+    self::assertStringContainsString(' [OK] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 completed', $output);
     $this->assertStringContainsString('Progress: 100', $output);
     $this->assertStringContainsString('Completed: Mon Jul 29 20:47:13 UTC 2019', $output);
     $this->assertStringContainsString('Task type: Application added to recents list', $output);
     $this->assertStringContainsString('Duration: 0 seconds', $output);
-    $this->assertEquals($statusCode, $this->getStatusCode());
+    $this->assertEquals(Command::SUCCESS, $this->getStatusCode());
+  }
+
+  public function testTaskWaitCommandWithFailedTask(): void {
+    $notificationUuid = '1bd3487e-71d1-4fca-a2d9-5f969b3d35c1';
+    $this->mockRequest(
+      'getNotificationByUuid',
+      $notificationUuid,
+      NULL,
+      NULL,
+      function ($response): void {
+        $response->status = 'failed';}
+    );
+    $this->executeCommand([
+      'notification-uuid' => $notificationUuid,
+    ]);
+    $this->prophet->checkPredictions();
+    self::assertStringContainsString(' [ERROR] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 failed', $this->getDisplay());
+    $this->assertEquals(Command::FAILURE, $this->getStatusCode());
   }
 
   /**
-   * @return array<mixed>
+   * @return (string|int)[][]
    */
   public function providerTestTaskWaitCommand(): array {
     return [
       [
-        'completed',
-        ' [OK] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 completed',
-        Command::SUCCESS,
+        '1bd3487e-71d1-4fca-a2d9-5f969b3d35c1',
       ],
       [
-        'failed',
-        ' [ERROR] The task with notification uuid 1bd3487e-71d1-4fca-a2d9-5f969b3d35c1 failed',
-        Command::FAILURE,
+        'https://cloud.acquia.com/api/notifications/1bd3487e-71d1-4fca-a2d9-5f969b3d35c1',
+      ],
+      [
+        <<<'EOT'
+{
+  "message": "Caches are being cleared.",
+  "_links": {
+    "self": {
+      "href": "https://cloud.acquia.com/api/environments/12-d314739e-296f-11e9-b210-d663bd873d93/domains/example.com/actions/clear-caches"
+    },
+    "notification": {
+      "href": "https://cloud.acquia.com/api/notifications/1bd3487e-71d1-4fca-a2d9-5f969b3d35c1"
+    }
+  }
+}
+EOT,
       ],
     ];
-  }
-
-  public function testTaskWaitCommandWithStandardInput(): void {
-    $taskResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/domains/{domain}/actions/clear-caches', 'post', 202);
-    $this->mockNotificationResponseFromObject($taskResponse->{'Clearing cache'}->value);
-    $json = json_encode($taskResponse->{'Clearing cache'}->value);
-    $this->executeCommand(['notification-uuid' => $json]);
-
-    // Assert.
-    $this->prophet->checkPredictions();
   }
 
   public function testTaskWaitCommandWithInvalidInput(): void {


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #1558

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Anywhere that a notification UUID is required as argument, support passing a notification object or URL as well. This basically generalizes the `getNotificationUuid` logic in app:task-wait to all commands.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Try `acli app:task-wait` with various forms of arguments to ensure they still work:

```
# Notifications object response
wacli app:task-wait "$(acli api:environments:domain-clear-caches pipelinesvalidation2.dev pipelinesvalidation2dev.prod.acquia-sites.com)"
# Notification UUID
wacli app:task-wait 227eccb1-3345-4a2d-b042-eddd56a78ed7
# Notification URL
wacli app:task-wait https:\/\/cloud.acquia.com\/api\/notifications\/64df4412-20fa-4489-8cbf-1e73095d03eb
```

@cdubz could you please help test and let me know if it satisfies your request? If you follow the steps above, you can find a pre-built version of CLI for this PR to test with, or you can build it yourself.