### PR TITLE
Added prompt for php version for cs:wizard command

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -16,7 +16,7 @@ class CodeStudioCiCdVariables {
   /**
    * @return array<mixed>
    */
-  public static function getDefaults(?string $cloudApplicationUuid = NULL, ?string $cloudKey = NULL, ?string $cloudSecret = NULL, ?string $projectAccessTokenName = NULL, ?string $projectAccessToken = NULL, int $phpVersion): array {
+  public static function getDefaults(?string $cloudApplicationUuid = NULL, ?string $cloudKey = NULL, ?string $cloudSecret = NULL, ?string $projectAccessTokenName = NULL, ?string $projectAccessToken = NULL, ?string $phpVersion = NULL): array {
     return [
       [
         'key' => 'ACQUIA_APPLICATION_UUID',

--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -16,7 +16,7 @@ class CodeStudioCiCdVariables {
   /**
    * @return array<mixed>
    */
-  public static function getDefaults(?string $cloudApplicationUuid = NULL, ?string $cloudKey = NULL, ?string $cloudSecret = NULL, ?string $projectAccessTokenName = NULL, ?string $projectAccessToken = NULL): array {
+  public static function getDefaults(?string $cloudApplicationUuid = NULL, ?string $cloudKey = NULL, ?string $cloudSecret = NULL, ?string $projectAccessTokenName = NULL, ?string $projectAccessToken = NULL, int $phpVersion): array {
     return [
       [
         'key' => 'ACQUIA_APPLICATION_UUID',
@@ -51,6 +51,13 @@ class CodeStudioCiCdVariables {
         'masked' => TRUE,
         'protected' => FALSE,
         'value' => $projectAccessToken,
+        'variable_type' => 'env_var',
+      ],
+      [
+        'key' => 'PHP_VERSION',
+        'masked' => FALSE,
+        'protected' => FALSE,
+        'value' => $phpVersion,
         'variable_type' => 'env_var',
       ],
     ];

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -48,8 +48,8 @@ class CodeStudioWizardCommand extends WizardCommandBase {
     $this->reAuthenticate($cloudKey, $cloudSecret, $this->cloudCredentials->getBaseUri(), $this->cloudCredentials->getAccountsUri());
 
     $phpVersions = [
-      'PHP_version_8.1' => 8.1,
-      'PHP_version_8.2' => 8.2,
+      'PHP_version_8.1' => "8.1",
+      'PHP_version_8.2' => "8.2",
     ];
     $project = $this->io->choice('Select a PHP version', array_values($phpVersions), $phpVersions['PHP_version_8.1']);
     $project = array_search($project, $phpVersions, TRUE);

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -170,7 +170,7 @@ class CodeStudioWizardCommand extends WizardCommandBase {
     return $projectAccessToken['token'];
   }
 
-  private function setGitLabCiCdVariables(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken, int $phpVersion): void {
+  private function setGitLabCiCdVariables(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken, string $phpVersion): void {
     $this->io->writeln("Setting GitLab CI/CD variables for {$project['path_with_namespace']}..");
     $gitlabCicdVariables = CodeStudioCiCdVariables::getDefaults($cloudApplicationUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $phpVersion);
     $gitlabCicdExistingVariables = $this->gitLabClient->projects()

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -46,6 +46,15 @@ class CodeStudioWizardCommand extends WizardCommandBase {
     // But, we specifically need an API Token key-pair of Code Studio.
     // So we reauthenticate to be sure we're using the provided credentials.
     $this->reAuthenticate($cloudKey, $cloudSecret, $this->cloudCredentials->getBaseUri(), $this->cloudCredentials->getAccountsUri());
+
+    $phpVersions = [
+      'PHP_version_8.1' => 8.1,
+      'PHP_version_8.2' => 8.2,
+    ];
+    $project = $this->io->choice('Select a PHP version', array_values($phpVersions), $phpVersions['PHP_version_8.1']);
+    $project = array_search($project, $phpVersions, TRUE);
+    $phpVersion = $phpVersions[$project];
+
     $appUuid = $this->determineCloudApplication();
 
     // Get Cloud account.
@@ -92,7 +101,7 @@ class CodeStudioWizardCommand extends WizardCommandBase {
     $projectAccessTokenName = 'acquia-codestudio';
     $projectAccessToken = $this->createProjectAccessToken($project, $projectAccessTokenName);
     $this->updateGitLabProject($project);
-    $this->setGitLabCiCdVariables($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken);
+    $this->setGitLabCiCdVariables($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $phpVersion);
     $this->createScheduledPipeline($project);
 
     $this->io->success([
@@ -161,9 +170,9 @@ class CodeStudioWizardCommand extends WizardCommandBase {
     return $projectAccessToken['token'];
   }
 
-  private function setGitLabCiCdVariables(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken): void {
+  private function setGitLabCiCdVariables(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken, int $phpVersion): void {
     $this->io->writeln("Setting GitLab CI/CD variables for {$project['path_with_namespace']}..");
-    $gitlabCicdVariables = CodeStudioCiCdVariables::getDefaults($cloudApplicationUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken);
+    $gitlabCicdVariables = CodeStudioCiCdVariables::getDefaults($cloudApplicationUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $phpVersion);
     $gitlabCicdExistingVariables = $this->gitLabClient->projects()
       ->variables($project['id']);
     $gitlabCicdExistingVariablesKeyed = [];

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -633,7 +633,7 @@ abstract class CommandTestBase extends TestBase {
           'protected' => FALSE,
           'value' => '111aae74-e81a-4052-b4b9-a27a62e6b6a6',
           'variable_type' => 'env_var',
-        ],
+      ],
     ];
   }
 

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -213,6 +213,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->expectExceptionMessage('Unable to authenticate with Code Studio');
     $this->executeCommand([
       '--key' => $this->key,
+      '--phpversion' => $this->phpVersion,
       '--secret' => $this->secret,
     ]);
   }
@@ -227,6 +228,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->expectExceptionMessage('Could not determine GitLab token');
     $this->executeCommand([
       '--key' => $this->key,
+      '--phpversion' => $this->phpVersion,
       '--secret' => $this->secret,
     ]);
   }

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -65,7 +65,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
-          '--phpversion' => "8.1",
+          '--phpversion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
       ],
@@ -84,7 +84,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
-          '--phpversion' => "8.1",
+          '--phpversion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
       ],
@@ -103,7 +103,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
-          '--phpversion' => "8.1",
+          '--phpversion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
       ],
@@ -122,7 +122,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args
         [
           '--key' => $this->key,
-          '--phpversion' => "8.1",
+          '--phpVersion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
       ],
@@ -137,7 +137,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           $this->key,
           // Enter Cloud secret,
           $this->secret,
-          '--phpversion' => "8.1",
+          '--phpversion' => $this->phpVersion,
           // Do you want to continue?
           'y',
         ],

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -65,7 +65,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
-          '--phpversion' => $this->phpVersion,
+          '--phpVersion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
       ],
@@ -84,7 +84,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
-          '--phpversion' => $this->phpVersion,
+          '--phpVersion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
       ],
@@ -103,7 +103,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
-          '--phpversion' => $this->phpVersion,
+          '--phpVersion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
       ],
@@ -137,7 +137,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           $this->key,
           // Enter Cloud secret,
           $this->secret,
-          '--phpversion' => $this->phpVersion,
+          '--phpVersion' => $this->phpVersion,
           // Do you want to continue?
           'y',
         ],
@@ -213,7 +213,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->expectExceptionMessage('Unable to authenticate with Code Studio');
     $this->executeCommand([
       '--key' => $this->key,
-      '--phpversion' => $this->phpVersion,
+      '--phpVersion' => $this->phpVersion,
       '--secret' => $this->secret,
     ]);
   }
@@ -228,7 +228,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->expectExceptionMessage('Could not determine GitLab token');
     $this->executeCommand([
       '--key' => $this->key,
-      '--phpversion' => $this->phpVersion,
+      '--phpVersion' => $this->phpVersion,
       '--secret' => $this->secret,
     ]);
   }

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -67,7 +67,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           '--key' => $this->key,
           '--secret' => $this->secret,
         ],
-        //'--phpVersion' => $this->phpVersion,
       ],
       // Two projects.
       [
@@ -86,7 +85,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           '--key' => $this->key,
           '--secret' => $this->secret,
         ],
-        // '--phpVersion' => $this->phpVersion,
       ],
       [
         // No projects.
@@ -107,7 +105,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           '--key' => $this->key,
           '--secret' => $this->secret,
         ],
