### PR TITLE
Explicitly set php version to be used during CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           coverage: none
+          php-version: '8.1'
       - name: 'Get ACLI version'
         id: acli-version
         run: |


### PR DESCRIPTION
**Motivation**
There were a couple of changes in shivammathur/setup-php (specifically [#754](https://github.com/shivammathur/setup-php/commit/a5fb328c6a38ac8086676fc64e6e78a39d6ef69e)) which resulted in new builds using [PHP 8.0 during the build](https://github.com/acquia/cli/actions/runs/6263194877/job/17007030360#step:6:379) step.

**Proposed changes**
This change explicitly sets the php version to be used.

**Alternatives considered**
None

**Testing steps**
The build step will fail (example) without this with:
```
"Error: ] Your system is not ready to run the application.                       
                                                                                

Fix the following mandatory requirements:
=========================================

 * The application requires a version matching "^8.1"."
 ``` 
 
And it will pass with this PR merged.
