### PR TITLE
CLI-1221: TypeError and warning in remote:alises:download

### DIFF
--- a/tests/phpunit/src/Commands/InferApplicationTest.php
+++ b/tests/phpunit/src/Commands/InferApplicationTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Tests\Commands;
 
 use Acquia\Cli\Command\App\LinkCommand;
+use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\CommandTestBase;
 use Symfony\Component\Console\Command\Command;
 
@@ -20,13 +21,8 @@ class InferApplicationTest extends CommandTestBase {
     return $this->injectCommand(LinkCommand::class);
   }
 
-  public function setUp(mixed $output = NULL): void {
-    parent::setUp();
-    $this->createMockGitConfigFile();
-  }
-
   public function testInfer(): void {
-
+    $this->createMockGitConfigFile();
     $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
     $environmentResponse = $this->getMockEnvironmentResponse();
@@ -56,6 +52,7 @@ class InferApplicationTest extends CommandTestBase {
   }
 
   public function testInferFailure(): void {
+    $this->createMockGitConfigFile();
     $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();
 
@@ -85,6 +82,13 @@ class InferApplicationTest extends CommandTestBase {
     $this->assertStringContainsString('Searching for a matching Cloud application...', $output);
     $this->assertStringContainsString('Could not find a matching Cloud application.', $output);
     $this->assertStringContainsString('The Cloud application Sample application 1 has been linked', $output);
+  }
+
+  public function testInferInvalidGitConfig(): void {
+    $this->expectException(AcquiaCliException::class);
+    $this->executeCommand([], [
+      'y',
+    ]);
   }
 
 }

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -36,7 +36,7 @@ class SshKeyUploadCommandTest extends CommandTestBase {
           // Would you like to wait until Cloud Platform is ready? (yes/no)
           'y',
           // Would you like Acquia CLI to search for a Cloud application that matches your local git config? (yes/no)
-          'y',
+          'n',
         ],
         // Perms.
         TRUE,
@@ -52,7 +52,7 @@ class SshKeyUploadCommandTest extends CommandTestBase {
           // Would you like to wait until Cloud Platform is ready? (yes/no)
           'y',
           // Would you like Acquia CLI to search for a Cloud application that matches your local git config? (yes/no)
-          'y',
+          'n',
         ],
         // Perms.
         FALSE,
@@ -63,7 +63,7 @@ class SshKeyUploadCommandTest extends CommandTestBase {
   /**
    * @dataProvider providerTestUpload
    */
-  public function testUpload(mixed $args, mixed $inputs, mixed $perms): void {
+  public function testUpload(array $args, array $inputs, bool $perms): void {
     $sshKeysRequestBody = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
     $body = [
       'json' => [


### PR DESCRIPTION
This has the side effect of throwing an exception when the Git config is invalid or missing, as opposed to before when it might still fall back to other methods of finding the application. I think it's a desirable change.