### PR TITLE
CLI-1035: Put build files in var dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,12 +110,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: acli.phar
-          path: build/acli.phar
+          path: var/acli.phar
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: build/acli.phar
+          files: var/acli.phar
   # Require all checks to pass without having to enumerate them in the branch protection UI.
   # @see https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957
   check:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 
 drupal
 .idea
-build
 *.bak
 .DS_STORE
 

--- a/.phplint.yml
+++ b/.phplint.yml
@@ -1,10 +1,9 @@
 path: ./
 jobs: 10
-cache: build/phplint.cache
+cache: var/phplint.cache
 extensions:
   - php
 exclude:
-  - build
   - var
   - vendor
 warning: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Any changes to the `acli update` command should be manually tested using the fol
 
 1. Replace `@package_version@` on this line with `1.0.0` or any older version string: https://github.com/acquia/cli/blob/v1.0.0/bin/acli#L84
 1. Build acli.phar as described above.
-1. Now test: `./build/acli.phar self:update`
+1. Now test: `./var/acli.phar self:update`
 
 ### Writing tests
 

--- a/box.json
+++ b/box.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/box-project/box/4.3.7/res/schema.json",
     "directories": [
         "config",
-        "var"
+        "var/cache"
     ],
     "files": [
         ".env"
@@ -11,7 +11,7 @@
         "KevinGH\\Box\\Compactor\\Php",
         "KevinGH\\Box\\Compactor\\Json"
     ],
-    "output": "build/acli.phar",
+    "output": "var/acli.phar",
     "exclude-composer-files": false,
     "force-autodiscovery": true
 }

--- a/composer.json
+++ b/composer.json
@@ -137,10 +137,10 @@
             "rm -rf gardener"
         ],
         "box-install": [
-            "curl -f -L https://github.com/box-project/box/releases/download/4.4.0/box.phar -o build/box.phar"
+            "curl -f -L https://github.com/box-project/box/releases/download/4.4.0/box.phar -o var/box.phar"
         ],
         "box-compile": [
-            "php build/box.phar compile"
+            "php var/box.phar compile"
         ],
         "infection": [
             "php -d pcov.enabled=1 vendor/bin/infection --threads=8"
@@ -153,7 +153,7 @@
         ],
         "unit-serial": "phpunit tests/phpunit -vvv --group serial",
         "unit-parallel": "paratest --exclude-group serial",
-        "coverage": "php -d pcov.enabled=1 vendor/bin/phpunit tests/phpunit --coverage-clover build/logs/clover.xml",
+        "coverage": "php -d pcov.enabled=1 vendor/bin/phpunit tests/phpunit --coverage-clover var/logs/clover.xml",
         "lint": "phplint",
         "test": [
             "@lint",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,7 @@
   <arg name="extensions" value="php,inc,test,css,txt,md,yml"/>
 
   <arg name="colors"/>
-  <arg name="cache" value="build/.phpcs-cache"/>
+  <arg name="cache" value="var/.phpcs-cache"/>
   <arg name="parallel" value="10"/>
 
   <file>src</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        cacheResultFile="build/.phpunit.result.cache"
+        cacheResultFile="var/.phpunit.result.cache"
         failOnWarning="true"
         failOnRisky="true"
         convertErrorsToExceptions="true"


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Travis proposed that any temporary build files can go in `var`, along with the Symfony cache and similar directories.

The only difference is that we do actually ship the cache with acli.phar, but that should be easy enough to work around.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
I'm not convinced this won't explode our CI/CD, but let's find out...
