### PR TITLE
CLI-1039: Update box, fix typeerror in some terminals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
             "rm -rf gardener"
         ],
         "box-install": [
-            "curl -f -L https://github.com/box-project/box/releases/download/4.3.7/box.phar -o build/box.phar"
+            "curl -f -L https://github.com/box-project/box/releases/download/4.4.0/box.phar -o build/box.phar"
         ],
         "box-compile": [
             "php build/box.phar compile"

--- a/composer.lock
+++ b/composer.lock
@@ -12506,5 +12506,5 @@
     "platform-overrides": {
         "php": "8.0.21"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This may fix type errors that some people see related to the Box requirements checker in some terminals, especially Git Bash. See https://github.com/box-project/box/pull/999
