### PR TITLE
CLI-1181: [pull:code] disable scripts for build branches

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -508,15 +508,15 @@ abstract class PullCommandBase extends CommandBase {
 
   protected function runComposerScripts(callable $outputCallback = NULL): void {
     if (!file_exists(Path::join($this->dir, 'composer.json'))) {
-      $this->logger->notice('composer.json file not found. Skipping composer install.');
+      $this->io->note('composer.json file not found. Skipping composer install.');
       return;
     }
     if (!$this->localMachineHelper->commandExists('composer')) {
-      $this->logger->notice('Composer not found. Skipping composer install.');
+      $this->io->note('Composer not found. Skipping composer install.');
       return;
     }
     if (file_exists(Path::join($this->dir, 'vendor'))) {
-      $this->logger->notice('Composer dependencies already installed. Skipping composer install.');
+      $this->io->note('Composer dependencies already installed. Skipping composer install.');
       return;
     }
     $this->checklist->addItem("Installing Composer dependencies");

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -507,14 +507,21 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   protected function runComposerScripts(callable $outputCallback = NULL): void {
-    if (file_exists($this->dir . '/composer.json') && $this->localMachineHelper->commandExists('composer')) {
-      $this->checklist->addItem("Installing Composer dependencies");
-      $this->composerInstall($outputCallback);
-      $this->checklist->completePreviousItem();
+    if (!file_exists(Path::join($this->dir, 'composer.json'))) {
+      $this->logger->notice('composer.json file not found. Skipping composer install.');
+      return;
     }
-    else {
-      $this->logger->notice('composer or composer.json file not found. Skipping composer install.');
+    if (!$this->localMachineHelper->commandExists('composer')) {
+      $this->logger->notice('Composer not found. Skipping composer install.');
+      return;
     }
+    if (file_exists(Path::join($this->dir, 'vendor'))) {
+      $this->logger->notice('Composer dependencies already installed. Skipping composer install.');
+      return;
+    }
+    $this->checklist->addItem("Installing Composer dependencies");
+    $this->composerInstall($outputCallback);
+    $this->checklist->completePreviousItem();
   }
 
   private function determineSite(string|\AcquiaCloudApi\Response\EnvironmentResponse|array $environment, InputInterface $input): mixed {


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->

For certain applications and environments, `composer install` can fail when composer dependencies are already installed

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

Don't run composer install if dependencies are already installed; i.e., for build branches.
