### PR TITLE
CLI-1171: Home directory errors on Windows

### DIFF
--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -223,7 +223,7 @@ class LocalMachineHelper {
     $home = getenv('HOME');
     if (!$home) {
       $system = '';
-      if (getenv('MSYSTEM') !== NULL) {
+      if (getenv('MSYSTEM')) {
         $system = strtoupper(substr(getenv('MSYSTEM'), 0, 4));
       }
       if ($system !== 'MING') {

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -215,9 +215,7 @@ class LocalMachineHelper {
   /**
    * Returns the appropriate home directory.
    *
-   * Adapted from Ads Package Manager by Ed Reel.
-   *
-   * @url https://github.com/uberhacker/tpm
+   * @see https://github.com/pantheon-systems/terminus/blob/1d89e20dd388dc08979a1bc52dfd142b26c03dcf/src/Config/DefaultsConfig.php#L99
    */
   public static function getHomeDir(): string {
     $home = getenv('HOME');

--- a/tests/phpunit/src/Misc/LocalMachineHelperTest.php
+++ b/tests/phpunit/src/Misc/LocalMachineHelperTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Tests\Misc;
 
+use Acquia\Cli\Exception\AcquiaCliException;
+use Acquia\Cli\Helpers\LocalMachineHelper;
 use Acquia\Cli\Tests\TestBase;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -59,6 +61,39 @@ class LocalMachineHelperTest extends TestBase {
     $localMachineHelper = $this->localMachineHelper;
     $exists = $localMachineHelper->commandExists('cat');
     $this->assertIsBool($exists);
+  }
+
+  public function testHomeDirWindowsCmd(): void {
+    self::setEnvVars([
+      'HOMEPATH' => 'something',
+    ]);
+    self::unsetEnvVars([
+      'MSYSTEM',
+      'HOME',
+    ]);
+    $home = LocalMachineHelper::getHomeDir();
+    $this->assertEquals('something', $home);
+  }
+
+  public function testHomeDirWindowsMsys2(): void {
+    self::setEnvVars([
+      'HOMEPATH' => 'something',
+      'MSYSTEM' => 'MSYS2',
+    ]);
+    self::unsetEnvVars(['HOME']);
+    $home = LocalMachineHelper::getHomeDir();
+    $this->assertEquals('something', $home);
+  }
+
+  /**
+   * I don't know why, but apparently Ming is unsupported ¯\_(ツ)_/¯.
+   */
+  public function testHomeDirWindowsMing(): void {
+    self::setEnvVars(['MSYSTEM' => 'MING']);
+    self::unsetEnvVars(['HOME']);
+    $this->expectException(AcquiaCliException::class);
+    $this->expectExceptionMessage('Could not determine $HOME directory. Ensure $HOME is set in your shell.');
+    LocalMachineHelper::getHomeDir();
   }
 
 }

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -164,7 +164,10 @@ abstract class TestBase extends TestCase {
    * This method is called before each test.
    */
   protected function setUp(): void {
-    putenv('COLUMNS=85');
+    self::setEnvVars([
+      'COLUMNS' => '85',
+      'HOME' => '/home/test',
+    ]);
     $this->output = new BufferedOutput();
     $this->input = new ArrayInput([]);
 
@@ -241,9 +244,14 @@ abstract class TestBase extends TestCase {
     }
   }
 
-  public static function unsetEnvVars(mixed $envVars): void {
+  public static function unsetEnvVars(array $envVars): void {
     foreach ($envVars as $key => $value) {
-      putenv($key);
+      if (is_int($key)) {
+        putenv($value);
+      }
+      else {
+        putenv($key);
+      }
     }
   }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #1610 

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
extending env variable testing condition to avoid PHP error when the var is not present

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
