### PR TITLE
Set code studio default env variable values to be masked

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -20,28 +20,28 @@ class CodeStudioCiCdVariables {
     return [
       [
         'key' => 'ACQUIA_APPLICATION_UUID',
-        'masked'  => FALSE,
+        'masked' => TRUE,
         'protected' => FALSE,
         'value' => $cloudApplicationUuid,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_CLOUD_API_TOKEN_KEY',
-        'masked' => FALSE,
+        'masked' => TRUE,
         'protected' => FALSE,
         'value' => $cloudKey,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_CLOUD_API_TOKEN_SECRET',
-        'masked' => FALSE,
+        'masked' => TRUE,
         'protected' => FALSE,
         'value' => $cloudSecret,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_GLAB_TOKEN_NAME',
-        'masked' => FALSE,
+        'masked' => TRUE,
         'protected' => FALSE,
         'value' => $projectAccessTokenName,
         'variable_type' => 'env_var',

--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -20,28 +20,28 @@ class CodeStudioCiCdVariables {
     return [
       [
         'key' => 'ACQUIA_APPLICATION_UUID',
-        'masked' => FALSE,
+        'masked' => TRUE,
         'protected' => FALSE,
         'value' => $cloudApplicationUuid,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_CLOUD_API_TOKEN_KEY',
-        'masked' => FALSE,
+        'masked' => TRUE,
         'protected' => FALSE,
         'value' => $cloudKey,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_CLOUD_API_TOKEN_SECRET',
-        'masked' => FALSE,
+        'masked' => TRUE,
         'protected' => FALSE,
         'value' => $cloudSecret,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_GLAB_TOKEN_NAME',
-        'masked' => FALSE,
+        'masked' => TRUE,
         'protected' => FALSE,
         'value' => $projectAccessTokenName,
         'variable_type' => 'env_var',

--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -20,28 +20,28 @@ class CodeStudioCiCdVariables {
     return [
       [
         'key' => 'ACQUIA_APPLICATION_UUID',
-        'masked' => TRUE,
+        'masked' => FALSE,
         'protected' => FALSE,
         'value' => $cloudApplicationUuid,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_CLOUD_API_TOKEN_KEY',
-        'masked' => TRUE,
+        'masked' => FALSE,
         'protected' => FALSE,
         'value' => $cloudKey,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_CLOUD_API_TOKEN_SECRET',
-        'masked' => TRUE,
+        'masked' => FALSE,
         'protected' => FALSE,
         'value' => $cloudSecret,
         'variable_type' => 'env_var',
       ],
       [
         'key' => 'ACQUIA_GLAB_TOKEN_NAME',
-        'masked' => TRUE,
+        'masked' => FALSE,
         'protected' => FALSE,
         'value' => $projectAccessTokenName,
         'variable_type' => 'env_var',

--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -20,7 +20,7 @@ class CodeStudioCiCdVariables {
     return [
       [
         'key' => 'ACQUIA_APPLICATION_UUID',
-        'masked' => FALSE,
+        'masked'  => FALSE,
         'protected' => FALSE,
         'value' => $cloudApplicationUuid,
         'variable_type' => 'env_var',

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -621,7 +621,7 @@ abstract class CommandTestBase extends TestBase {
       0 => [
           'environment_scope' => '*',
           'key' => 'ACQUIA_APPLICATION_UUID',
-          'masked' => FALSE,
+          'masked' => TRUE,
           'protected' => FALSE,
           'value' => '2b3f7cf0-6602-4590-948b-3b07b1b005ef',
           'variable_type' => 'env_var',
@@ -629,7 +629,7 @@ abstract class CommandTestBase extends TestBase {
       1 => [
           'environment_scope' => '*',
           'key' => 'ACQUIA_CLOUD_API_TOKEN_KEY',
-          'masked' => FALSE,
+          'masked' => TRUE,
           'protected' => FALSE,
           'value' => '111aae74-e81a-4052-b4b9-a27a62e6b6a6',
           'variable_type' => 'env_var',

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -621,7 +621,7 @@ abstract class CommandTestBase extends TestBase {
       0 => [
           'environment_scope' => '*',
           'key' => 'ACQUIA_APPLICATION_UUID',
-          'masked' => TRUE,
+          'masked' => FALSE,
           'protected' => FALSE,
           'value' => '2b3f7cf0-6602-4590-948b-3b07b1b005ef',
           'variable_type' => 'env_var',
@@ -629,7 +629,7 @@ abstract class CommandTestBase extends TestBase {
       1 => [
           'environment_scope' => '*',
           'key' => 'ACQUIA_CLOUD_API_TOKEN_KEY',
-          'masked' => TRUE,
+          'masked' => FALSE,
           'protected' => FALSE,
           'value' => '111aae74-e81a-4052-b4b9-a27a62e6b6a6',
           'variable_type' => 'env_var',


### PR DESCRIPTION
**Motivation**
Recently we found that code studio environment variables like `TOKEN_KEY, TOKEN_SECRET` are being logged in  sumo logic in plain text format, which is a security concern.
Fixes GL-1377

**Proposed changes**
In order to avoid logging env variable values in clear text format, we will be masking code studio default env variable.
In this PR we will setting all default env variable values as `masked`.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
You can replicate this issue by creating a new project for code studio and check the env variables values under CI/CD variable. You will see currently default env values is not masked except `ACQUIA_GLAB_TOKEN_SECRET`.

Once these changes are deployed then you can verify the changes by creating a new project for code studio and run a pipeline with printing the default variables inside it. Now verify the job logs, You should not see value of default env variables in job logs. 
