### PR TITLE
d.o's GitLab instance 403s if `User-Agent` is absent or empty

### DIFF
--- a/src/Command/App/NewFromDrupal7Command.php
+++ b/src/Command/App/NewFromDrupal7Command.php
@@ -148,6 +148,9 @@ class NewFromDrupal7Command extends CommandBase {
         return Command::FAILURE;
       }
     }
+    // PHP defaults to no user agent. (Drupal.org's) GitLab requires it.
+    // @see https://www.php.net/manual/en/filesystem.configuration.php#ini.user-agent
+    ini_set('user_agent', 'ACLI');
     $recommendations_resource = fopen($recommendations_location, 'r');
     $recommendations = Recommendations::createFromResource($recommendations_resource);
     fclose($recommendations_resource);


### PR DESCRIPTION
**Motivation**
#1543 added `acli app:new:from:drupal7`. 👍  Next steps in open sourcing: https://git.drupalcode.org/project/acquia_migrate/-/tree/recommendations is live.

So now let's get it all working together. Unfortunately, this made me hit an edge case in GitLab and/or PHP.


Ideally, we'd get the command to automatically download the latest, to allow you to omit `--recommendations`. But as an MVP, we can do:
```
./bin/acli app:new:from:drupal7 --directory=/tmp/foo --recommendations=https://git.drupalcode.org/project/acquia_migrate/-/raw/recommendations/recommendations.json --stored-analysis tests/fixtures/drupal7/training.acquia.com/extensions.json 
```

Unfortunately, this is the output:
```
🤖 Scanning Drupal 7 site.
👍 Found Drupal 7 site (7.70 to be precise) at <location unknown>, with 96 modules enabled!
PHP Warning:  fopen(https://git.drupalcode.org/project/acquia_migrate/-/raw/recommendations/recommendations.json?ref_type=heads): Failed to open stream: HTTP request failed! HTTP/1.1 403 Forbidden.
 in /Users/wim.leers/cli/src/Command/App/NewFromDrupal7Command.php on line 151
…
```

**Proposed changes**
```
+    // PHP defaults to no user agent. (Drupal.org's) GitLab requires it.
+    // @see https://www.php.net/manual/en/filesystem.configuration.php#ini.user-agent
+    ini_set('user_agent', 'ACLI');
     $recommendations_resource = fopen($recommendations_location, 'r');
```
☝️ That's literally the whole PR! 😄 

**Alternatives considered**
Impossible.

**Testing steps**
```
curl -A "" https://git.drupalcode.org/project/acquia_migrate/-/raw/recommendations/recommendations.json

<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html>
  <head>
    <title>403 Forbidden.</title>
  </head>
  <body>
    <h1>Error 403 Forbidden.</h1>
    <p>Forbidden.</p>
    <h3>Error 54113</h3>
    <p>Details: cache-bru1480054-BRU 1693583048 3782263104</p>
    <hr>
    <p>Varnish cache server</p>
  </body>
</html>
```
vs
```
curl -A "ACLI" https://git.drupalcode.org/project/acquia_migrate/-/raw/recommendations/recommendations.json
{
    "data": [
        {
            "package": null,
……………………
}
```