### PR TITLE
CLI-1175: [auth:acsf-logout] undefined array key

### DIFF
--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -47,7 +47,6 @@ services:
     parent: Acquia\Cli\Command\CommandBase
     exclude:
       - ../../src/Command/CommandBase.php
-      - ../../src/Command/Acsf/AcsfCommandBase.php
       - ../../src/Command/Acsf/AcsfListCommand.php
       - ../../src/Command/Acsf/AcsfListCommandBase.php
       - ../../src/Command/Acsf/AcsfApiBaseCommand.php

--- a/src/Command/Auth/AuthAcsfLogoutCommand.php
+++ b/src/Command/Auth/AuthAcsfLogoutCommand.php
@@ -22,11 +22,11 @@ class AuthAcsfLogoutCommand extends CommandBase {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    if (!$this->cloudApiClientService->isMachineAuthenticated()) {
-      $this->io->error(['You are not logged into any factories.']);
-      return 1;
-    }
     $factories = $this->datastoreCloud->get('acsf_factories');
+    if (empty($factories)) {
+      $this->io->error(['You are not logged into any factories.']);
+      return Command::FAILURE;
+    }
     foreach ($factories as $url => $factory) {
       $factories[$url]['url'] = $url;
     }


### PR DESCRIPTION
cloudApiClientService should be an instance of AcsfClientService but it's not. I can't figure out how to wire up the service container to make that work.

It's easy enough to do without it though.