### PR TITLE
CLI-1210: Drop tables instead of database

### DIFF
--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -350,7 +350,7 @@ abstract class CommandTestBase extends TestBase {
 
   protected function mockCreateMySqlDumpOnLocal(ObjectProphecy $localMachineHelper): void {
     $localMachineHelper->checkRequiredBinariesExist(["mysqldump", "gzip"])->shouldBeCalled();
-    $process = $this->mockProcess(TRUE);
+    $process = $this->mockProcess();
     $process->getOutput()->willReturn('');
     $command = 'MYSQL_PWD=drupal mysqldump --host=localhost --user=drupal drupal | pv --rate --bytes | gzip -9 > ' . sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz';
     $localMachineHelper->executeFromCmd($command, Argument::type('callable'), NULL, TRUE)->willReturn($process->reveal())

--- a/tests/phpunit/src/Commands/Archive/ArchiveExporterCommandTest.php
+++ b/tests/phpunit/src/Commands/Archive/ArchiveExporterCommandTest.php
@@ -22,6 +22,11 @@ class ArchiveExporterCommandTest extends PullCommandTestBase {
     return $this->injectCommand(ArchiveExportCommand::class);
   }
 
+  public function setUp(): void {
+    self::unsetEnvVars(['ACLI_DB_HOST', 'ACLI_DB_USER', 'ACLI_DB_PASSWORD', 'ACLI_DB_NAME']);
+    parent::setUp();
+  }
+
   public function testArchiveExport(): void {
     touch(Path::join($this->projectDir, '.gitignore'));
     $destinationDir = 'foo';

--- a/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
@@ -20,6 +20,11 @@ class PushDatabaseCommandTest extends CommandTestBase {
     return $this->injectCommand(PushDatabaseCommand::class);
   }
 
+  public function setUp(): void {
+    self::unsetEnvVars(['ACLI_DB_HOST', 'ACLI_DB_USER', 'ACLI_DB_PASSWORD', 'ACLI_DB_NAME']);
+    parent::setUp();
+  }
+
   public function testPushDatabase(): void {
     $applicationsResponse = $this->mockApplicationsRequest();
     $this->mockApplicationRequest();


### PR DESCRIPTION
Fixes #1629 
Fixes #1634 

Note, this has the side effect of no longer creating a db if it doesn't already exist.