### PR TITLE
Make `acli app:new:from:drupal7` defer entirely to the recommendations

### DIFF
--- a/config/from_d7_config.json
+++ b/config/from_d7_config.json
@@ -9,7 +9,6 @@
       }
     ],
     "require": {
-      "acquia/acquia-migrate-accelerate": "^1@dev",
       "composer/installers": "^1.9",
       "cweagans/composer-patches": "^1.7",
       "drupal/core-composer-scaffold": "9.0.1",


### PR DESCRIPTION
**Motivation**
For historical reasons, the predecessor of `acli app:new:from:drupal7` had to hardcode the package containing the AM:A Drupal module.

That is still there. It's never gotten in the way.

Until now.

Because `config/from_d7_config.json` is hardcoded to list `acquia/acquia-migrate-accelerate` in its project template, the recommendations that we will have at https://git.drupalcode.org/project/acquia_migrate/-/tree/recommendations will generate a project that continues to install the packagist/closed source AMA retrieved from GitHub instead of the open source AMA source retrieved from d.o’s packagist facade.

IOW, both of these will exist in the generated `composer.json`:
- `acquia/acquia-migrate-accelerate` 
- `drupal/acquia_migrate` (once it exists)

Clearly we shouldn't install the same module twice.

**Proposed changes**
Remove `acquia/acquia-migrate-accelerate` from the template.

**Alternatives considered**
/

**Testing steps**
If the [integration test](https://github.com/acquia/cli/blob/main/tests/phpunit/src/Commands/App/NewFromDrupal7CommandTest.php) still passes (which it will 👍 ), you'll know it's working correctly: because `config/from_d7_recommendations.json` is now the only place where `acquia/acquia-migrate-accelerate` is explicitly defined!
