### PR TITLE
Make `acli app:new:from:drupal7` default to the latest AMA recommendations on d.o

### DIFF
--- a/src/Command/App/NewFromDrupal7Command.php
+++ b/src/Command/App/NewFromDrupal7Command.php
@@ -137,7 +137,7 @@ class NewFromDrupal7Command extends CommandBase {
     fclose($config_resource);
 
     // Parse recommendations for project builder.
-    $recommendations_location = __DIR__ . '/../../../config/from_d7_recommendations.json';
+    $recommendations_location = "https://git.drupalcode.org/project/acquia_migrate/-/raw/recommendations/recommendations.json";
     if ($input->getOption('recommendations') !== NULL) {
       $raw_recommendations_location = $input->getOption('recommendations');
       try {

--- a/src/Command/App/NewFromDrupal7Command.php
+++ b/src/Command/App/NewFromDrupal7Command.php
@@ -148,6 +148,9 @@ class NewFromDrupal7Command extends CommandBase {
         return Command::FAILURE;
       }
     }
+    // PHP defaults to no user agent. (Drupal.org's) GitLab requires it.
+    // @see https://www.php.net/manual/en/filesystem.configuration.php#ini.user-agent
+    ini_set('user_agent', 'ACLI');
     $recommendations_resource = fopen($recommendations_location, 'r');
     $recommendations = Recommendations::createFromResource($recommendations_resource);
     fclose($recommendations_resource);


### PR DESCRIPTION
**Motivation**
#1543 added `acli app:new:from:drupal7`. 👍  Next steps in open sourcing: https://git.drupalcode.org/project/acquia_migrate/-/tree/recommendations is live.

So now let's get it all working together. Unfortunately, this made me hit an edge case in GitLab and/or PHP. I opened #1587 for that.

**Ideally, we'd get the command to automatically download the latest, to allow you to omit `--recommendations`.**

That'd be a much better UX than having to specify a long URL manually.

**Proposed changes**

Defaulting to automatically downloading the latest is a one-line change:
```
-    $recommendations_location = __DIR__ . '/../../../config/from_d7_recommendations.json';
+    $recommendations_location = "https://git.drupalcode.org/project/acquia_migrate/-/raw/recommendations/recommendations.json";
```

(plus the bugfix in #1587)

```
+    // PHP defaults to no user agent. (Drupal.org's) GitLab requires it.
+    // @see https://www.php.net/manual/en/filesystem.configuration.php#ini.user-agent
+    ini_set('user_agent', 'ACLI');
     $recommendations_resource = fopen($recommendations_location, 'r');
```
☝️ That's literally the whole PR! 😄 

**Alternatives considered**
#1587 is the absolute minimum.

**Testing steps**
Before:
```
$ ./bin/acli app:new:from:drupal7 --directory=/tmp/foo  --stored-analysis tests/fixtures/drupal7/training.acquia.com/extensions.json 
🤖 Scanning Drupal 7 site.
👍 Found Drupal 7 site (7.70 to be precise) at <location unknown>, with 96 modules enabled!
🤖 Computing recommendations for this Drupal 7 site…
🥳 Great news: found 9 recommendations that apply to this Drupal 7 site, resulting in a composer.json with:
	- 11 packages
	- 1 patches
	- 4 modules to be installed!
🚀 Generated composer.json and committed to a new git repo.
…
```

After:
```
$ ./bin/acli app:new:from:drupal7 --directory=/tmp/foo  --stored-analysis tests/fixtures/drupal7/training.acquia.com/extensions.json 
🤖 Scanning Drupal 7 site.
👍 Found Drupal 7 site (7.70 to be precise) at <location unknown>, with 96 modules enabled!
🤖 Computing recommendations for this Drupal 7 site…
🥳 Great news: found 105 recommendations that apply to this Drupal 7 site, resulting in a composer.json with:
	- 46 packages
	- 1 patches
	- 64 modules to be installed!
🚀 Generated composer.json and committed to a new git repo.
…
```

Note: 11 → 46 packages, 4 → 64 modules!