-        // '--phpVersion' => $this->phpVersion,
       ],
       [
         // No projects.
@@ -128,7 +125,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           '--key' => $this->key,
           '--secret' => $this->secret,
         ],
-        // '--phpVersion' => $this->phpVersion,
       ],
       [
         // No projects.
@@ -147,7 +143,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           '--key' => $this->key,
           '--secret' => $this->secret,
         ],
-        // '--phpVersion' => $this->phpVersion,
       ],
       [
         // No projects.
@@ -165,7 +160,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           // Do you want to continue?
           'y',
         ],
-        // '--phpVersion' => $this->phpVersion,
         // Args
         [],
       ],
@@ -185,7 +179,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           // Do you want to continue?
           'y',
         ],
-        // '--phpVersion' => $this->phpVersion,
         // Args
         [],
       ],
@@ -259,7 +252,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->executeCommand([
       '--key' => $this->key,
       '--secret' => $this->secret,
-      // '--phpVersion' => $this->phpVersion,
     ]);
   }
 
@@ -274,7 +266,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->executeCommand([
       '--key' => $this->key,
       '--secret' => $this->secret,
-      // '--phpVersion' => $this->phpVersion,
     ]);
   }
 

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -65,6 +65,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
+          '--phpversion' => "8.1",
           '--secret' => $this->secret,
         ],
       ],
@@ -83,6 +84,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
+          '--phpversion' => "8.1",
           '--secret' => $this->secret,
         ],
       ],
