### PR TITLE
CLI-1225: The pull:database command fails silently if pv is not installed.

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -392,7 +392,7 @@ abstract class PullCommandBase extends CommandBase {
     }
     else {
       $this->io->warning('Install `pv` to see progress bar');
-      $command = "gunzip $localDumpFilepath | MYSQL_PWD=$dbPassword mysql --host=$dbHost --user=$dbUser $dbName";
+      $command = "gunzip -c $localDumpFilepath | MYSQL_PWD=$dbPassword mysql --host=$dbHost --user=$dbUser $dbName";
     }
 
     $process = $this->localMachineHelper->executeFromCmd($command, $outputCallback, NULL, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -358,11 +358,12 @@ abstract class CommandTestBase extends TestBase {
   }
 
   protected function mockExecutePvExists(
-        ObjectProphecy $localMachineHelper
+        ObjectProphecy $localMachineHelper,
+        bool $pvExists = TRUE
     ): void {
     $localMachineHelper
             ->commandExists('pv')
-            ->willReturn(TRUE)
+            ->willReturn($pvExists)
             ->shouldBeCalled();
   }
 

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @property \Acquia\Cli\Command\Pull\PullDatabaseCommand $command
@@ -311,8 +312,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
     $localMachineHelper->checkRequiredBinariesExist(['gunzip', 'mysql'])->shouldBeCalled();
     $this->mockExecutePvExists($localMachineHelper, $pvExists);
     $process = $this->mockProcess($success);
-    $tmpDir = sys_get_temp_dir();
-    $command = $pvExists ? "pv $tmpDir/dev-$dbName-$dbMachineName-2012-05-15T12:00:00Z.sql.gz --bytes --rate | gunzip | MYSQL_PWD=drupal mysql --host=localhost --user=drupal $localDbName" : "gunzip -c $tmpDir/dev-$dbName-$dbMachineName-2012-05-15T12:00:00Z.sql.gz | MYSQL_PWD=drupal mysql --host=localhost --user=drupal $localDbName";
+    $filePath = Path::join(sys_get_temp_dir(), "dev-$dbName-$dbMachineName-2012-05-15T12:00:00Z.sql.gz");
+    $command = $pvExists ? "pv $filePath --bytes --rate | gunzip | MYSQL_PWD=drupal mysql --host=localhost --user=drupal $localDbName" : "gunzip -c $filePath | MYSQL_PWD=drupal mysql --host=localhost --user=drupal $localDbName";
     // MySQL import command.
     $localMachineHelper
       ->executeFromCmd($command, Argument::type('callable'),


### PR DESCRIPTION
**Motivation**
Fixes #1640: The pull:database command fails silently if pv is not installed

**Proposed changes**
if pv is not installed, run gunzip with the -c flag so the decompressed output is piped to the mysql command

**Alternatives considered**
There are other possible ways to manage output redirection in bash, this seemed simplest.

**Testing steps**
On a system without pv installed set the appropriate ACLI_DB_**** environmental variables and execute an acli pull:database request. See the database downloaded and the command appear to succeed. Open the database and see that it is not empty.

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
