### PR TITLE
CLI-1136: [push:artifact] include empty directories and symlinks

### DIFF
--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -192,13 +192,13 @@ class PushArtifactCommand extends PullCommandBase {
     // @see https://git.drupalcode.org/project/drupal/-/blob/9.1.x/sites/default/default.settings.php#L295
     $outputCallback('out', "Mirroring source files from $this->dir to $artifactDir");
     $originFinder = $this->localMachineHelper->getFinder();
-    $originFinder->files()->in($this->dir)
+    $originFinder->in($this->dir)
       // Include dot files like .htaccess.
       ->ignoreDotFiles(FALSE)
       // Ignore VCS ignored files (e.g. vendor) to speed up the mirror (Composer will restore them later).
       ->ignoreVCSIgnored(TRUE);
     $targetFinder = $this->localMachineHelper->getFinder();
-    $targetFinder->files()->in($artifactDir)->ignoreDotFiles(FALSE);
+    $targetFinder->in($artifactDir)->ignoreDotFiles(FALSE);
     $this->localMachineHelper->getFilesystem()->mirror($this->dir, $artifactDir, $originFinder, ['override' => TRUE, 'delete' => TRUE], $targetFinder);
 
     $this->localMachineHelper->checkRequiredBinariesExist(['composer']);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
push:artifact doesn't mirror symlinks that point to directories. It probably also doesn't mirror empty directories, though that's less likely to cause problems since empty directories are VCS ignored and not generally useful anyway.