@@ -101,6 +103,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
+          '--phpversion' => "8.1",
           '--secret' => $this->secret,
         ],
       ],
@@ -119,6 +122,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args
         [
           '--key' => $this->key,
+          '--phpversion' => "8.1",
           '--secret' => $this->secret,
         ],
       ],
@@ -133,6 +137,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           $this->key,
           // Enter Cloud secret,
           $this->secret,
+          '--phpversion' => "8.1",
           // Do you want to continue?
           'y',
         ],

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -65,9 +65,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
-          '--phpVersion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
+        //'--phpVersion' => $this->phpVersion,
       ],
       // Two projects.
       [
@@ -84,9 +84,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
-          '--phpVersion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
+        // '--phpVersion' => $this->phpVersion,
       ],
       [
         // No projects.
@@ -95,6 +95,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         [
           // 'Would you like to create a new Code Studio project?
           'y',
+          // Select PHP version
+          '0',
           // Do you want to continue?
           'y',
           // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
@@ -103,9 +105,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args.
         [
           '--key' => $this->key,
-          '--phpVersion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
+        // '--phpVersion' => $this->phpVersion,
       ],
       [
         // No projects.
@@ -122,9 +124,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         // Args
         [
           '--key' => $this->key,
-          '--phpVersion' => $this->phpVersion,
           '--secret' => $this->secret,
         ],
+        // '--phpVersion' => $this->phpVersion,
       ],
       [
         // No projects.
@@ -137,10 +139,12 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           $this->key,
           // Enter Cloud secret,
           $this->secret,
-          '--phpVersion' => $this->phpVersion,
+          // Select PHP version
+          '0',
           // Do you want to continue?
           'y',
         ],
+        // '--phpVersion' => $this->phpVersion,
         // Args
         [],
       ],
@@ -213,8 +217,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->expectExceptionMessage('Unable to authenticate with Code Studio');
     $this->executeCommand([
       '--key' => $this->key,
-      '--phpVersion' => $this->phpVersion,
       '--secret' => $this->secret,
+      // '--phpVersion' => $this->phpVersion,
     ]);
   }
 
@@ -228,8 +232,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->expectExceptionMessage('Could not determine GitLab token');
     $this->executeCommand([
       '--key' => $this->key,
-      '--phpVersion' => $this->phpVersion,
       '--secret' => $this->secret,
+      // '--phpVersion' => $this->phpVersion,
     ]);
   }
 

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -95,8 +95,29 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
         [
           // 'Would you like to create a new Code Studio project?
           'y',
-          // Select PHP version
+          // Select PHP version 8.1
           '0',
+          // Do you want to continue?
+          'y',
+          // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
+          'y',
+        ],
+        // Args.
+        [
+          '--key' => $this->key,
+          '--secret' => $this->secret,
+        ],
+        // '--phpVersion' => $this->phpVersion,
+      ],
+      [
+        // No projects.
+        [],
+        // Inputs.
+        [
+          // 'Would you like to create a new Code Studio project?
+          'y',
+          // Select PHP version 8.2
+          '1',
           // Do you want to continue?
           'y',
           // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
@@ -139,8 +160,28 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           $this->key,
           // Enter Cloud secret,
           $this->secret,
-          // Select PHP version
+          // Select PHP version 8.1
           '0',
+          // Do you want to continue?
+          'y',
+        ],
+        // '--phpVersion' => $this->phpVersion,
+        // Args
+        [],
+      ],
+      [
+        // No projects.
+        [],
+        // Inputs
+        [
+          // 'Would you like to create a new Code Studio project?
+          'y',
+          // Enter Cloud Key
+          $this->key,
+          // Enter Cloud secret,
+          $this->secret,
+          // Select PHP version 8.2
+          '1',
           // Do you want to continue?
           'y',
         ],

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -86,7 +86,7 @@ abstract class TestBase extends TestCase {
 
   protected string $secret = 'X1u\/PIQXtYaoeui.4RJSJpGZjwmWYmfl5AUQkAebYE=';
 
-  protected string $phpVersion = '8.1';
+  // protected string $phpVersion = '8.1';
 
   protected string $dataDir;
 

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -86,8 +86,6 @@ abstract class TestBase extends TestCase {
 
   protected string $secret = 'X1u\/PIQXtYaoeui.4RJSJpGZjwmWYmfl5AUQkAebYE=';
 
-  // protected string $phpVersion = '8.1';
-
   protected string $dataDir;
 
   protected string $cloudConfigFilepath;

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -86,6 +86,8 @@ abstract class TestBase extends TestCase {
 
   protected string $secret = 'X1u\/PIQXtYaoeui.4RJSJpGZjwmWYmfl5AUQkAebYE=';
 
+  protected string $phpVersion = '8.1';
+
   protected string $dataDir;
 
   protected string $cloudConfigFilepath;


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes # GL-1836

**Proposed changes**
Add a prompt to choose php version between two of them. Either 8.1 or 8.2

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
run command `./bin/acli cs:wizard` and CLI should ask to choose PHP version. Once steps are completed then verify PHP_VERSION variable should get added to code studio UI.

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
