### PR TITLE
CLI-1227: Implement PHP 8 attributes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export PATH="$PATH:${PWD}/vendor/bin"

--- a/src/Attribute/RequireAuth.php
+++ b/src/Attribute/RequireAuth.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Acquia\Cli\Attribute;
+
+/**
+ * Specify that a command requires authentication.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class RequireAuth {
+
+}

--- a/src/Attribute/RequireDb.php
+++ b/src/Attribute/RequireDb.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Acquia\Cli\Attribute;
+
+/**
+ * Specify that a command requires authentication.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class RequireDb {
+
+}

--- a/src/Command/Acsf/AcsfApiBaseCommand.php
+++ b/src/Command/Acsf/AcsfApiBaseCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Acsf;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\Api\ApiBaseCommand;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -13,7 +14,8 @@ use Symfony\Component\Console\Input\InputInterface;
 class AcsfApiBaseCommand extends ApiBaseCommand {
 
   protected function checkAuthentication(): void {
-    if ($this->commandRequiresAuthentication() && !$this->cloudApiClientService->isMachineAuthenticated()) {
+    $reflectionClass = new \ReflectionClass($this);
+    if ($reflectionClass->getAttributes(RequireAuth::class) && !$this->cloudApiClientService->isMachineAuthenticated()) {
       throw new AcquiaCliException('This machine is not yet authenticated with the Acquia Cloud Site Factory. Run `acli auth:acsf-login`');
     }
   }

--- a/src/Command/Acsf/AcsfApiBaseCommand.php
+++ b/src/Command/Acsf/AcsfApiBaseCommand.php
@@ -14,8 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 class AcsfApiBaseCommand extends ApiBaseCommand {
 
   protected function checkAuthentication(): void {
-    $reflectionClass = new \ReflectionClass($this);
-    if ($reflectionClass->getAttributes(RequireAuth::class) && !$this->cloudApiClientService->isMachineAuthenticated()) {
+    if ((new \ReflectionClass(static::class))->getAttributes(RequireAuth::class) && !$this->cloudApiClientService->isMachineAuthenticated()) {
       throw new AcquiaCliException('This machine is not yet authenticated with the Acquia Cloud Site Factory. Run `acli auth:acsf-login`');
     }
   }

--- a/src/Command/Acsf/AcsfListCommand.php
+++ b/src/Command/Acsf/AcsfListCommand.php
@@ -6,13 +6,12 @@ namespace Acquia\Cli\Command\Acsf;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'acsf:list', 'List all Acquia Cloud Site Factory commands', ['acsf'])]
+#[AsCommand(name: 'acsf:list', description: 'List all Acquia Cloud Site Factory commands', aliases: ['acsf'])]
 class AcsfListCommand extends AcsfListCommandBase {
 
   protected string $namespace = 'acsf';
 
-  protected function configure(): void
-  {
+  protected function configure(): void {
   }
 
 }

--- a/src/Command/Acsf/AcsfListCommand.php
+++ b/src/Command/Acsf/AcsfListCommand.php
@@ -9,10 +9,15 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'acsf:list')]
 class AcsfListCommand extends AcsfListCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = "List all Acquia Cloud Site Factory commands";
   protected string $namespace = 'acsf';
 
   protected function configure(): void {
-    $this->setDescription("List all Acquia Cloud Site Factory commands")
+    $this
       ->setAliases(['acsf']);
   }
 

--- a/src/Command/Acsf/AcsfListCommand.php
+++ b/src/Command/Acsf/AcsfListCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 
 #[RequireAuth]
 #[AsCommand(name: 'acsf:list', description: 'List all Acquia Cloud Site Factory commands', aliases: ['acsf'])]
-class AcsfListCommand extends AcsfListCommandBase {
+final class AcsfListCommand extends AcsfListCommandBase {
 
   protected string $namespace = 'acsf';
 

--- a/src/Command/Acsf/AcsfListCommand.php
+++ b/src/Command/Acsf/AcsfListCommand.php
@@ -6,19 +6,13 @@ namespace Acquia\Cli\Command\Acsf;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'acsf:list')]
+#[AsCommand(name: 'acsf:list', 'List all Acquia Cloud Site Factory commands', ['acsf'])]
 class AcsfListCommand extends AcsfListCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = "List all Acquia Cloud Site Factory commands";
   protected string $namespace = 'acsf';
 
-  protected function configure(): void {
-    $this
-      ->setAliases(['acsf']);
+  protected function configure(): void
+  {
   }
 
 }

--- a/src/Command/Acsf/AcsfListCommand.php
+++ b/src/Command/Acsf/AcsfListCommand.php
@@ -11,7 +11,4 @@ class AcsfListCommand extends AcsfListCommandBase {
 
   protected string $namespace = 'acsf';
 
-  protected function configure(): void {
-  }
-
 }

--- a/src/Command/Acsf/AcsfListCommand.php
+++ b/src/Command/Acsf/AcsfListCommand.php
@@ -4,8 +4,10 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Acsf;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+#[RequireAuth]
 #[AsCommand(name: 'acsf:list', description: 'List all Acquia Cloud Site Factory commands', aliases: ['acsf'])]
 class AcsfListCommand extends AcsfListCommandBase {
 

--- a/src/Command/Acsf/AcsfListCommandBase.php
+++ b/src/Command/Acsf/AcsfListCommandBase.php
@@ -17,14 +17,6 @@ class AcsfListCommandBase extends CommandBase {
     $this->namespace = $namespace;
   }
 
-  /**
-   * Indicates whether the command requires the machine to be authenticated with the Cloud Platform.
-   */
-  protected function commandRequiresAuthentication(): bool {
-    // Assume commands require authentication unless they opt out by overriding this method.
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $commands = $this->getApplication()->all();
     foreach ($commands as $command) {

--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
 #[RequireAuth]
-#[AsCommand(name: 'api:base')]
+#[AsCommand(name: 'api:base', hidden: TRUE)]
 class ApiBaseCommand extends CommandBase {
 
   protected string $method;
@@ -54,11 +54,6 @@ class ApiBaseCommand extends CommandBase {
    * @var array<mixed>
    */
   private array $pathParams = [];
-
-  protected function configure(): void {
-    $this->setHidden();
-    parent::configure();
-  }
 
   protected function interact(InputInterface $input, OutputInterface $output): void {
     $params = array_merge($this->queryParams, $this->postParams, $this->pathParams);

--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Api;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Exception\ApiErrorException;
@@ -21,6 +22,7 @@ use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
+#[RequireAuth]
 #[AsCommand(name: 'api:base')]
 class ApiBaseCommand extends CommandBase {
 

--- a/src/Command/Api/ApiListCommand.php
+++ b/src/Command/Api/ApiListCommand.php
@@ -9,10 +9,15 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'api:list')]
 class ApiListCommand extends ApiListCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = "List all API commands";
   protected string $namespace = 'api';
 
   protected function configure(): void {
-    $this->setDescription("List all API commands")
+    $this
       ->setAliases(['api']);
   }
 

--- a/src/Command/Api/ApiListCommand.php
+++ b/src/Command/Api/ApiListCommand.php
@@ -11,7 +11,4 @@ class ApiListCommand extends ApiListCommandBase {
 
   protected string $namespace = 'api';
 
-  protected function configure(): void {
-  }
-
 }

--- a/src/Command/Api/ApiListCommand.php
+++ b/src/Command/Api/ApiListCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 
 #[RequireAuth]
 #[AsCommand(name: 'api:list', description: 'List all API commands', aliases: ['api'])]
-class ApiListCommand extends ApiListCommandBase {
+final class ApiListCommand extends ApiListCommandBase {
 
   protected string $namespace = 'api';
 

--- a/src/Command/Api/ApiListCommand.php
+++ b/src/Command/Api/ApiListCommand.php
@@ -6,19 +6,13 @@ namespace Acquia\Cli\Command\Api;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'api:list')]
+#[AsCommand(name: 'api:list', 'List all API commands', ['api'])]
 class ApiListCommand extends ApiListCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = "List all API commands";
   protected string $namespace = 'api';
 
-  protected function configure(): void {
-    $this
-      ->setAliases(['api']);
+  protected function configure(): void
+  {
   }
 
 }

--- a/src/Command/Api/ApiListCommand.php
+++ b/src/Command/Api/ApiListCommand.php
@@ -6,13 +6,12 @@ namespace Acquia\Cli\Command\Api;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'api:list', 'List all API commands', ['api'])]
+#[AsCommand(name: 'api:list', description: 'List all API commands', aliases: ['api'])]
 class ApiListCommand extends ApiListCommandBase {
 
   protected string $namespace = 'api';
 
-  protected function configure(): void
-  {
+  protected function configure(): void {
   }
 
 }

--- a/src/Command/Api/ApiListCommand.php
+++ b/src/Command/Api/ApiListCommand.php
@@ -4,8 +4,10 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Api;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+#[RequireAuth]
 #[AsCommand(name: 'api:list', description: 'List all API commands', aliases: ['api'])]
 class ApiListCommand extends ApiListCommandBase {
 

--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -11,18 +11,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:open')]
+#[AsCommand(name: 'app:open', 'Opens your browser to view a given Cloud application', ['open', 'o'])]
 class AppOpenCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Opens your browser to view a given Cloud application';
 
   protected function configure(): void {
     $this
-      ->setAliases(['open', 'o'])
       ->acceptApplicationUuid();
   }
 

--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -22,8 +22,8 @@ class AppOpenCommand extends CommandBase {
 
   protected function configure(): void {
     $this
-      ->acceptApplicationUuid()
-      ->setAliases(['open', 'o']);
+      ->setAliases(['open', 'o'])
+      ->acceptApplicationUuid();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:open')]
 class AppOpenCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Opens your browser to view a given Cloud application';
+
   protected function configure(): void {
-    $this->setDescription('Opens your browser to view a given Cloud application')
+    $this
       ->acceptApplicationUuid()
       ->setAliases(['open', 'o']);
   }

--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\App;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'app:open', description: 'Opens your browser to view a given Cloud application', aliases: ['open', 'o'])]
 class AppOpenCommand extends CommandBase {
 

--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:open', 'Opens your browser to view a given Cloud application', ['open', 'o'])]
+#[AsCommand(name: 'app:open', description: 'Opens your browser to view a given Cloud application', aliases: ['open', 'o'])]
 class AppOpenCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/App/AppOpenCommand.php
+++ b/src/Command/App/AppOpenCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'app:open', description: 'Opens your browser to view a given Cloud application', aliases: ['open', 'o'])]
-class AppOpenCommand extends CommandBase {
+final class AppOpenCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/App/AppVcsInfo.php
+++ b/src/Command/App/AppVcsInfo.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\App;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Endpoints\Code;
@@ -14,6 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'app:vcs:info', description: 'Get all branches and tags of the application with the deployment status')]
 class AppVcsInfo extends CommandBase {
 

--- a/src/Command/App/AppVcsInfo.php
+++ b/src/Command/App/AppVcsInfo.php
@@ -17,8 +17,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:vcs:info')]
 class AppVcsInfo extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Get all branches and tags of the application with the deployment status';
+
   protected function configure(): void {
-    $this->setDescription('Get all branches and tags of the application with the deployment status')
+    $this
       ->addOption('deployed', NULL, InputOption::VALUE_OPTIONAL, 'Show only deployed branches and tags')
       ->addUsage('[<applicationAlias>] --deployed');
     $this->acceptApplicationUuid();

--- a/src/Command/App/AppVcsInfo.php
+++ b/src/Command/App/AppVcsInfo.php
@@ -14,14 +14,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:vcs:info')]
+#[AsCommand(name: 'app:vcs:info', 'Get all branches and tags of the application with the deployment status')]
 class AppVcsInfo extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Get all branches and tags of the application with the deployment status';
 
   protected function configure(): void {
     $this

--- a/src/Command/App/AppVcsInfo.php
+++ b/src/Command/App/AppVcsInfo.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:vcs:info', 'Get all branches and tags of the application with the deployment status')]
+#[AsCommand(name: 'app:vcs:info', description: 'Get all branches and tags of the application with the deployment status')]
 class AppVcsInfo extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/App/LinkCommand.php
+++ b/src/Command/App/LinkCommand.php
@@ -13,8 +13,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:link')]
 class LinkCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Associate your project with a Cloud Platform application';
+
   protected function configure(): void {
-    $this->setDescription('Associate your project with a Cloud Platform application')
+    $this
       ->setAliases(['link']);
     $this->acceptApplicationUuid();
   }

--- a/src/Command/App/LinkCommand.php
+++ b/src/Command/App/LinkCommand.php
@@ -4,12 +4,14 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\App;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'app:link', description: 'Associate your project with a Cloud Platform application', aliases: ['link'])]
 class LinkCommand extends CommandBase {
 

--- a/src/Command/App/LinkCommand.php
+++ b/src/Command/App/LinkCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'app:link', description: 'Associate your project with a Cloud Platform application', aliases: ['link'])]
-class LinkCommand extends CommandBase {
+final class LinkCommand extends CommandBase {
 
   protected function configure(): void {
     $this->acceptApplicationUuid();

--- a/src/Command/App/LinkCommand.php
+++ b/src/Command/App/LinkCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:link', 'Associate your project with a Cloud Platform application', ['link'])]
+#[AsCommand(name: 'app:link', description: 'Associate your project with a Cloud Platform application', aliases: ['link'])]
 class LinkCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/App/LinkCommand.php
+++ b/src/Command/App/LinkCommand.php
@@ -10,18 +10,10 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:link')]
+#[AsCommand(name: 'app:link', 'Associate your project with a Cloud Platform application', ['link'])]
 class LinkCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Associate your project with a Cloud Platform application';
-
   protected function configure(): void {
-    $this
-      ->setAliases(['link']);
     $this->acceptApplicationUuid();
   }
 

--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:log:tail')]
 class LogTailCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Tail the logs from your environments';
+
   protected function configure(): void {
-    $this->setDescription('Tail the logs from your environments')
+    $this
       ->acceptEnvironmentId()
       ->setAliases(['tail', 'log:tail']);
   }

--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -11,18 +11,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:log:tail')]
+#[AsCommand(name: 'app:log:tail', 'Tail the logs from your environments', ['tail', 'log:tail'])]
 class LogTailCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Tail the logs from your environments';
 
   protected function configure(): void {
     $this
-      ->setAliases(['tail', 'log:tail'])
       ->acceptEnvironmentId();
   }
 

--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:log:tail', 'Tail the logs from your environments', ['tail', 'log:tail'])]
+#[AsCommand(name: 'app:log:tail', description: 'Tail the logs from your environments', aliases: ['tail', 'log:tail'])]
 class LogTailCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\App;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use AcquiaCloudApi\Endpoints\Logs;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'app:log:tail', description: 'Tail the logs from your environments', aliases: ['tail', 'log:tail'])]
 class LogTailCommand extends CommandBase {
 

--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -22,8 +22,8 @@ class LogTailCommand extends CommandBase {
 
   protected function configure(): void {
     $this
-      ->acceptEnvironmentId()
-      ->setAliases(['tail', 'log:tail']);
+      ->setAliases(['tail', 'log:tail'])
+      ->acceptEnvironmentId();
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'app:log:tail', description: 'Tail the logs from your environments', aliases: ['tail', 'log:tail'])]
-class LogTailCommand extends CommandBase {
+final class LogTailCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -25,8 +25,8 @@ class NewCommand extends CommandBase {
 
   protected function configure(): void {
     $this
-      ->addArgument('directory', InputArgument::OPTIONAL, 'The destination directory')
-      ->setAliases(['new']);
+      ->setAliases(['new'])
+      ->addArgument('directory', InputArgument::OPTIONAL, 'The destination directory');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -14,18 +14,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 
-#[AsCommand(name: 'app:new:local')]
+#[AsCommand(name: 'app:new:local', 'Create a new Drupal or Next.js project', ['new'])]
 class NewCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Create a new Drupal or Next.js project';
 
   protected function configure(): void {
     $this
-      ->setAliases(['new'])
       ->addArgument('directory', InputArgument::OPTIONAL, 'The destination directory');
   }
 

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -17,8 +17,14 @@ use Symfony\Component\Filesystem\Path;
 #[AsCommand(name: 'app:new:local')]
 class NewCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Create a new Drupal or Next.js project';
+
   protected function configure(): void {
-    $this->setDescription('Create a new Drupal or Next.js project')
+    $this
       ->addArgument('directory', InputArgument::OPTIONAL, 'The destination directory')
       ->setAliases(['new']);
   }

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 
-#[AsCommand(name: 'app:new:local', 'Create a new Drupal or Next.js project', ['new'])]
+#[AsCommand(name: 'app:new:local', description: 'Create a new Drupal or Next.js project', aliases: ['new'])]
 class NewCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -64,10 +64,6 @@ class NewCommand extends CommandBase {
     return Command::SUCCESS;
   }
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   private function createNextJsProject(string $dir): void {
     $process = $this->localMachineHelper->execute([
       'npx',

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 
 #[AsCommand(name: 'app:new:local', description: 'Create a new Drupal or Next.js project', aliases: ['new'])]
-class NewCommand extends CommandBase {
+final class NewCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/App/NewFromDrupal7Command.php
+++ b/src/Command/App/NewFromDrupal7Command.php
@@ -28,7 +28,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
   // A nod to its roots.
   'ama',
 ])]
-class NewFromDrupal7Command extends CommandBase {
+final class NewFromDrupal7Command extends CommandBase {
 
   /**
    * Exit code raised when the URI flag does not correspond to configuration.

--- a/src/Command/App/NewFromDrupal7Command.php
+++ b/src/Command/App/NewFromDrupal7Command.php
@@ -22,14 +22,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Validator\Exception\ValidatorException;
 
-#[AsCommand(name: 'app:new:from:drupal7')]
+#[AsCommand(name: 'app:new:from:drupal7', 'Generate a new Drupal 9+ project from a Drupal 7 application using the default Acquia Migrate Accelerate recommendations.', [
+  // Currently only "from Drupal 7", more to potentially follow.
+  'from:d7',
+  // A nod to its roots.
+  'ama',
+])]
 class NewFromDrupal7Command extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Generate a new Drupal 9+ project from a Drupal 7 application using the default Acquia Migrate Accelerate recommendations.';
   /**
    * Exit code raised when the URI flag does not correspond to configuration.
    *
@@ -48,12 +48,6 @@ class NewFromDrupal7Command extends CommandBase {
 
   protected function configure(): void {
     $this
-      ->setAliases([
-        // Currently only "from Drupal 7", more to potentially follow.
-        'from:d7',
-        // A nod to its roots.
-        'ama',
-      ])
       ->addOption('drupal7-directory', 'source', InputOption::VALUE_OPTIONAL, 'The root of the Drupal 7 application')
       ->addOption('drupal7-uri', 'uri', InputOption::VALUE_OPTIONAL, 'Only necessary in case of a multisite. If a single site, this will be computed automatically.')
       ->addOption('stored-analysis', 'analysis', InputOption::VALUE_OPTIONAL, 'As an alternative to drupal7-directory, it is possible to pass a stored analysis.')

--- a/src/Command/App/NewFromDrupal7Command.php
+++ b/src/Command/App/NewFromDrupal7Command.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Validator\Exception\ValidatorException;
 
-#[AsCommand(name: 'app:new:from:drupal7', 'Generate a new Drupal 9+ project from a Drupal 7 application using the default Acquia Migrate Accelerate recommendations.', [
+#[AsCommand(name: 'app:new:from:drupal7', description: 'Generate a new Drupal 9+ project from a Drupal 7 application using the default Acquia Migrate Accelerate recommendations.', aliases: [
   // Currently only "from Drupal 7", more to potentially follow.
   'from:d7',
   // A nod to its roots.

--- a/src/Command/App/NewFromDrupal7Command.php
+++ b/src/Command/App/NewFromDrupal7Command.php
@@ -214,10 +214,6 @@ class NewFromDrupal7Command extends CommandBase {
     return Command::SUCCESS;
   }
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   private function initializeGitRepository(string $dir): void {
     if ($this->localMachineHelper->getFilesystem()->exists(Path::join($dir, '.git'))) {
       $this->logger->debug('.git directory detected, skipping Git repo initialization');

--- a/src/Command/App/NewFromDrupal7Command.php
+++ b/src/Command/App/NewFromDrupal7Command.php
@@ -26,6 +26,11 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 class NewFromDrupal7Command extends CommandBase {
 
   /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Generate a new Drupal 9+ project from a Drupal 7 application using the default Acquia Migrate Accelerate recommendations.';
+  /**
    * Exit code raised when the URI flag does not correspond to configuration.
    *
    * This typically indicates the value of the --drupal7-uri flag does not
@@ -42,7 +47,7 @@ class NewFromDrupal7Command extends CommandBase {
   public const ERR_INDETERMINATE_SITE = 4;
 
   protected function configure(): void {
-    $this->setDescription('Generate a new Drupal 9+ project from a Drupal 7 application using the default Acquia Migrate Accelerate recommendations.')
+    $this
       ->addOption('drupal7-directory', 'source', InputOption::VALUE_OPTIONAL, 'The root of the Drupal 7 application')
       ->addOption('drupal7-uri', 'uri', InputOption::VALUE_OPTIONAL, 'Only necessary in case of a multisite. If a single site, this will be computed automatically.')
       ->addOption('stored-analysis', 'analysis', InputOption::VALUE_OPTIONAL, 'As an alternative to drupal7-directory, it is possible to pass a stored analysis.')

--- a/src/Command/App/NewFromDrupal7Command.php
+++ b/src/Command/App/NewFromDrupal7Command.php
@@ -48,17 +48,17 @@ class NewFromDrupal7Command extends CommandBase {
 
   protected function configure(): void {
     $this
-      ->addOption('drupal7-directory', 'source', InputOption::VALUE_OPTIONAL, 'The root of the Drupal 7 application')
-      ->addOption('drupal7-uri', 'uri', InputOption::VALUE_OPTIONAL, 'Only necessary in case of a multisite. If a single site, this will be computed automatically.')
-      ->addOption('stored-analysis', 'analysis', InputOption::VALUE_OPTIONAL, 'As an alternative to drupal7-directory, it is possible to pass a stored analysis.')
-      ->addOption('recommendations', 'recommendations', InputOption::VALUE_OPTIONAL, 'Overrides the default recommendations.')
-      ->addOption('directory', 'destination', InputOption::VALUE_OPTIONAL, 'The directory where to generate the new application.')
       ->setAliases([
         // Currently only "from Drupal 7", more to potentially follow.
         'from:d7',
         // A nod to its roots.
         'ama',
-      ]);
+      ])
+      ->addOption('drupal7-directory', 'source', InputOption::VALUE_OPTIONAL, 'The root of the Drupal 7 application')
+      ->addOption('drupal7-uri', 'uri', InputOption::VALUE_OPTIONAL, 'Only necessary in case of a multisite. If a single site, this will be computed automatically.')
+      ->addOption('stored-analysis', 'analysis', InputOption::VALUE_OPTIONAL, 'As an alternative to drupal7-directory, it is possible to pass a stored analysis.')
+      ->addOption('recommendations', 'recommendations', InputOption::VALUE_OPTIONAL, 'Overrides the default recommendations.')
+      ->addOption('directory', 'destination', InputOption::VALUE_OPTIONAL, 'The directory where to generate the new application.');
   }
 
   private function getInspector(InputInterface $input): SiteInspectorInterface {

--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:task-wait', 'Wait for a task to complete')]
+#[AsCommand(name: 'app:task-wait', description: 'Wait for a task to complete')]
 class TaskWaitCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:task-wait')]
 class TaskWaitCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Wait for a task to complete';
+
   protected function configure(): void {
-    $this->setDescription('Wait for a task to complete')
+    $this
       ->addArgument('notification-uuid', InputArgument::REQUIRED, 'The task notification UUID or Cloud Platform API response containing a linked notification')
       ->setHelp('Accepts either a notification UUID or Cloud Platform API response as JSON string. The JSON string must contain the _links->notification->href property.')
       ->addUsage('"$(acli api:environments:domain-clear-caches [environmentId] [domain])"');

--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\App;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'app:task-wait', description: 'Wait for a task to complete')]
 class TaskWaitCommand extends CommandBase {
 

--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'app:task-wait', description: 'Wait for a task to complete')]
-class TaskWaitCommand extends CommandBase {
+final class TaskWaitCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/App/TaskWaitCommand.php
+++ b/src/Command/App/TaskWaitCommand.php
@@ -11,14 +11,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:task-wait')]
+#[AsCommand(name: 'app:task-wait', 'Wait for a task to complete')]
 class TaskWaitCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Wait for a task to complete';
 
   protected function configure(): void {
     $this

--- a/src/Command/App/UnlinkCommand.php
+++ b/src/Command/App/UnlinkCommand.php
@@ -11,11 +11,10 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:unlink', 'Remove local association between your project and a Cloud Platform application', ['unlink'])]
+#[AsCommand(name: 'app:unlink', description: 'Remove local association between your project and a Cloud Platform application', aliases: ['unlink'])]
 class UnlinkCommand extends CommandBase {
 
-  protected function configure(): void
-  {
+  protected function configure(): void {
   }
 
   protected function commandRequiresAuthentication(): bool {

--- a/src/Command/App/UnlinkCommand.php
+++ b/src/Command/App/UnlinkCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:unlink')]
 class UnlinkCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Remove local association between your project and a Cloud Platform application';
+
   protected function configure(): void {
-    $this->setDescription('Remove local association between your project and a Cloud Platform application')
+    $this
       ->setAliases(['unlink']);
   }
 

--- a/src/Command/App/UnlinkCommand.php
+++ b/src/Command/App/UnlinkCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'app:unlink', description: 'Remove local association between your project and a Cloud Platform application', aliases: ['unlink'])]
-class UnlinkCommand extends CommandBase {
+final class UnlinkCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->validateCwdIsValidDrupalProject();

--- a/src/Command/App/UnlinkCommand.php
+++ b/src/Command/App/UnlinkCommand.php
@@ -11,18 +11,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'app:unlink')]
+#[AsCommand(name: 'app:unlink', 'Remove local association between your project and a Cloud Platform application', ['unlink'])]
 class UnlinkCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Remove local association between your project and a Cloud Platform application';
-
-  protected function configure(): void {
-    $this
-      ->setAliases(['unlink']);
+  protected function configure(): void
+  {
   }
 
   protected function commandRequiresAuthentication(): bool {

--- a/src/Command/App/UnlinkCommand.php
+++ b/src/Command/App/UnlinkCommand.php
@@ -14,9 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:unlink', description: 'Remove local association between your project and a Cloud Platform application', aliases: ['unlink'])]
 class UnlinkCommand extends CommandBase {
 
-  protected function configure(): void {
-  }
-
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }

--- a/src/Command/App/UnlinkCommand.php
+++ b/src/Command/App/UnlinkCommand.php
@@ -14,10 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'app:unlink', description: 'Remove local association between your project and a Cloud Platform application', aliases: ['unlink'])]
 class UnlinkCommand extends CommandBase {
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->validateCwdIsValidDrupalProject();
 

--- a/src/Command/Archive/ArchiveExportCommand.php
+++ b/src/Command/Archive/ArchiveExportCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Archive;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
@@ -18,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
+#[RequireAuth]
 #[AsCommand(name: 'archive:export', description: 'Export an archive of the Drupal application including code, files, and database')]
 class ArchiveExportCommand extends CommandBase {
 

--- a/src/Command/Archive/ArchiveExportCommand.php
+++ b/src/Command/Archive/ArchiveExportCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Filesystem\Path;
 
 #[RequireAuth]
 #[AsCommand(name: 'archive:export', description: 'Export an archive of the Drupal application including code, files, and database')]
-class ArchiveExportCommand extends CommandBase {
+final class ArchiveExportCommand extends CommandBase {
 
   protected Checklist $checklist;
 

--- a/src/Command/Archive/ArchiveExportCommand.php
+++ b/src/Command/Archive/ArchiveExportCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
-#[AsCommand(name: 'archive:export', 'Export an archive of the Drupal application including code, files, and database')]
+#[AsCommand(name: 'archive:export', description: 'Export an archive of the Drupal application including code, files, and database')]
 class ArchiveExportCommand extends CommandBase {
 
   protected Checklist $checklist;

--- a/src/Command/Archive/ArchiveExportCommand.php
+++ b/src/Command/Archive/ArchiveExportCommand.php
@@ -9,6 +9,7 @@ use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Closure;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
+#[AsCommand(name: 'archive:export')]
 class ArchiveExportCommand extends CommandBase {
 
   protected Checklist $checklist;
@@ -35,7 +37,6 @@ class ArchiveExportCommand extends CommandBase {
   }
 
   protected function configure(): void {
-    $this->setName('archive:export');
     $this->setDescription('Export an archive of the Drupal application including code, files, and database')
       ->addArgument('destination-dir', InputArgument::REQUIRED, 'The destination directory for the archive file')
       ->addOption('source-dir', 'dir', InputOption::VALUE_REQUIRED, 'The directory containing the Drupal project to be pushed')

--- a/src/Command/Archive/ArchiveExportCommand.php
+++ b/src/Command/Archive/ArchiveExportCommand.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\Archive;
 
 use Acquia\Cli\Attribute\RequireAuth;
+use Acquia\Cli\Attribute\RequireDb;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
@@ -20,6 +21,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
 #[RequireAuth]
+#[RequireDb]
 #[AsCommand(name: 'archive:export', description: 'Export an archive of the Drupal application including code, files, and database')]
 final class ArchiveExportCommand extends CommandBase {
 
@@ -33,10 +35,6 @@ final class ArchiveExportCommand extends CommandBase {
   private string|array|bool|null $destinationDir;
 
   private const PUBLIC_FILES_DIR = '/docroot/sites/default/files';
-
-  protected function commandRequiresDatabase(): bool {
-    return TRUE;
-  }
 
   protected function configure(): void {
     $this

--- a/src/Command/Archive/ArchiveExportCommand.php
+++ b/src/Command/Archive/ArchiveExportCommand.php
@@ -21,6 +21,11 @@ use Symfony\Component\Filesystem\Path;
 #[AsCommand(name: 'archive:export')]
 class ArchiveExportCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Export an archive of the Drupal application including code, files, and database';
   protected Checklist $checklist;
 
   private Filesystem $fs;
@@ -37,7 +42,7 @@ class ArchiveExportCommand extends CommandBase {
   }
 
   protected function configure(): void {
-    $this->setDescription('Export an archive of the Drupal application including code, files, and database')
+    $this
       ->addArgument('destination-dir', InputArgument::REQUIRED, 'The destination directory for the archive file')
       ->addOption('source-dir', 'dir', InputOption::VALUE_REQUIRED, 'The directory containing the Drupal project to be pushed')
       ->addOption('no-files', NULL, InputOption::VALUE_NONE, 'Exclude public files directory from archive')

--- a/src/Command/Archive/ArchiveExportCommand.php
+++ b/src/Command/Archive/ArchiveExportCommand.php
@@ -18,14 +18,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
-#[AsCommand(name: 'archive:export')]
+#[AsCommand(name: 'archive:export', 'Export an archive of the Drupal application including code, files, and database')]
 class ArchiveExportCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Export an archive of the Drupal application including code, files, and database';
   protected Checklist $checklist;
 
   private Filesystem $fs;

--- a/src/Command/Auth/AuthAcsfLoginCommand.php
+++ b/src/Command/Auth/AuthAcsfLoginCommand.php
@@ -21,10 +21,6 @@ class AuthAcsfLoginCommand extends CommandBase {
       ->addOption('factory-url', 'f', InputOption::VALUE_REQUIRED, "Your Site Factory URL");
   }
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     if ($input->getOption('factory-url')) {
       $factoryUrl = $input->getOption('factory-url');

--- a/src/Command/Auth/AuthAcsfLoginCommand.php
+++ b/src/Command/Auth/AuthAcsfLoginCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'auth:acsf-login', description: 'Register your Site Factory API key and secret to use API functionality')]
-class AuthAcsfLoginCommand extends CommandBase {
+final class AuthAcsfLoginCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Auth/AuthAcsfLoginCommand.php
+++ b/src/Command/Auth/AuthAcsfLoginCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:acsf-login', 'Register your Site Factory API key and secret to use API functionality')]
+#[AsCommand(name: 'auth:acsf-login', description: 'Register your Site Factory API key and secret to use API functionality')]
 class AuthAcsfLoginCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Auth/AuthAcsfLoginCommand.php
+++ b/src/Command/Auth/AuthAcsfLoginCommand.php
@@ -11,14 +11,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:acsf-login')]
+#[AsCommand(name: 'auth:acsf-login', 'Register your Site Factory API key and secret to use API functionality')]
 class AuthAcsfLoginCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Register your Site Factory API key and secret to use API functionality';
 
   protected function configure(): void {
     $this

--- a/src/Command/Auth/AuthAcsfLoginCommand.php
+++ b/src/Command/Auth/AuthAcsfLoginCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'auth:acsf-login')]
 class AuthAcsfLoginCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Register your Site Factory API key and secret to use API functionality';
+
   protected function configure(): void {
-    $this->setDescription('Register your Site Factory API key and secret to use API functionality')
+    $this
       ->addOption('username', 'u', InputOption::VALUE_REQUIRED, "Your Site Factory username")
       ->addOption('key', 'k', InputOption::VALUE_REQUIRED, "Your Site Factory key")
       ->addOption('factory-url', 'f', InputOption::VALUE_REQUIRED, "Your Site Factory URL");

--- a/src/Command/Auth/AuthAcsfLogoutCommand.php
+++ b/src/Command/Auth/AuthAcsfLogoutCommand.php
@@ -13,10 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'auth:acsf-logout', description: 'Remove your Site Factory key and secret from your local machine.')]
 class AuthAcsfLogoutCommand extends CommandBase {
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $factories = $this->datastoreCloud->get('acsf_factories');
     if (empty($factories)) {

--- a/src/Command/Auth/AuthAcsfLogoutCommand.php
+++ b/src/Command/Auth/AuthAcsfLogoutCommand.php
@@ -13,9 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'auth:acsf-logout', description: 'Remove your Site Factory key and secret from your local machine.')]
 class AuthAcsfLogoutCommand extends CommandBase {
 
-  protected function configure(): void {
-  }
-
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }

--- a/src/Command/Auth/AuthAcsfLogoutCommand.php
+++ b/src/Command/Auth/AuthAcsfLogoutCommand.php
@@ -10,14 +10,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:acsf-logout')]
+#[AsCommand(name: 'auth:acsf-logout', 'Remove your Site Factory key and secret from your local machine.')]
 class AuthAcsfLogoutCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Remove your Site Factory key and secret from your local machine.';
 
   protected function configure(): void {
   }

--- a/src/Command/Auth/AuthAcsfLogoutCommand.php
+++ b/src/Command/Auth/AuthAcsfLogoutCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:acsf-logout', 'Remove your Site Factory key and secret from your local machine.')]
+#[AsCommand(name: 'auth:acsf-logout', description: 'Remove your Site Factory key and secret from your local machine.')]
 class AuthAcsfLogoutCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Auth/AuthAcsfLogoutCommand.php
+++ b/src/Command/Auth/AuthAcsfLogoutCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'auth:acsf-logout', description: 'Remove your Site Factory key and secret from your local machine.')]
-class AuthAcsfLogoutCommand extends CommandBase {
+final class AuthAcsfLogoutCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $factories = $this->datastoreCloud->get('acsf_factories');

--- a/src/Command/Auth/AuthAcsfLogoutCommand.php
+++ b/src/Command/Auth/AuthAcsfLogoutCommand.php
@@ -13,8 +13,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'auth:acsf-logout')]
 class AuthAcsfLogoutCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Remove your Site Factory key and secret from your local machine.';
+
   protected function configure(): void {
-    $this->setDescription('Remove your Site Factory key and secret from your local machine.');
   }
 
   protected function commandRequiresAuthentication(): bool {

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'auth:login')]
 class AuthLoginCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Register your Cloud API key and secret to use API functionality';
+
   protected function configure(): void {
-    $this->setDescription('Register your Cloud API key and secret to use API functionality')
+    $this
       ->setAliases(['login'])
       ->addOption('key', 'k', InputOption::VALUE_REQUIRED, 'Your Cloud API key')
       ->addOption('secret', 's', InputOption::VALUE_REQUIRED, 'Your Cloud API secret');

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:login', 'Register your Cloud API key and secret to use API functionality', ['login'])]
+#[AsCommand(name: 'auth:login', description: 'Register your Cloud API key and secret to use API functionality', aliases: ['login'])]
 class AuthLoginCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'auth:login', description: 'Register your Cloud API key and secret to use API functionality', aliases: ['login'])]
-class AuthLoginCommand extends CommandBase {
+final class AuthLoginCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -11,18 +11,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:login')]
+#[AsCommand(name: 'auth:login', 'Register your Cloud API key and secret to use API functionality', ['login'])]
 class AuthLoginCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Register your Cloud API key and secret to use API functionality';
 
   protected function configure(): void {
     $this
-      ->setAliases(['login'])
       ->addOption('key', 'k', InputOption::VALUE_REQUIRED, 'Your Cloud API key')
       ->addOption('secret', 's', InputOption::VALUE_REQUIRED, 'Your Cloud API secret');
   }

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -20,10 +20,6 @@ class AuthLoginCommand extends CommandBase {
       ->addOption('secret', 's', InputOption::VALUE_REQUIRED, 'Your Cloud API secret');
   }
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     if ($this->cloudApiClientService->isMachineAuthenticated()) {
       $answer = $this->io->confirm('Your machine has already been authenticated with the Cloud Platform API, would you like to re-authenticate?');

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -10,18 +10,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:logout')]
+#[AsCommand(name: 'auth:logout', 'Remove Cloud API key and secret from local machine.', ['logout'])]
 class AuthLogoutCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Remove Cloud API key and secret from local machine.';
-
-  protected function configure(): void {
-    $this
-      ->setAliases(['logout']);
+  protected function configure(): void
+  {
   }
 
   protected function commandRequiresAuthentication(): bool {

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'auth:logout', description: 'Remove Cloud API key and secret from local machine.', aliases: ['logout'])]
-class AuthLogoutCommand extends CommandBase {
+final class AuthLogoutCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     if ($this->cloudApiClientService->isMachineAuthenticated()) {

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -13,9 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'auth:logout', description: 'Remove Cloud API key and secret from local machine.', aliases: ['logout'])]
 class AuthLogoutCommand extends CommandBase {
 
-  protected function configure(): void {
-  }
-
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -13,10 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'auth:logout', description: 'Remove Cloud API key and secret from local machine.', aliases: ['logout'])]
 class AuthLogoutCommand extends CommandBase {
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     if ($this->cloudApiClientService->isMachineAuthenticated()) {
       $answer = $this->io->confirm('Are you sure you\'d like to unset the Acquia Cloud API key for Acquia CLI?');

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -10,11 +10,10 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:logout', 'Remove Cloud API key and secret from local machine.', ['logout'])]
+#[AsCommand(name: 'auth:logout', description: 'Remove Cloud API key and secret from local machine.', aliases: ['logout'])]
 class AuthLogoutCommand extends CommandBase {
 
-  protected function configure(): void
-  {
+  protected function configure(): void {
   }
 
   protected function commandRequiresAuthentication(): bool {

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -13,8 +13,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'auth:logout')]
 class AuthLogoutCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Remove Cloud API key and secret from local machine.';
+
   protected function configure(): void {
-    $this->setDescription('Remove Cloud API key and secret from local machine.')
+    $this
       ->setAliases(['logout']);
   }
 

--- a/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\CodeStudio;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Gitlab\Exception\RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'codestudio:php-version', description: 'Change the PHP version in Code Studio')]
 class CodeStudioPhpVersionCommand extends CommandBase {
 

--- a/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
@@ -14,10 +14,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'codestudio:php-version')]
 class CodeStudioPhpVersionCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Change the PHP version in Code Studio';
   use CodeStudioCommandTrait;
 
   protected function configure(): void {
-    $this->setDescription('Change the PHP version in Code Studio')
+    $this
       ->addArgument('php-version', InputArgument::REQUIRED, 'The PHP version that needs to configured or updated')
       ->addUsage('8.1 myapp')
       ->addUsage('8.1 abcd1234-1111-2222-3333-0e02b2c3d470');

--- a/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'codestudio:php-version', 'Change the PHP version in Code Studio')]
+#[AsCommand(name: 'codestudio:php-version', description: 'Change the PHP version in Code Studio')]
 class CodeStudioPhpVersionCommand extends CommandBase {
 
   use CodeStudioCommandTrait;

--- a/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'codestudio:php-version', description: 'Change the PHP version in Code Studio')]
-class CodeStudioPhpVersionCommand extends CommandBase {
+final class CodeStudioPhpVersionCommand extends CommandBase {
 
   use CodeStudioCommandTrait;
 

--- a/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPhpVersionCommand.php
@@ -11,14 +11,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'codestudio:php-version')]
+#[AsCommand(name: 'codestudio:php-version', 'Change the PHP version in Code Studio')]
 class CodeStudioPhpVersionCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Change the PHP version in Code Studio';
   use CodeStudioCommandTrait;
 
   protected function configure(): void {

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Yaml\Yaml;
 
 #[AsCommand(name: 'codestudio:pipelines-migrate', description: 'Migrate .acquia-pipeline.yml file to .gitlab-ci.yml file for a given Acquia Cloud application', aliases: ['cs:pipelines-migrate'])]
-class CodeStudioPipelinesMigrateCommand extends CommandBase {
+final class CodeStudioPipelinesMigrateCommand extends CommandBase {
 
   use CodeStudioCommandTrait;
 

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -16,19 +16,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Yaml\Yaml;
 
-#[AsCommand(name: 'codestudio:pipelines-migrate')]
+#[AsCommand(name: 'codestudio:pipelines-migrate', 'Migrate .acquia-pipeline.yml file to .gitlab-ci.yml file for a given Acquia Cloud application', ['cs:pipelines-migrate'])]
 class CodeStudioPipelinesMigrateCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Migrate .acquia-pipeline.yml file to .gitlab-ci.yml file for a given Acquia Cloud application';
   use CodeStudioCommandTrait;
 
   protected function configure(): void {
     $this
-      ->setAliases(['cs:pipelines-migrate'])
       ->addOption('key', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API token that Code Studio will use')
       ->addOption('secret', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API secret that Code Studio will use')
       ->addOption('gitlab-token', NULL, InputOption::VALUE_REQUIRED, 'The GitLab personal access token that will be used to communicate with the GitLab instance')

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -74,10 +74,6 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
     return Command::SUCCESS;
   }
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   /**
    * Check whether wizard command is executed by checking the env variable of codestudio project.
    *

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Yaml\Yaml;
 
-#[AsCommand(name: 'codestudio:pipelines-migrate', 'Migrate .acquia-pipeline.yml file to .gitlab-ci.yml file for a given Acquia Cloud application', ['cs:pipelines-migrate'])]
+#[AsCommand(name: 'codestudio:pipelines-migrate', description: 'Migrate .acquia-pipeline.yml file to .gitlab-ci.yml file for a given Acquia Cloud application', aliases: ['cs:pipelines-migrate'])]
 class CodeStudioPipelinesMigrateCommand extends CommandBase {
 
   use CodeStudioCommandTrait;

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -28,11 +28,11 @@ class CodeStudioPipelinesMigrateCommand extends CommandBase {
 
   protected function configure(): void {
     $this
+      ->setAliases(['cs:pipelines-migrate'])
       ->addOption('key', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API token that Code Studio will use')
       ->addOption('secret', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API secret that Code Studio will use')
       ->addOption('gitlab-token', NULL, InputOption::VALUE_REQUIRED, 'The GitLab personal access token that will be used to communicate with the GitLab instance')
-      ->addOption('gitlab-project-id', NULL, InputOption::VALUE_REQUIRED, 'The project ID (an integer) of the GitLab project to configure.')
-      ->setAliases(['cs:pipelines-migrate']);
+      ->addOption('gitlab-project-id', NULL, InputOption::VALUE_REQUIRED, 'The project ID (an integer) of the GitLab project to configure.');
     $this->acceptApplicationUuid();
     $this->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
   }

--- a/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
+++ b/src/Command/CodeStudio/CodeStudioPipelinesMigrateCommand.php
@@ -19,10 +19,15 @@ use Symfony\Component\Yaml\Yaml;
 #[AsCommand(name: 'codestudio:pipelines-migrate')]
 class CodeStudioPipelinesMigrateCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Migrate .acquia-pipeline.yml file to .gitlab-ci.yml file for a given Acquia Cloud application';
   use CodeStudioCommandTrait;
 
   protected function configure(): void {
-    $this->setDescription('Migrate .acquia-pipeline.yml file to .gitlab-ci.yml file for a given Acquia Cloud application')
+    $this
       ->addOption('key', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API token that Code Studio will use')
       ->addOption('secret', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API secret that Code Studio will use')
       ->addOption('gitlab-token', NULL, InputOption::VALUE_REQUIRED, 'The GitLab personal access token that will be used to communicate with the GitLab instance')

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -115,10 +115,6 @@ class CodeStudioWizardCommand extends WizardCommandBase {
     return Command::SUCCESS;
   }
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   /**
    * @param array $project
    * @return array<mixed>|null

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'codestudio:wizard', description: 'Create and/or configure a new Code Studio project for a given Acquia Cloud application', aliases: ['cs:wizard'])]
-class CodeStudioWizardCommand extends WizardCommandBase {
+final class CodeStudioWizardCommand extends WizardCommandBase {
 
   use CodeStudioCommandTrait;
 

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -18,12 +18,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'codestudio:wizard')]
 class CodeStudioWizardCommand extends WizardCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Create and/or configure a new Code Studio project for a given Acquia Cloud application';
   use CodeStudioCommandTrait;
 
   private Checklist $checklist;
 
   protected function configure(): void {
-    $this->setDescription('Create and/or configure a new Code Studio project for a given Acquia Cloud application')
+    $this
       ->addOption('key', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API token that Code Studio will use')
       ->addOption('secret', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API secret that Code Studio will use')
       ->addOption('gitlab-token', NULL, InputOption::VALUE_REQUIRED, 'The GitLab personal access token that will be used to communicate with the GitLab instance')

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'codestudio:wizard', 'Create and/or configure a new Code Studio project for a given Acquia Cloud application', ['cs:wizard'])]
+#[AsCommand(name: 'codestudio:wizard', description: 'Create and/or configure a new Code Studio project for a given Acquia Cloud application', aliases: ['cs:wizard'])]
 class CodeStudioWizardCommand extends WizardCommandBase {
 
   use CodeStudioCommandTrait;

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -15,21 +15,15 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'codestudio:wizard')]
+#[AsCommand(name: 'codestudio:wizard', 'Create and/or configure a new Code Studio project for a given Acquia Cloud application', ['cs:wizard'])]
 class CodeStudioWizardCommand extends WizardCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Create and/or configure a new Code Studio project for a given Acquia Cloud application';
   use CodeStudioCommandTrait;
 
   private Checklist $checklist;
 
   protected function configure(): void {
     $this
-      ->setAliases(['cs:wizard'])
       ->addOption('key', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API token that Code Studio will use')
       ->addOption('secret', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API secret that Code Studio will use')
       ->addOption('gitlab-token', NULL, InputOption::VALUE_REQUIRED, 'The GitLab personal access token that will be used to communicate with the GitLab instance')

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -29,12 +29,12 @@ class CodeStudioWizardCommand extends WizardCommandBase {
 
   protected function configure(): void {
     $this
+      ->setAliases(['cs:wizard'])
       ->addOption('key', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API token that Code Studio will use')
       ->addOption('secret', NULL, InputOption::VALUE_REQUIRED, 'The Cloud Platform API secret that Code Studio will use')
       ->addOption('gitlab-token', NULL, InputOption::VALUE_REQUIRED, 'The GitLab personal access token that will be used to communicate with the GitLab instance')
       ->addOption('gitlab-project-id', NULL, InputOption::VALUE_REQUIRED, 'The project ID (an integer) of the GitLab project to configure.')
-      ->addOption('gitlab-host-name', NULL, InputOption::VALUE_REQUIRED, 'The GitLab hostname.')
-      ->setAliases(['cs:wizard']);
+      ->addOption('gitlab-host-name', NULL, InputOption::VALUE_REQUIRED, 'The GitLab hostname.');
     $this->acceptApplicationUuid();
   }
 

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command;
 
 use Acquia\Cli\ApiCredentialsInterface;
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\Command\Ssh\SshKeyCommandBase;
 use Acquia\Cli\DataStore\AcquiaCliDatastore;
@@ -112,7 +113,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->setLocalDbName();
     $this->setLocalDbHost();
     parent::__construct();
-    if ($this->commandRequiresAuthentication()) {
+    $reflectionClass = new \ReflectionClass($this);
+    if ($reflectionClass->getAttributes(RequireAuth::class)) {
       $this->appendHelp('This command requires authentication via the Cloud Platform API.');
     }
     if ($this->commandRequiresDatabase()) {
@@ -299,14 +301,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       ->addUsage('myapp.dev default');
 
     return $this;
-  }
-
-  /**
-   * Indicates whether the command requires the machine to be authenticated with the Cloud Platform.
-   */
-  protected function commandRequiresAuthentication(): bool {
-    // Assume commands require authentication unless they opt out by overriding this method.
-    return TRUE;
   }
 
   protected function commandRequiresDatabase(): bool {
@@ -1477,7 +1471,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   protected function checkAuthentication(): void {
-    if ($this->commandRequiresAuthentication() && !$this->cloudApiClientService->isMachineAuthenticated()) {
+    $reflectionClass = new \ReflectionClass($this);
+    if ($reflectionClass->getAttributes(RequireAuth::class) && !$this->cloudApiClientService->isMachineAuthenticated()) {
       throw new AcquiaCliException('This machine is not yet authenticated with the Cloud Platform. Run `acli auth:login`');
     }
   }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -6,6 +6,7 @@ namespace Acquia\Cli\Command;
 
 use Acquia\Cli\ApiCredentialsInterface;
 use Acquia\Cli\Attribute\RequireAuth;
+use Acquia\Cli\Attribute\RequireDb;
 use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\Command\Ssh\SshKeyCommandBase;
 use Acquia\Cli\DataStore\AcquiaCliDatastore;
@@ -117,7 +118,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     if ($reflectionClass->getAttributes(RequireAuth::class)) {
       $this->appendHelp('This command requires authentication via the Cloud Platform API.');
     }
-    if ($this->commandRequiresDatabase()) {
+    if ($reflectionClass->getAttributes(RequireDb::class)) {
       $this->appendHelp('This command requires an active database connection. Set the following environment variables prior to running this command: '
         . 'ACLI_DB_HOST, ACLI_DB_NAME, ACLI_DB_USER, ACLI_DB_PASSWORD');
     }
@@ -301,10 +302,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
       ->addUsage('myapp.dev default');
 
     return $this;
-  }
-
-  protected function commandRequiresDatabase(): bool {
-    return FALSE;
   }
 
   /**

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -114,11 +114,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     $this->setLocalDbName();
     $this->setLocalDbHost();
     parent::__construct();
-    $reflectionClass = new \ReflectionClass($this);
-    if ($reflectionClass->getAttributes(RequireAuth::class)) {
+    if ((new \ReflectionClass(static::class))->getAttributes(RequireAuth::class)) {
       $this->appendHelp('This command requires authentication via the Cloud Platform API.');
     }
-    if ($reflectionClass->getAttributes(RequireDb::class)) {
+    if ((new \ReflectionClass(static::class))->getAttributes(RequireDb::class)) {
       $this->appendHelp('This command requires an active database connection. Set the following environment variables prior to running this command: '
         . 'ACLI_DB_HOST, ACLI_DB_NAME, ACLI_DB_USER, ACLI_DB_PASSWORD');
     }
@@ -1468,8 +1467,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   }
 
   protected function checkAuthentication(): void {
-    $reflectionClass = new \ReflectionClass($this);
-    if ($reflectionClass->getAttributes(RequireAuth::class) && !$this->cloudApiClientService->isMachineAuthenticated()) {
+    if ((new \ReflectionClass(static::class))->getAttributes(RequireAuth::class) && !$this->cloudApiClientService->isMachineAuthenticated()) {
       throw new AcquiaCliException('This machine is not yet authenticated with the Cloud Platform. Run `acli auth:login`');
     }
   }

--- a/src/Command/DocsCommand.php
+++ b/src/Command/DocsCommand.php
@@ -20,10 +20,6 @@ class DocsCommand extends CommandBase {
       ->addUsage('acli');
   }
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $acquiaProducts = [
       'Acquia CLI' => [

--- a/src/Command/DocsCommand.php
+++ b/src/Command/DocsCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
-#[AsCommand(name: 'docs', 'Open Acquia product documentation in a web browser')]
+#[AsCommand(name: 'docs', description: 'Open Acquia product documentation in a web browser')]
 class DocsCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/DocsCommand.php
+++ b/src/Command/DocsCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 #[AsCommand(name: 'docs')]
 class DocsCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Open Acquia product documentation in a web browser';
+
   protected function configure(): void {
-    $this->setDescription('Open Acquia product documentation in a web browser')
+    $this
       ->addArgument('product', InputArgument::OPTIONAL, 'Acquia Product Name')
       ->addUsage('acli');
   }

--- a/src/Command/DocsCommand.php
+++ b/src/Command/DocsCommand.php
@@ -11,14 +11,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
-#[AsCommand(name: 'docs')]
+#[AsCommand(name: 'docs', 'Open Acquia product documentation in a web browser')]
 class DocsCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Open Acquia product documentation in a web browser';
 
   protected function configure(): void {
     $this

--- a/src/Command/DocsCommand.php
+++ b/src/Command/DocsCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
 #[AsCommand(name: 'docs', description: 'Open Acquia product documentation in a web browser')]
-class DocsCommand extends CommandBase {
+final class DocsCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Email;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
@@ -25,6 +26,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
 
+#[RequireAuth]
 #[AsCommand(name: 'email:configure', description: 'Configure Platform email for one or more applications', aliases: ['ec'])]
 class ConfigurePlatformEmailCommand extends CommandBase {
 

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -28,8 +28,14 @@ use Symfony\Component\Yaml\Yaml;
 #[AsCommand(name: 'email:configure')]
 class ConfigurePlatformEmailCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Configure Platform email for one or more applications';
+
   protected function configure(): void {
-    $this->setDescription('Configure Platform email for one or more applications')
+    $this
       ->addArgument('subscriptionUuid', InputArgument::OPTIONAL, 'The subscription UUID to register the domain with.')
       ->setHelp('This command configures Platform Email for a domain in a subscription. It registers the domain with the subscription, associates the domain with an application or set of applications, and enables Platform Email for selected environments of these applications.')
       ->setAliases(['ec']);

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -28,7 +28,7 @@ use Symfony\Component\Yaml\Yaml;
 
 #[RequireAuth]
 #[AsCommand(name: 'email:configure', description: 'Configure Platform email for one or more applications', aliases: ['ec'])]
-class ConfigurePlatformEmailCommand extends CommandBase {
+final class ConfigurePlatformEmailCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
 
-#[AsCommand(name: 'email:configure', 'Configure Platform email for one or more applications', ['ec'])]
+#[AsCommand(name: 'email:configure', description: 'Configure Platform email for one or more applications', aliases: ['ec'])]
 class ConfigurePlatformEmailCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -36,9 +36,9 @@ class ConfigurePlatformEmailCommand extends CommandBase {
 
   protected function configure(): void {
     $this
+      ->setAliases(['ec'])
       ->addArgument('subscriptionUuid', InputArgument::OPTIONAL, 'The subscription UUID to register the domain with.')
-      ->setHelp('This command configures Platform Email for a domain in a subscription. It registers the domain with the subscription, associates the domain with an application or set of applications, and enables Platform Email for selected environments of these applications.')
-      ->setAliases(['ec']);
+      ->setHelp('This command configures Platform Email for a domain in a subscription. It registers the domain with the subscription, associates the domain with an application or set of applications, and enables Platform Email for selected environments of these applications.');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Email/ConfigurePlatformEmailCommand.php
+++ b/src/Command/Email/ConfigurePlatformEmailCommand.php
@@ -25,18 +25,11 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
 
-#[AsCommand(name: 'email:configure')]
+#[AsCommand(name: 'email:configure', 'Configure Platform email for one or more applications', ['ec'])]
 class ConfigurePlatformEmailCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Configure Platform email for one or more applications';
 
   protected function configure(): void {
     $this
-      ->setAliases(['ec'])
       ->addArgument('subscriptionUuid', InputArgument::OPTIONAL, 'The subscription UUID to register the domain with.')
       ->setHelp('This command configures Platform Email for a domain in a subscription. It registers the domain with the subscription, associates the domain with an application or set of applications, and enables Platform Email for selected environments of these applications.');
   }

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Email;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Response\SubscriptionResponse;
@@ -18,6 +19,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'email:info', description: 'Print information related to Platform Email set up in a subscription.')]
 class EmailInfoForSubscriptionCommand extends CommandBase {
 

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'email:info', description: 'Print information related to Platform Email set up in a subscription.')]
-class EmailInfoForSubscriptionCommand extends CommandBase {
+final class EmailInfoForSubscriptionCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -21,8 +21,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'email:info')]
 class EmailInfoForSubscriptionCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Print information related to Platform Email set up in a subscription.';
+
   protected function configure(): void {
-    $this->setDescription('Print information related to Platform Email set up in a subscription.')
+    $this
       ->addArgument('subscriptionUuid', InputArgument::OPTIONAL, 'The subscription UUID whose Platform Email configuration is to be checked.')
       ->setHelp('This command lists information related to Platform Email for a subscription, including which domains have been validated, which have not, and which applications have Platform Email domains associated.');
   }

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'email:info', 'Print information related to Platform Email set up in a subscription.')]
+#[AsCommand(name: 'email:info', description: 'Print information related to Platform Email set up in a subscription.')]
 class EmailInfoForSubscriptionCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Email/EmailInfoForSubscriptionCommand.php
+++ b/src/Command/Email/EmailInfoForSubscriptionCommand.php
@@ -18,14 +18,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'email:info')]
+#[AsCommand(name: 'email:info', 'Print information related to Platform Email set up in a subscription.')]
 class EmailInfoForSubscriptionCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Print information related to Platform Email set up in a subscription.';
 
   protected function configure(): void {
     $this

--- a/src/Command/Env/EnvCertCreateCommand.php
+++ b/src/Command/Env/EnvCertCreateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Env;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use AcquiaCloudApi\Endpoints\SslCertificates;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'env:certificate-create', description: 'Install an SSL certificate.')]
 class EnvCertCreateCommand extends CommandBase {
 

--- a/src/Command/Env/EnvCertCreateCommand.php
+++ b/src/Command/Env/EnvCertCreateCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'env:certificate-create', description: 'Install an SSL certificate.')]
-class EnvCertCreateCommand extends CommandBase {
+final class EnvCertCreateCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Env/EnvCertCreateCommand.php
+++ b/src/Command/Env/EnvCertCreateCommand.php
@@ -13,14 +13,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:certificate-create')]
+#[AsCommand(name: 'env:certificate-create', 'Install an SSL certificate.')]
 class EnvCertCreateCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Install an SSL certificate.';
 
   protected function configure(): void {
     $this

--- a/src/Command/Env/EnvCertCreateCommand.php
+++ b/src/Command/Env/EnvCertCreateCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:certificate-create', 'Install an SSL certificate.')]
+#[AsCommand(name: 'env:certificate-create', description: 'Install an SSL certificate.')]
 class EnvCertCreateCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Env/EnvCertCreateCommand.php
+++ b/src/Command/Env/EnvCertCreateCommand.php
@@ -16,8 +16,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'env:certificate-create')]
 class EnvCertCreateCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Install an SSL certificate.';
+
   protected function configure(): void {
-    $this->setDescription('Install an SSL certificate.')
+    $this
       ->addArgument('certificate', InputArgument::REQUIRED, 'Filename of the SSL certificate being installed')
       ->addArgument('private-key', InputArgument::REQUIRED, 'Filename of the SSL private key')
       ->addOption('legacy', '', InputOption::VALUE_OPTIONAL, 'True for legacy certificates', FALSE)

--- a/src/Command/Env/EnvCopyCronCommand.php
+++ b/src/Command/Env/EnvCopyCronCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:cron-copy', 'Copy all cron tasks from one Acquia Cloud Platform environment to another')]
+#[AsCommand(name: 'env:cron-copy', description: 'Copy all cron tasks from one Acquia Cloud Platform environment to another')]
 class EnvCopyCronCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Env/EnvCopyCronCommand.php
+++ b/src/Command/Env/EnvCopyCronCommand.php
@@ -16,8 +16,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'env:cron-copy')]
 class EnvCopyCronCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Copy all cron tasks from one Acquia Cloud Platform environment to another';
+
   protected function configure(): void {
-    $this->setDescription('Copy all cron tasks from one Acquia Cloud Platform environment to another')
+    $this
       ->addArgument('source_env', InputArgument::REQUIRED, 'Alias of the source environment in the format `app-name.env` or the environment uuid')
       ->addArgument('dest_env', InputArgument::REQUIRED, 'Alias of the destination environment in the format `app-name.env` or the environment uuid')
       ->addUsage('<srcEnvironmentAlias> <destEnvironmentAlias>')

--- a/src/Command/Env/EnvCopyCronCommand.php
+++ b/src/Command/Env/EnvCopyCronCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'env:cron-copy', description: 'Copy all cron tasks from one Acquia Cloud Platform environment to another')]
-class EnvCopyCronCommand extends CommandBase {
+final class EnvCopyCronCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Env/EnvCopyCronCommand.php
+++ b/src/Command/Env/EnvCopyCronCommand.php
@@ -13,14 +13,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:cron-copy')]
+#[AsCommand(name: 'env:cron-copy', 'Copy all cron tasks from one Acquia Cloud Platform environment to another')]
 class EnvCopyCronCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Copy all cron tasks from one Acquia Cloud Platform environment to another';
 
   protected function configure(): void {
     $this

--- a/src/Command/Env/EnvCopyCronCommand.php
+++ b/src/Command/Env/EnvCopyCronCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Env;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use AcquiaCloudApi\Endpoints\Crons;
 use Exception;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'env:cron-copy', description: 'Copy all cron tasks from one Acquia Cloud Platform environment to another')]
 class EnvCopyCronCommand extends CommandBase {
 

--- a/src/Command/Env/EnvCreateCommand.php
+++ b/src/Command/Env/EnvCreateCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'env:create', description: 'Create a new Continuous Delivery Environment (CDE)')]
-class EnvCreateCommand extends CommandBase {
+final class EnvCreateCommand extends CommandBase {
 
   private Checklist $checklist;
 

--- a/src/Command/Env/EnvCreateCommand.php
+++ b/src/Command/Env/EnvCreateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Env;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
@@ -16,6 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'env:create', description: 'Create a new Continuous Delivery Environment (CDE)')]
 class EnvCreateCommand extends CommandBase {
 

--- a/src/Command/Env/EnvCreateCommand.php
+++ b/src/Command/Env/EnvCreateCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:create', 'Create a new Continuous Delivery Environment (CDE)')]
+#[AsCommand(name: 'env:create', description: 'Create a new Continuous Delivery Environment (CDE)')]
 class EnvCreateCommand extends CommandBase {
 
   private Checklist $checklist;

--- a/src/Command/Env/EnvCreateCommand.php
+++ b/src/Command/Env/EnvCreateCommand.php
@@ -16,14 +16,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:create')]
+#[AsCommand(name: 'env:create', 'Create a new Continuous Delivery Environment (CDE)')]
 class EnvCreateCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Create a new Continuous Delivery Environment (CDE)';
   private Checklist $checklist;
 
   protected function configure(): void {

--- a/src/Command/Env/EnvCreateCommand.php
+++ b/src/Command/Env/EnvCreateCommand.php
@@ -19,10 +19,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'env:create')]
 class EnvCreateCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Create a new Continuous Delivery Environment (CDE)';
   private Checklist $checklist;
 
   protected function configure(): void {
-    $this->setDescription('Create a new Continuous Delivery Environment (CDE)');
     $this->addArgument('label', InputArgument::REQUIRED, 'The label of the new environment');
     $this->addArgument('branch', InputArgument::OPTIONAL, 'The vcs path (git branch name) to deploy to the new environment');
     $this->acceptApplicationUuid();

--- a/src/Command/Env/EnvDeleteCommand.php
+++ b/src/Command/Env/EnvDeleteCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Env;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Endpoints\Environments;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'env:delete', description: 'Delete a Continuous Delivery Environment (CDE)')]
 class EnvDeleteCommand extends CommandBase {
 

--- a/src/Command/Env/EnvDeleteCommand.php
+++ b/src/Command/Env/EnvDeleteCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'env:delete', description: 'Delete a Continuous Delivery Environment (CDE)')]
-class EnvDeleteCommand extends CommandBase {
+final class EnvDeleteCommand extends CommandBase {
 
   protected function configure(): void {
     $this->acceptEnvironmentId();

--- a/src/Command/Env/EnvDeleteCommand.php
+++ b/src/Command/Env/EnvDeleteCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:delete', 'Delete a Continuous Delivery Environment (CDE)')]
+#[AsCommand(name: 'env:delete', description: 'Delete a Continuous Delivery Environment (CDE)')]
 class EnvDeleteCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Env/EnvDeleteCommand.php
+++ b/src/Command/Env/EnvDeleteCommand.php
@@ -16,8 +16,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'env:delete')]
 class EnvDeleteCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Delete a Continuous Delivery Environment (CDE)';
+
   protected function configure(): void {
-    $this->setDescription('Delete a Continuous Delivery Environment (CDE)');
     $this->acceptEnvironmentId();
   }
 

--- a/src/Command/Env/EnvDeleteCommand.php
+++ b/src/Command/Env/EnvDeleteCommand.php
@@ -13,14 +13,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:delete')]
+#[AsCommand(name: 'env:delete', 'Delete a Continuous Delivery Environment (CDE)')]
 class EnvDeleteCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Delete a Continuous Delivery Environment (CDE)';
 
   protected function configure(): void {
     $this->acceptEnvironmentId();

--- a/src/Command/Env/EnvMirrorCommand.php
+++ b/src/Command/Env/EnvMirrorCommand.php
@@ -17,14 +17,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:mirror')]
+#[AsCommand(name: 'env:mirror', 'Makes one environment identical to another in terms of code, database, files, and configuration.')]
 class EnvMirrorCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Makes one environment identical to another in terms of code, database, files, and configuration.';
   private Checklist $checklist;
 
   protected function configure(): void {

--- a/src/Command/Env/EnvMirrorCommand.php
+++ b/src/Command/Env/EnvMirrorCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'env:mirror', 'Makes one environment identical to another in terms of code, database, files, and configuration.')]
+#[AsCommand(name: 'env:mirror', description: 'Makes one environment identical to another in terms of code, database, files, and configuration.')]
 class EnvMirrorCommand extends CommandBase {
 
   private Checklist $checklist;

--- a/src/Command/Env/EnvMirrorCommand.php
+++ b/src/Command/Env/EnvMirrorCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'env:mirror', description: 'Makes one environment identical to another in terms of code, database, files, and configuration.')]
-class EnvMirrorCommand extends CommandBase {
+final class EnvMirrorCommand extends CommandBase {
 
   private Checklist $checklist;
 

--- a/src/Command/Env/EnvMirrorCommand.php
+++ b/src/Command/Env/EnvMirrorCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Env;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Output\Checklist;
 use AcquiaCloudApi\Connector\Client;
@@ -17,6 +18,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'env:mirror', description: 'Makes one environment identical to another in terms of code, database, files, and configuration.')]
 class EnvMirrorCommand extends CommandBase {
 

--- a/src/Command/Env/EnvMirrorCommand.php
+++ b/src/Command/Env/EnvMirrorCommand.php
@@ -20,10 +20,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'env:mirror')]
 class EnvMirrorCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Makes one environment identical to another in terms of code, database, files, and configuration.';
   private Checklist $checklist;
 
   protected function configure(): void {
-    $this->setDescription('Makes one environment identical to another in terms of code, database, files, and configuration.');
     $this->addArgument('source-environment', InputArgument::REQUIRED, 'The Cloud Platform source environment ID or alias')
       ->addUsage('[<environmentAlias>]')
       ->addUsage('myapp.dev')

--- a/src/Command/HelloWorldCommand.php
+++ b/src/Command/HelloWorldCommand.php
@@ -9,14 +9,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'hello-world')]
+#[AsCommand(name: 'hello-world', 'Test command used for asserting core functionality')]
 class HelloWorldCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Test command used for asserting core functionality';
 
   protected function configure(): void {
     $this

--- a/src/Command/HelloWorldCommand.php
+++ b/src/Command/HelloWorldCommand.php
@@ -9,13 +9,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'hello-world', description: 'Test command used for asserting core functionality')]
+#[AsCommand(name: 'hello-world', description: 'Test command used for asserting core functionality', hidden: TRUE)]
 final class HelloWorldCommand extends CommandBase {
-
-  protected function configure(): void {
-    $this
-      ->setHidden();
-  }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->io->success('Hello world!');

--- a/src/Command/HelloWorldCommand.php
+++ b/src/Command/HelloWorldCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'hello-world', description: 'Test command used for asserting core functionality')]
-class HelloWorldCommand extends CommandBase {
+final class HelloWorldCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/HelloWorldCommand.php
+++ b/src/Command/HelloWorldCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'hello-world', 'Test command used for asserting core functionality')]
+#[AsCommand(name: 'hello-world', description: 'Test command used for asserting core functionality')]
 class HelloWorldCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/HelloWorldCommand.php
+++ b/src/Command/HelloWorldCommand.php
@@ -12,8 +12,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'hello-world')]
 class HelloWorldCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Test command used for asserting core functionality';
+
   protected function configure(): void {
-    $this->setDescription('Test command used for asserting core functionality')
+    $this
       ->setHidden();
   }
 

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
-#[AsCommand(name: 'ide:create', 'Create a Cloud IDE')]
+#[AsCommand(name: 'ide:create', description: 'Create a Cloud IDE')]
 class IdeCreateCommand extends IdeCommandBase {
 
   private IdeResponse $ide;

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Validation;
 
 #[RequireAuth]
 #[AsCommand(name: 'ide:create', description: 'Create a Cloud IDE')]
-class IdeCreateCommand extends IdeCommandBase {
+final class IdeCreateCommand extends IdeCommandBase {
 
   private IdeResponse $ide;
 

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ide;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Helpers\LoopHelper;
 use Acquia\Cli\Output\Checklist;
 use AcquiaCloudApi\Endpoints\Account;
@@ -20,6 +21,7 @@ use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
+#[RequireAuth]
 #[AsCommand(name: 'ide:create', description: 'Create a Cloud IDE')]
 class IdeCreateCommand extends IdeCommandBase {
 

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -23,12 +23,16 @@ use Symfony\Component\Validator\Validation;
 #[AsCommand(name: 'ide:create')]
 class IdeCreateCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Create a Cloud IDE';
   private IdeResponse $ide;
 
   private Client $client;
 
   protected function configure(): void {
-    $this->setDescription('Create a Cloud IDE');
     $this->acceptApplicationUuid();
     $this->addOption('label', NULL, InputOption::VALUE_REQUIRED, 'The label for the IDE');
   }

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -20,14 +20,9 @@ use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
-#[AsCommand(name: 'ide:create')]
+#[AsCommand(name: 'ide:create', 'Create a Cloud IDE')]
 class IdeCreateCommand extends IdeCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Create a Cloud IDE';
   private IdeResponse $ide;
 
   private Client $client;

--- a/src/Command/Ide/IdeDeleteCommand.php
+++ b/src/Command/Ide/IdeDeleteCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ide:delete', description: 'Delete a Cloud IDE')]
-class IdeDeleteCommand extends IdeCommandBase {
+final class IdeDeleteCommand extends IdeCommandBase {
 
   use SshCommandTrait;
 

--- a/src/Command/Ide/IdeDeleteCommand.php
+++ b/src/Command/Ide/IdeDeleteCommand.php
@@ -11,14 +11,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:delete')]
+#[AsCommand(name: 'ide:delete', 'Delete a Cloud IDE')]
 class IdeDeleteCommand extends IdeCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Delete a Cloud IDE';
   use SshCommandTrait;
 
   protected function configure(): void {

--- a/src/Command/Ide/IdeDeleteCommand.php
+++ b/src/Command/Ide/IdeDeleteCommand.php
@@ -14,10 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:delete')]
 class IdeDeleteCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Delete a Cloud IDE';
   use SshCommandTrait;
 
   protected function configure(): void {
-    $this->setDescription('Delete a Cloud IDE');
     $this->acceptApplicationUuid();
     // @todo Add option to accept an ide UUID.
   }

--- a/src/Command/Ide/IdeDeleteCommand.php
+++ b/src/Command/Ide/IdeDeleteCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:delete', 'Delete a Cloud IDE')]
+#[AsCommand(name: 'ide:delete', description: 'Delete a Cloud IDE')]
 class IdeDeleteCommand extends IdeCommandBase {
 
   use SshCommandTrait;

--- a/src/Command/Ide/IdeDeleteCommand.php
+++ b/src/Command/Ide/IdeDeleteCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ide;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Helpers\SshCommandTrait;
 use AcquiaCloudApi\Endpoints\Ides;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ide:delete', description: 'Delete a Cloud IDE')]
 class IdeDeleteCommand extends IdeCommandBase {
 

--- a/src/Command/Ide/IdeInfoCommand.php
+++ b/src/Command/Ide/IdeInfoCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ide;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use AcquiaCloudApi\Endpoints\Ides;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ide:info', description: 'Print information about a Cloud IDE')]
 class IdeInfoCommand extends IdeCommandBase {
 

--- a/src/Command/Ide/IdeInfoCommand.php
+++ b/src/Command/Ide/IdeInfoCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ide:info', description: 'Print information about a Cloud IDE')]
-class IdeInfoCommand extends IdeCommandBase {
+final class IdeInfoCommand extends IdeCommandBase {
 
   protected function configure(): void {
     $this->acceptApplicationUuid();

--- a/src/Command/Ide/IdeInfoCommand.php
+++ b/src/Command/Ide/IdeInfoCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:info', 'Print information about a Cloud IDE')]
+#[AsCommand(name: 'ide:info', description: 'Print information about a Cloud IDE')]
 class IdeInfoCommand extends IdeCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Ide/IdeInfoCommand.php
+++ b/src/Command/Ide/IdeInfoCommand.php
@@ -14,8 +14,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:info')]
 class IdeInfoCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Print information about a Cloud IDE';
+
   protected function configure(): void {
-    $this->setDescription('Print information about a Cloud IDE');
     $this->acceptApplicationUuid();
   }
 

--- a/src/Command/Ide/IdeInfoCommand.php
+++ b/src/Command/Ide/IdeInfoCommand.php
@@ -11,14 +11,8 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:info')]
+#[AsCommand(name: 'ide:info', 'Print information about a Cloud IDE')]
 class IdeInfoCommand extends IdeCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Print information about a Cloud IDE';
 
   protected function configure(): void {
     $this->acceptApplicationUuid();

--- a/src/Command/Ide/IdeListCommand.php
+++ b/src/Command/Ide/IdeListCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ide:list:app', description: 'List available Cloud IDEs belonging to a given application', aliases: ['ide:list'])]
-class IdeListCommand extends IdeCommandBase {
+final class IdeListCommand extends IdeCommandBase {
 
   protected function configure(): void {
     $this->acceptApplicationUuid();

--- a/src/Command/Ide/IdeListCommand.php
+++ b/src/Command/Ide/IdeListCommand.php
@@ -15,8 +15,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:list:app')]
 class IdeListCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'List available Cloud IDEs belonging to a given application';
+
   protected function configure(): void {
-    $this->setDescription('List available Cloud IDEs belonging to a given application');
     $this->setAliases(['ide:list']);
     $this->acceptApplicationUuid();
   }

--- a/src/Command/Ide/IdeListCommand.php
+++ b/src/Command/Ide/IdeListCommand.php
@@ -12,17 +12,10 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:list:app')]
+#[AsCommand(name: 'ide:list:app', 'List available Cloud IDEs belonging to a given application', ['ide:list'])]
 class IdeListCommand extends IdeCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'List available Cloud IDEs belonging to a given application';
-
   protected function configure(): void {
-    $this->setAliases(['ide:list']);
     $this->acceptApplicationUuid();
   }
 

--- a/src/Command/Ide/IdeListCommand.php
+++ b/src/Command/Ide/IdeListCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:list:app', 'List available Cloud IDEs belonging to a given application', ['ide:list'])]
+#[AsCommand(name: 'ide:list:app', description: 'List available Cloud IDEs belonging to a given application', aliases: ['ide:list'])]
 class IdeListCommand extends IdeCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Ide/IdeListCommand.php
+++ b/src/Command/Ide/IdeListCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ide;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use AcquiaCloudApi\Endpoints\Ides;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ide:list:app', description: 'List available Cloud IDEs belonging to a given application', aliases: ['ide:list'])]
 class IdeListCommand extends IdeCommandBase {
 

--- a/src/Command/Ide/IdeListMineCommand.php
+++ b/src/Command/Ide/IdeListMineCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:list:mine', 'List Cloud IDEs belonging to you')]
+#[AsCommand(name: 'ide:list:mine', description: 'List Cloud IDEs belonging to you')]
 class IdeListMineCommand extends IdeCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Ide/IdeListMineCommand.php
+++ b/src/Command/Ide/IdeListMineCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ide:list:mine', description: 'List Cloud IDEs belonging to you')]
-class IdeListMineCommand extends IdeCommandBase {
+final class IdeListMineCommand extends IdeCommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $acquiaCloudClient = $this->cloudApiClientService->getClient();

--- a/src/Command/Ide/IdeListMineCommand.php
+++ b/src/Command/Ide/IdeListMineCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ide;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use AcquiaCloudApi\Endpoints\Applications;
 use AcquiaCloudApi\Endpoints\Ides;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ide:list:mine', description: 'List Cloud IDEs belonging to you')]
 class IdeListMineCommand extends IdeCommandBase {
 

--- a/src/Command/Ide/IdeListMineCommand.php
+++ b/src/Command/Ide/IdeListMineCommand.php
@@ -16,9 +16,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:list:mine', description: 'List Cloud IDEs belonging to you')]
 class IdeListMineCommand extends IdeCommandBase {
 
-  protected function configure(): void {
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $acquiaCloudClient = $this->cloudApiClientService->getClient();
     $ides = new Ides($acquiaCloudClient);

--- a/src/Command/Ide/IdeListMineCommand.php
+++ b/src/Command/Ide/IdeListMineCommand.php
@@ -13,14 +13,8 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:list:mine')]
+#[AsCommand(name: 'ide:list:mine', 'List Cloud IDEs belonging to you')]
 class IdeListMineCommand extends IdeCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'List Cloud IDEs belonging to you';
 
   protected function configure(): void {
   }

--- a/src/Command/Ide/IdeListMineCommand.php
+++ b/src/Command/Ide/IdeListMineCommand.php
@@ -16,8 +16,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:list:mine')]
 class IdeListMineCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'List Cloud IDEs belonging to you';
+
   protected function configure(): void {
-    $this->setDescription('List Cloud IDEs belonging to you');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Ide/IdeOpenCommand.php
+++ b/src/Command/Ide/IdeOpenCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:open')]
 class IdeOpenCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Open a Cloud IDE in your browser';
+
   protected function configure(): void {
-    $this->setDescription('Open a Cloud IDE in your browser')
+    $this
       ->setHidden(AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
     $this->acceptApplicationUuid();
     // @todo Add option to accept an ide UUID.

--- a/src/Command/Ide/IdeOpenCommand.php
+++ b/src/Command/Ide/IdeOpenCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ide:open', description: 'Open a Cloud IDE in your browser')]
-class IdeOpenCommand extends IdeCommandBase {
+final class IdeOpenCommand extends IdeCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Ide/IdeOpenCommand.php
+++ b/src/Command/Ide/IdeOpenCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ide;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use AcquiaCloudApi\Endpoints\Ides;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ide:open', description: 'Open a Cloud IDE in your browser')]
 class IdeOpenCommand extends IdeCommandBase {
 

--- a/src/Command/Ide/IdeOpenCommand.php
+++ b/src/Command/Ide/IdeOpenCommand.php
@@ -11,14 +11,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:open')]
+#[AsCommand(name: 'ide:open', 'Open a Cloud IDE in your browser')]
 class IdeOpenCommand extends IdeCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Open a Cloud IDE in your browser';
 
   protected function configure(): void {
     $this

--- a/src/Command/Ide/IdeOpenCommand.php
+++ b/src/Command/Ide/IdeOpenCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:open', 'Open a Cloud IDE in your browser')]
+#[AsCommand(name: 'ide:open', description: 'Open a Cloud IDE in your browser')]
 class IdeOpenCommand extends IdeCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Ide/IdePhpVersionCommand.php
+++ b/src/Command/Ide/IdePhpVersionCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:php-version', 'Change the PHP version in the current IDE')]
+#[AsCommand(name: 'ide:php-version', description: 'Change the PHP version in the current IDE')]
 class IdePhpVersionCommand extends IdeCommandBase {
 
   private string $idePhpFilePathPrefix;

--- a/src/Command/Ide/IdePhpVersionCommand.php
+++ b/src/Command/Ide/IdePhpVersionCommand.php
@@ -17,15 +17,6 @@ class IdePhpVersionCommand extends IdeCommandBase {
 
   private string $idePhpFilePathPrefix;
 
-  /*
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   *
-   * @return bool
-   */
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function configure(): void {
     $this
       ->addArgument('version', InputArgument::REQUIRED, 'The PHP version')

--- a/src/Command/Ide/IdePhpVersionCommand.php
+++ b/src/Command/Ide/IdePhpVersionCommand.php
@@ -15,6 +15,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:php-version')]
 class IdePhpVersionCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Change the PHP version in the current IDE';
   private string $idePhpFilePathPrefix;
 
   /*
@@ -27,7 +32,7 @@ class IdePhpVersionCommand extends IdeCommandBase {
   }
 
   protected function configure(): void {
-    $this->setDescription('Change the PHP version in the current IDE')
+    $this
       ->addArgument('version', InputArgument::REQUIRED, 'The PHP version')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
   }

--- a/src/Command/Ide/IdePhpVersionCommand.php
+++ b/src/Command/Ide/IdePhpVersionCommand.php
@@ -12,14 +12,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:php-version')]
+#[AsCommand(name: 'ide:php-version', 'Change the PHP version in the current IDE')]
 class IdePhpVersionCommand extends IdeCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Change the PHP version in the current IDE';
   private string $idePhpFilePathPrefix;
 
   /*

--- a/src/Command/Ide/IdePhpVersionCommand.php
+++ b/src/Command/Ide/IdePhpVersionCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'ide:php-version', description: 'Change the PHP version in the current IDE')]
-class IdePhpVersionCommand extends IdeCommandBase {
+final class IdePhpVersionCommand extends IdeCommandBase {
 
   private string $idePhpFilePathPrefix;
 

--- a/src/Command/Ide/IdeServiceRestartCommand.php
+++ b/src/Command/Ide/IdeServiceRestartCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
 #[AsCommand(name: 'ide:service-restart', description: 'Restart a service in the Cloud IDE')]
-class IdeServiceRestartCommand extends IdeCommandBase {
+final class IdeServiceRestartCommand extends IdeCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Ide/IdeServiceRestartCommand.php
+++ b/src/Command/Ide/IdeServiceRestartCommand.php
@@ -14,14 +14,8 @@ use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
-#[AsCommand(name: 'ide:service-restart')]
+#[AsCommand(name: 'ide:service-restart', 'Restart a service in the Cloud IDE')]
 class IdeServiceRestartCommand extends IdeCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Restart a service in the Cloud IDE';
 
   protected function commandRequiresAuthentication(): bool {
     return FALSE;

--- a/src/Command/Ide/IdeServiceRestartCommand.php
+++ b/src/Command/Ide/IdeServiceRestartCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
-#[AsCommand(name: 'ide:service-restart', 'Restart a service in the Cloud IDE')]
+#[AsCommand(name: 'ide:service-restart', description: 'Restart a service in the Cloud IDE')]
 class IdeServiceRestartCommand extends IdeCommandBase {
 
   protected function commandRequiresAuthentication(): bool {

--- a/src/Command/Ide/IdeServiceRestartCommand.php
+++ b/src/Command/Ide/IdeServiceRestartCommand.php
@@ -17,10 +17,6 @@ use Symfony\Component\Validator\Validation;
 #[AsCommand(name: 'ide:service-restart', description: 'Restart a service in the Cloud IDE')]
 class IdeServiceRestartCommand extends IdeCommandBase {
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function configure(): void {
     $this
       ->addArgument('service', InputArgument::REQUIRED, 'The name of the service to restart')

--- a/src/Command/Ide/IdeServiceRestartCommand.php
+++ b/src/Command/Ide/IdeServiceRestartCommand.php
@@ -17,12 +17,18 @@ use Symfony\Component\Validator\Validation;
 #[AsCommand(name: 'ide:service-restart')]
 class IdeServiceRestartCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Restart a service in the Cloud IDE';
+
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
   protected function configure(): void {
-    $this->setDescription('Restart a service in the Cloud IDE')
+    $this
       ->addArgument('service', InputArgument::REQUIRED, 'The name of the service to restart')
       ->addUsage('php')
       ->addUsage('apache')

--- a/src/Command/Ide/IdeServiceStartCommand.php
+++ b/src/Command/Ide/IdeServiceStartCommand.php
@@ -14,14 +14,8 @@ use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
-#[AsCommand(name: 'ide:service-start')]
+#[AsCommand(name: 'ide:service-start', 'Start a service in the Cloud IDE')]
 class IdeServiceStartCommand extends IdeCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Start a service in the Cloud IDE';
 
   protected function commandRequiresAuthentication(): bool {
     return FALSE;

--- a/src/Command/Ide/IdeServiceStartCommand.php
+++ b/src/Command/Ide/IdeServiceStartCommand.php
@@ -17,12 +17,18 @@ use Symfony\Component\Validator\Validation;
 #[AsCommand(name: 'ide:service-start')]
 class IdeServiceStartCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Start a service in the Cloud IDE';
+
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
   protected function configure(): void {
-    $this->setDescription('Start a service in the Cloud IDE')
+    $this
       ->addArgument('service', InputArgument::REQUIRED, 'The name of the service to start')
       ->addUsage('php')
       ->addUsage('apache')

--- a/src/Command/Ide/IdeServiceStartCommand.php
+++ b/src/Command/Ide/IdeServiceStartCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
-#[AsCommand(name: 'ide:service-start', 'Start a service in the Cloud IDE')]
+#[AsCommand(name: 'ide:service-start', description: 'Start a service in the Cloud IDE')]
 class IdeServiceStartCommand extends IdeCommandBase {
 
   protected function commandRequiresAuthentication(): bool {

--- a/src/Command/Ide/IdeServiceStartCommand.php
+++ b/src/Command/Ide/IdeServiceStartCommand.php
@@ -17,10 +17,6 @@ use Symfony\Component\Validator\Validation;
 #[AsCommand(name: 'ide:service-start', description: 'Start a service in the Cloud IDE')]
 class IdeServiceStartCommand extends IdeCommandBase {
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function configure(): void {
     $this
       ->addArgument('service', InputArgument::REQUIRED, 'The name of the service to start')

--- a/src/Command/Ide/IdeServiceStartCommand.php
+++ b/src/Command/Ide/IdeServiceStartCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
 #[AsCommand(name: 'ide:service-start', description: 'Start a service in the Cloud IDE')]
-class IdeServiceStartCommand extends IdeCommandBase {
+final class IdeServiceStartCommand extends IdeCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Ide/IdeServiceStopCommand.php
+++ b/src/Command/Ide/IdeServiceStopCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
-#[AsCommand(name: 'ide:service-stop', 'Stop a service in the Cloud IDE')]
+#[AsCommand(name: 'ide:service-stop', description: 'Stop a service in the Cloud IDE')]
 class IdeServiceStopCommand extends IdeCommandBase {
 
   protected function commandRequiresAuthentication(): bool {

--- a/src/Command/Ide/IdeServiceStopCommand.php
+++ b/src/Command/Ide/IdeServiceStopCommand.php
@@ -14,14 +14,8 @@ use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
-#[AsCommand(name: 'ide:service-stop')]
+#[AsCommand(name: 'ide:service-stop', 'Stop a service in the Cloud IDE')]
 class IdeServiceStopCommand extends IdeCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Stop a service in the Cloud IDE';
 
   protected function commandRequiresAuthentication(): bool {
     return FALSE;

--- a/src/Command/Ide/IdeServiceStopCommand.php
+++ b/src/Command/Ide/IdeServiceStopCommand.php
@@ -17,12 +17,18 @@ use Symfony\Component\Validator\Validation;
 #[AsCommand(name: 'ide:service-stop')]
 class IdeServiceStopCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Stop a service in the Cloud IDE';
+
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
   protected function configure(): void {
-    $this->setDescription('Stop a service in the Cloud IDE')
+    $this
       ->addArgument('service', InputArgument::REQUIRED, 'The name of the service to stop')
       ->addUsage('php')
       ->addUsage('apache')

--- a/src/Command/Ide/IdeServiceStopCommand.php
+++ b/src/Command/Ide/IdeServiceStopCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 
 #[AsCommand(name: 'ide:service-stop', description: 'Stop a service in the Cloud IDE')]
-class IdeServiceStopCommand extends IdeCommandBase {
+final class IdeServiceStopCommand extends IdeCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Ide/IdeServiceStopCommand.php
+++ b/src/Command/Ide/IdeServiceStopCommand.php
@@ -17,10 +17,6 @@ use Symfony\Component\Validator\Validation;
 #[AsCommand(name: 'ide:service-stop', description: 'Stop a service in the Cloud IDE')]
 class IdeServiceStopCommand extends IdeCommandBase {
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function configure(): void {
     $this
       ->addArgument('service', InputArgument::REQUIRED, 'The name of the service to stop')

--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -18,6 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class IdeShareCommand extends CommandBase {
 
   /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Get the share URL for a Cloud IDE';
+  /**
    * @var array<mixed>
    */
   private array $shareCodeFilepaths;
@@ -27,7 +32,7 @@ class IdeShareCommand extends CommandBase {
   }
 
   protected function configure(): void {
-    $this->setDescription('Get the share URL for a Cloud IDE')
+    $this
       ->addOption('regenerate', '', InputOption::VALUE_NONE, 'regenerate the share code')
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
   }

--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -14,14 +14,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:share')]
+#[AsCommand(name: 'ide:share', 'Get the share URL for a Cloud IDE')]
 class IdeShareCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Get the share URL for a Cloud IDE';
   /**
    * @var array<mixed>
    */

--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -22,10 +22,6 @@ class IdeShareCommand extends CommandBase {
    */
   private array $shareCodeFilepaths;
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function configure(): void {
     $this
       ->addOption('regenerate', '', InputOption::VALUE_NONE, 'regenerate the share code')

--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'ide:share', description: 'Get the share URL for a Cloud IDE')]
-class IdeShareCommand extends CommandBase {
+final class IdeShareCommand extends CommandBase {
 
   /**
    * @var array<mixed>

--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:share', 'Get the share URL for a Cloud IDE')]
+#[AsCommand(name: 'ide:share', description: 'Get the share URL for a Cloud IDE')]
 class IdeShareCommand extends CommandBase {
 
   /**

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -16,10 +16,6 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
 
   private ?bool $xDebugEnabled;
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function configure(): void {
     $this
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv());

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'ide:xdebug-toggle', description: 'Toggle Xdebug on or off in the current IDE', aliases: ['xdebug'])]
-class IdeXdebugToggleCommand extends IdeCommandBase {
+final class IdeXdebugToggleCommand extends IdeCommandBase {
 
   private ?bool $xDebugEnabled;
 

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -11,14 +11,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:xdebug-toggle')]
+#[AsCommand(name: 'ide:xdebug-toggle', 'Toggle Xdebug on or off in the current IDE', ['xdebug'])]
 class IdeXdebugToggleCommand extends IdeCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Toggle Xdebug on or off in the current IDE';
   private ?bool $xDebugEnabled;
 
   protected function commandRequiresAuthentication(): bool {
@@ -27,7 +22,6 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
 
   protected function configure(): void {
     $this
-      ->setAliases(['xdebug'])
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
   }
 

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:xdebug-toggle', 'Toggle Xdebug on or off in the current IDE', ['xdebug'])]
+#[AsCommand(name: 'ide:xdebug-toggle', description: 'Toggle Xdebug on or off in the current IDE', aliases: ['xdebug'])]
 class IdeXdebugToggleCommand extends IdeCommandBase {
 
   private ?bool $xDebugEnabled;

--- a/src/Command/Ide/IdeXdebugToggleCommand.php
+++ b/src/Command/Ide/IdeXdebugToggleCommand.php
@@ -14,6 +14,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:xdebug-toggle')]
 class IdeXdebugToggleCommand extends IdeCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Toggle Xdebug on or off in the current IDE';
   private ?bool $xDebugEnabled;
 
   protected function commandRequiresAuthentication(): bool {
@@ -21,7 +26,7 @@ class IdeXdebugToggleCommand extends IdeCommandBase {
   }
 
   protected function configure(): void {
-    $this->setDescription('Toggle Xdebug on or off in the current IDE')
+    $this
       ->setAliases(['xdebug'])
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv());
   }

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ide:wizard:ssh-key:create-upload', description: 'Wizard to perform first time setup tasks within an IDE', aliases: ['ide:wizard'])]
-class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
+final class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -12,18 +12,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:wizard:ssh-key:create-upload')]
+#[AsCommand(name: 'ide:wizard:ssh-key:create-upload', 'Wizard to perform first time setup tasks within an IDE', ['ide:wizard'])]
 class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Wizard to perform first time setup tasks within an IDE';
 
   protected function configure(): void {
     $this
-      ->setAliases(['ide:wizard'])
       ->setHidden(!CommandBase::isAcquiaCloudIde());
   }
 

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:wizard:ssh-key:create-upload', 'Wizard to perform first time setup tasks within an IDE', ['ide:wizard'])]
+#[AsCommand(name: 'ide:wizard:ssh-key:create-upload', description: 'Wizard to perform first time setup tasks within an IDE', aliases: ['ide:wizard'])]
 class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -15,8 +15,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:wizard:ssh-key:create-upload')]
 class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Wizard to perform first time setup tasks within an IDE';
+
   protected function configure(): void {
-    $this->setDescription('Wizard to perform first time setup tasks within an IDE')
+    $this
       ->setAliases(['ide:wizard'])
       ->setHidden(!CommandBase::isAcquiaCloudIde());
   }

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ide\Wizard;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Output\Checklist;
 use AcquiaCloudApi\Endpoints\Account;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ide:wizard:ssh-key:create-upload', description: 'Wizard to perform first time setup tasks within an IDE', aliases: ['ide:wizard'])]
 class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
 

--- a/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
@@ -12,14 +12,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:wizard:ssh-key:delete')]
+#[AsCommand(name: 'ide:wizard:ssh-key:delete', 'Wizard to delete SSH key for IDE from Cloud')]
 class IdeWizardDeleteSshKeyCommand extends IdeWizardCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Wizard to delete SSH key for IDE from Cloud';
   use SshCommandTrait;
 
   protected function configure(): void {

--- a/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ide\Wizard;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\SshCommandTrait;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ide:wizard:ssh-key:delete', description: 'Wizard to delete SSH key for IDE from Cloud')]
 class IdeWizardDeleteSshKeyCommand extends IdeWizardCommandBase {
 

--- a/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ide:wizard:ssh-key:delete', description: 'Wizard to delete SSH key for IDE from Cloud')]
-class IdeWizardDeleteSshKeyCommand extends IdeWizardCommandBase {
+final class IdeWizardDeleteSshKeyCommand extends IdeWizardCommandBase {
 
   use SshCommandTrait;
 

--- a/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ide:wizard:ssh-key:delete', 'Wizard to delete SSH key for IDE from Cloud')]
+#[AsCommand(name: 'ide:wizard:ssh-key:delete', description: 'Wizard to delete SSH key for IDE from Cloud')]
 class IdeWizardDeleteSshKeyCommand extends IdeWizardCommandBase {
 
   use SshCommandTrait;

--- a/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardDeleteSshKeyCommand.php
@@ -15,10 +15,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ide:wizard:ssh-key:delete')]
 class IdeWizardDeleteSshKeyCommand extends IdeWizardCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Wizard to delete SSH key for IDE from Cloud';
   use SshCommandTrait;
 
   protected function configure(): void {
-    $this->setDescription('Wizard to delete SSH key for IDE from Cloud')
+    $this
       ->setHidden(!CommandBase::isAcquiaCloudIde());
   }
 

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\Pull;
 
 use Acquia\Cli\Attribute\RequireAuth;
+use Acquia\Cli\Attribute\RequireDb;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -13,12 +14,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
+#[RequireDb]
 #[AsCommand(name: 'pull:code', description: 'Copy code from a Cloud Platform environment')]
 final class PullCodeCommand extends PullCommandBase {
-
-  protected function commandRequiresDatabase(): bool {
-    return TRUE;
-  }
 
   protected function configure(): void {
     $this

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Pull;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'pull:code', description: 'Copy code from a Cloud Platform environment')]
 class PullCodeCommand extends PullCommandBase {
 

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'pull:code', description: 'Copy code from a Cloud Platform environment')]
-class PullCodeCommand extends PullCommandBase {
+final class PullCodeCommand extends PullCommandBase {
 
   protected function commandRequiresDatabase(): bool {
     return TRUE;

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:code', 'Copy code from a Cloud Platform environment')]
+#[AsCommand(name: 'pull:code', description: 'Copy code from a Cloud Platform environment')]
 class PullCodeCommand extends PullCommandBase {
 
   protected function commandRequiresDatabase(): bool {

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -11,14 +11,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:code')]
+#[AsCommand(name: 'pull:code', 'Copy code from a Cloud Platform environment')]
 class PullCodeCommand extends PullCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Copy code from a Cloud Platform environment';
 
   protected function commandRequiresDatabase(): bool {
     return TRUE;

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -14,12 +14,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'pull:code')]
 class PullCodeCommand extends PullCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Copy code from a Cloud Platform environment';
+
   protected function commandRequiresDatabase(): bool {
     return TRUE;
   }
 
   protected function configure(): void {
-    $this->setDescription('Copy code from a Cloud Platform environment')
+    $this
       ->acceptEnvironmentId()
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\Pull;
 
 use Acquia\Cli\Attribute\RequireAuth;
+use Acquia\Cli\Attribute\RequireDb;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -13,12 +14,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
+#[RequireDb]
 #[AsCommand(name: 'pull:all', description: 'Copy code, database, and files from a Cloud Platform environment', aliases: ['refresh', 'pull'])]
 final class PullCommand extends PullCommandBase {
-
-  protected function commandRequiresDatabase(): bool {
-    return TRUE;
-  }
 
   protected function configure(): void {
     $this

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'pull:all', description: 'Copy code, database, and files from a Cloud Platform environment', aliases: ['refresh', 'pull'])]
-class PullCommand extends PullCommandBase {
+final class PullCommand extends PullCommandBase {
 
   protected function commandRequiresDatabase(): bool {
     return TRUE;

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -14,13 +14,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'pull:all')]
 class PullCommand extends PullCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Copy code, database, and files from a Cloud Platform environment';
+
   protected function commandRequiresDatabase(): bool {
     return TRUE;
   }
 
   protected function configure(): void {
     $this->setAliases(['refresh', 'pull'])
-      ->setDescription('Copy code, database, and files from a Cloud Platform environment')
       ->acceptEnvironmentId()
       ->acceptSite()
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -11,21 +11,15 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:all')]
+#[AsCommand(name: 'pull:all', 'Copy code, database, and files from a Cloud Platform environment', ['refresh', 'pull'])]
 class PullCommand extends PullCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Copy code, database, and files from a Cloud Platform environment';
 
   protected function commandRequiresDatabase(): bool {
     return TRUE;
   }
 
   protected function configure(): void {
-    $this->setAliases(['refresh', 'pull'])
+    $this
       ->acceptEnvironmentId()
       ->acceptSite()
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Pull;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'pull:all', description: 'Copy code, database, and files from a Cloud Platform environment', aliases: ['refresh', 'pull'])]
 class PullCommand extends PullCommandBase {
 

--- a/src/Command/Pull/PullCommand.php
+++ b/src/Command/Pull/PullCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:all', 'Copy code, database, and files from a Cloud Platform environment', ['refresh', 'pull'])]
+#[AsCommand(name: 'pull:all', description: 'Copy code, database, and files from a Cloud Platform environment', aliases: ['refresh', 'pull'])]
 class PullCommand extends PullCommandBase {
 
   protected function commandRequiresDatabase(): bool {

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\Pull;
 
 use Acquia\Cli\Attribute\RequireAuth;
+use Acquia\Cli\Attribute\RequireDb;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,12 +13,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
+#[RequireDb]
 #[AsCommand(name: 'pull:database', description: 'Import database backup from a Cloud Platform environment', aliases: ['pull:db'])]
 final class PullDatabaseCommand extends PullCommandBase {
-
-  protected function commandRequiresDatabase(): bool {
-    return TRUE;
-  }
 
   protected function configure(): void {
     $this

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -10,14 +10,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:database')]
+#[AsCommand(name: 'pull:database', 'Import database backup from a Cloud Platform environment', ['pull:db'])]
 class PullDatabaseCommand extends PullCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Import database backup from a Cloud Platform environment';
 
   protected function commandRequiresDatabase(): bool {
     return TRUE;
@@ -25,7 +19,6 @@ class PullDatabaseCommand extends PullCommandBase {
 
   protected function configure(): void {
     $this
-      ->setAliases(['pull:db'])
       ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. If no backup exists, one will be created.')
       ->acceptEnvironmentId()
       ->acceptSite()

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'pull:database', description: 'Import database backup from a Cloud Platform environment', aliases: ['pull:db'])]
-class PullDatabaseCommand extends PullCommandBase {
+final class PullDatabaseCommand extends PullCommandBase {
 
   protected function commandRequiresDatabase(): bool {
     return TRUE;

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -13,12 +13,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'pull:database')]
 class PullDatabaseCommand extends PullCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Import database backup from a Cloud Platform environment';
+
   protected function commandRequiresDatabase(): bool {
     return TRUE;
   }
 
   protected function configure(): void {
-    $this->setDescription('Import database backup from a Cloud Platform environment')
+    $this
       ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. If no backup exists, one will be created.')
       ->setAliases(['pull:db'])
       ->acceptEnvironmentId()

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:database', 'Import database backup from a Cloud Platform environment', ['pull:db'])]
+#[AsCommand(name: 'pull:database', description: 'Import database backup from a Cloud Platform environment', aliases: ['pull:db'])]
 class PullDatabaseCommand extends PullCommandBase {
 
   protected function commandRequiresDatabase(): bool {

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -25,8 +25,8 @@ class PullDatabaseCommand extends PullCommandBase {
 
   protected function configure(): void {
     $this
-      ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. If no backup exists, one will be created.')
       ->setAliases(['pull:db'])
+      ->setHelp('This uses the latest available database backup, which may be up to 24 hours old. If no backup exists, one will be created.')
       ->acceptEnvironmentId()
       ->acceptSite()
       ->addOption('no-scripts', NULL, InputOption::VALUE_NONE,

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -4,12 +4,14 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Pull;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'pull:database', description: 'Import database backup from a Cloud Platform environment', aliases: ['pull:db'])]
 class PullDatabaseCommand extends PullCommandBase {
 

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'pull:files', description: 'Copy Drupal public files from a Cloud Platform environment to your local environment')]
-class PullFilesCommand extends PullCommandBase {
+final class PullFilesCommand extends PullCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -12,8 +12,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'pull:files')]
 class PullFilesCommand extends PullCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Copy Drupal public files from a Cloud Platform environment to your local environment';
+
   protected function configure(): void {
-    $this->setDescription('Copy Drupal public files from a Cloud Platform environment to your local environment')
+    $this
       ->acceptEnvironmentId()
       ->acceptSite();
   }

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:files', 'Copy Drupal public files from a Cloud Platform environment to your local environment')]
+#[AsCommand(name: 'pull:files', description: 'Copy Drupal public files from a Cloud Platform environment to your local environment')]
 class PullFilesCommand extends PullCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -4,11 +4,13 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Pull;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'pull:files', description: 'Copy Drupal public files from a Cloud Platform environment to your local environment')]
 class PullFilesCommand extends PullCommandBase {
 

--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -9,14 +9,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:files')]
+#[AsCommand(name: 'pull:files', 'Copy Drupal public files from a Cloud Platform environment to your local environment')]
 class PullFilesCommand extends PullCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Copy Drupal public files from a Cloud Platform environment to your local environment';
 
   protected function configure(): void {
     $this

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -19,10 +19,6 @@ class PullScriptsCommand extends PullCommandBase {
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed');
   }
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->executeAllScripts($input, $this->getOutputCallback($output, $this->checklist));
 

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'pull:run-scripts', description: 'Execute post pull scripts')]
-class PullScriptsCommand extends PullCommandBase {
+final class PullScriptsCommand extends PullCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -10,14 +10,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:run-scripts')]
+#[AsCommand(name: 'pull:run-scripts', 'Execute post pull scripts')]
 class PullScriptsCommand extends PullCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Execute post pull scripts';
 
   protected function configure(): void {
     $this

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'pull:run-scripts', 'Execute post pull scripts')]
+#[AsCommand(name: 'pull:run-scripts', description: 'Execute post pull scripts')]
 class PullScriptsCommand extends PullCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Pull/PullScriptsCommand.php
+++ b/src/Command/Pull/PullScriptsCommand.php
@@ -13,8 +13,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'pull:run-scripts')]
 class PullScriptsCommand extends PullCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Execute post pull scripts';
+
   protected function configure(): void {
-    $this->setDescription('Execute post pull scripts')
+    $this
       ->acceptEnvironmentId()
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed');
   }

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -20,6 +20,11 @@ use Symfony\Component\Filesystem\Path;
 class PushArtifactCommand extends PullCommandBase {
 
   /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Build and push a code artifact to a Cloud Platform environment';
+  /**
    * Composer vendor directories.
    *
    * @var array<mixed>
@@ -40,7 +45,7 @@ class PushArtifactCommand extends PullCommandBase {
   private string $destinationGitRef;
 
   protected function configure(): void {
-    $this->setDescription('Build and push a code artifact to a Cloud Platform environment')
+    $this
       ->addOption('dir', NULL, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be pushed')
       ->addOption('no-sanitize', NULL, InputOption::VALUE_NONE, 'Do not sanitize the build artifact')
       ->addOption('dry-run', NULL, InputOption::VALUE_NONE, 'Deprecated: Use no-push instead')

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -60,10 +60,6 @@ class PushArtifactCommand extends PullCommandBase {
       ->addUsage('--destination-git-urls=example@svn-1.prod.hosting.acquia.com:example.git --destination-git-branch=main-build');
   }
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $this->setDirAndRequireProjectCwd($input);
     if ($input->getOption('no-clone')) {

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 
 #[AsCommand(name: 'push:artifact', description: 'Build and push a code artifact to a Cloud Platform environment')]
-class PushArtifactCommand extends PullCommandBase {
+final class PushArtifactCommand extends PullCommandBase {
 
   /**
    * Composer vendor directories.

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -16,14 +16,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 
-#[AsCommand(name: 'push:artifact')]
+#[AsCommand(name: 'push:artifact', 'Build and push a code artifact to a Cloud Platform environment')]
 class PushArtifactCommand extends PullCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Build and push a code artifact to a Cloud Platform environment';
   /**
    * Composer vendor directories.
    *

--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 
-#[AsCommand(name: 'push:artifact', 'Build and push a code artifact to a Cloud Platform environment')]
+#[AsCommand(name: 'push:artifact', description: 'Build and push a code artifact to a Cloud Platform environment')]
 class PushArtifactCommand extends PullCommandBase {
 
   /**

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Push;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\Pull\PullCommandBase;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'push:code', description: 'Push code from your IDE to a Cloud Platform environment')]
 class PushCodeCommand extends PullCommandBase {
 

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -11,14 +11,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'push:code')]
+#[AsCommand(name: 'push:code', 'Push code from your IDE to a Cloud Platform environment')]
 class PushCodeCommand extends PullCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Push code from your IDE to a Cloud Platform environment';
 
   protected function configure(): void {
     $this

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'push:code', 'Push code from your IDE to a Cloud Platform environment')]
+#[AsCommand(name: 'push:code', description: 'Push code from your IDE to a Cloud Platform environment')]
 class PushCodeCommand extends PullCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'push:code')]
 class PushCodeCommand extends PullCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Push code from your IDE to a Cloud Platform environment';
+
   protected function configure(): void {
-    $this->setDescription('Push code from your IDE to a Cloud Platform environment')
+    $this
       ->setHidden(!AcquiaDrupalEnvironmentDetector::isAhIdeEnv() && !self::isLandoEnv());
   }
 

--- a/src/Command/Push/PushCodeCommand.php
+++ b/src/Command/Push/PushCodeCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'push:code', description: 'Push code from your IDE to a Cloud Platform environment')]
-class PushCodeCommand extends PullCommandBase {
+final class PushCodeCommand extends PullCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\Push;
 
 use Acquia\Cli\Attribute\RequireAuth;
+use Acquia\Cli\Attribute\RequireDb;
 use Acquia\Cli\Command\Pull\PullCommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
@@ -16,12 +17,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
+#[RequireDb]
 #[AsCommand(name: 'push:database', description: 'Push a database from your local environment to a Cloud Platform environment', aliases: ['push:db'])]
 final class PushDatabaseCommand extends PullCommandBase {
-
-  protected function commandRequiresDatabase(): bool {
-    return TRUE;
-  }
 
   protected function configure(): void {
     $this

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -14,14 +14,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'push:database')]
+#[AsCommand(name: 'push:database', 'Push a database from your local environment to a Cloud Platform environment', ['push:db'])]
 class PushDatabaseCommand extends PullCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Push a database from your local environment to a Cloud Platform environment';
 
   protected function commandRequiresDatabase(): bool {
     return TRUE;
@@ -29,7 +23,6 @@ class PushDatabaseCommand extends PullCommandBase {
 
   protected function configure(): void {
     $this
-      ->setAliases(['push:db'])
       ->acceptEnvironmentId()
       ->acceptSite();
   }

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'push:database', 'Push a database from your local environment to a Cloud Platform environment', ['push:db'])]
+#[AsCommand(name: 'push:database', description: 'Push a database from your local environment to a Cloud Platform environment', aliases: ['push:db'])]
 class PushDatabaseCommand extends PullCommandBase {
 
   protected function commandRequiresDatabase(): bool {

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Push;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\Pull\PullCommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Output\Checklist;
@@ -14,6 +15,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'push:database', description: 'Push a database from your local environment to a Cloud Platform environment', aliases: ['push:db'])]
 class PushDatabaseCommand extends PullCommandBase {
 

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -17,12 +17,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'push:database')]
 class PushDatabaseCommand extends PullCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Push a database from your local environment to a Cloud Platform environment';
+
   protected function commandRequiresDatabase(): bool {
     return TRUE;
   }
 
   protected function configure(): void {
-    $this->setDescription('Push a database from your local environment to a Cloud Platform environment')
+    $this
       ->setAliases(['push:db'])
       ->acceptEnvironmentId()
       ->acceptSite();

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'push:database', description: 'Push a database from your local environment to a Cloud Platform environment', aliases: ['push:db'])]
-class PushDatabaseCommand extends PullCommandBase {
+final class PushDatabaseCommand extends PullCommandBase {
 
   protected function commandRequiresDatabase(): bool {
     return TRUE;

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -15,8 +15,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'push:files')]
 class PushFilesCommand extends PullCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Copy Drupal public files from your local environment to a Cloud Platform environment';
+
   protected function configure(): void {
-    $this->setDescription('Copy Drupal public files from your local environment to a Cloud Platform environment')
+    $this
       ->acceptEnvironmentId()
       ->acceptSite();
   }

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'push:files', description: 'Copy Drupal public files from your local environment to a Cloud Platform environment')]
-class PushFilesCommand extends PullCommandBase {
+final class PushFilesCommand extends PullCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -12,14 +12,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'push:files')]
+#[AsCommand(name: 'push:files', 'Copy Drupal public files from your local environment to a Cloud Platform environment')]
 class PushFilesCommand extends PullCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Copy Drupal public files from your local environment to a Cloud Platform environment';
 
   protected function configure(): void {
     $this

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'push:files', 'Copy Drupal public files from your local environment to a Cloud Platform environment')]
+#[AsCommand(name: 'push:files', description: 'Copy Drupal public files from your local environment to a Cloud Platform environment')]
 class PushFilesCommand extends PullCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Push/PushFilesCommand.php
+++ b/src/Command/Push/PushFilesCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Push;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\Pull\PullCommandBase;
 use Acquia\Cli\Output\Checklist;
 use AcquiaCloudApi\Response\EnvironmentResponse;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'push:files', description: 'Copy Drupal public files from your local environment to a Cloud Platform environment')]
 class PushFilesCommand extends PullCommandBase {
 

--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'remote:aliases:list', 'List all aliases for the Cloud Platform environments', ['aliases', 'sa'])]
+#[AsCommand(name: 'remote:aliases:list', description: 'List all aliases for the Cloud Platform environments', aliases: ['aliases', 'sa'])]
 class AliasListCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Remote;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use AcquiaCloudApi\Endpoints\Applications;
 use AcquiaCloudApi\Endpoints\Environments;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'remote:aliases:list', description: 'List all aliases for the Cloud Platform environments', aliases: ['aliases', 'sa'])]
 class AliasListCommand extends CommandBase {
 

--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -13,18 +13,10 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'remote:aliases:list')]
+#[AsCommand(name: 'remote:aliases:list', 'List all aliases for the Cloud Platform environments', ['aliases', 'sa'])]
 class AliasListCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'List all aliases for the Cloud Platform environments';
-
   protected function configure(): void {
-    $this
-      ->setAliases(['aliases', 'sa']);
     $this->acceptApplicationUuid();
   }
 

--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -16,8 +16,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'remote:aliases:list')]
 class AliasListCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'List all aliases for the Cloud Platform environments';
+
   protected function configure(): void {
-    $this->setDescription('List all aliases for the Cloud Platform environments')
+    $this
       ->setAliases(['aliases', 'sa']);
     $this->acceptApplicationUuid();
   }

--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'remote:aliases:list', description: 'List all aliases for the Cloud Platform environments', aliases: ['aliases', 'sa'])]
-class AliasListCommand extends CommandBase {
+final class AliasListCommand extends CommandBase {
 
   protected function configure(): void {
     $this->acceptApplicationUuid();

--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Filesystem\Path;
 /**
  * A command to proxy Drush commands on an environment using SSH.
  */
-#[AsCommand(name: 'remote:aliases:download', 'Download Drush aliases for the Cloud Platform')]
+#[AsCommand(name: 'remote:aliases:download', description: 'Download Drush aliases for the Cloud Platform')]
 class AliasesDownloadCommand extends SshCommand {
 
   private string $drushArchiveFilepath;

--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -20,14 +20,9 @@ use Symfony\Component\Filesystem\Path;
 /**
  * A command to proxy Drush commands on an environment using SSH.
  */
-#[AsCommand(name: 'remote:aliases:download')]
+#[AsCommand(name: 'remote:aliases:download', 'Download Drush aliases for the Cloud Platform')]
 class AliasesDownloadCommand extends SshCommand {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Download Drush aliases for the Cloud Platform';
   private string $drushArchiveFilepath;
 
   protected function configure(): void {

--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Remote;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Endpoints\Account;
@@ -20,6 +21,7 @@ use Symfony\Component\Filesystem\Path;
 /**
  * A command to proxy Drush commands on an environment using SSH.
  */
+#[RequireAuth]
 #[AsCommand(name: 'remote:aliases:download', description: 'Download Drush aliases for the Cloud Platform')]
 class AliasesDownloadCommand extends SshCommand {
 

--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -23,10 +23,15 @@ use Symfony\Component\Filesystem\Path;
 #[AsCommand(name: 'remote:aliases:download')]
 class AliasesDownloadCommand extends SshCommand {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Download Drush aliases for the Cloud Platform';
   private string $drushArchiveFilepath;
 
   protected function configure(): void {
-    $this->setDescription('Download Drush aliases for the Cloud Platform')
+    $this
       ->addOption('destination-dir', NULL, InputOption::VALUE_REQUIRED, 'The directory to which aliases will be downloaded')
       ->addOption('all', NULL, InputOption::VALUE_NONE, 'Download the aliases for all applications that you have access to, not just the current one.');
     $this->acceptApplicationUuid();

--- a/src/Command/Remote/AliasesDownloadCommand.php
+++ b/src/Command/Remote/AliasesDownloadCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Filesystem\Path;
  */
 #[RequireAuth]
 #[AsCommand(name: 'remote:aliases:download', description: 'Download Drush aliases for the Cloud Platform')]
-class AliasesDownloadCommand extends SshCommand {
+final class AliasesDownloadCommand extends SshBaseCommand {
 
   private string $drushArchiveFilepath;
 

--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -15,9 +15,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'remote:drush')]
 class DrushCommand extends SshBaseCommand {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Run a Drush command remotely on a application\'s environment';
+
   protected function configure(): void {
     $this->setAliases(['drush', 'dr'])
-      ->setDescription('Run a Drush command remotely on a application\'s environment')
       ->setHelp('<fg=black;bg=cyan>Pay close attention to the argument syntax! Note the usage of <options=bold;bg=cyan>--</> to separate the drush command arguments and options.</>')
       ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
       ->addArgument('drush_command', InputArgument::IS_ARRAY, 'Drush command')

--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[RequireAuth]
 #[AsCommand(name: 'remote:drush', description: 'Run a Drush command remotely on a application\'s environment', aliases: ['drush', 'dr'])]
-class DrushCommand extends SshBaseCommand {
+final class DrushCommand extends SshBaseCommand {
 
   protected function configure(): void {
     $this

--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -12,17 +12,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * A command to proxy Drush commands on an environment using SSH.
  */
-#[AsCommand(name: 'remote:drush')]
+#[AsCommand(name: 'remote:drush', 'Run a Drush command remotely on a application\'s environment', ['drush', 'dr'])]
 class DrushCommand extends SshBaseCommand {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Run a Drush command remotely on a application\'s environment';
-
   protected function configure(): void {
-    $this->setAliases(['drush', 'dr'])
+    $this
       ->setHelp('<fg=black;bg=cyan>Pay close attention to the argument syntax! Note the usage of <options=bold;bg=cyan>--</> to separate the drush command arguments and options.</>')
       ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
       ->addArgument('drush_command', InputArgument::IS_ARRAY, 'Drush command')

--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * A command to proxy Drush commands on an environment using SSH.
  */
-#[AsCommand(name: 'remote:drush', 'Run a Drush command remotely on a application\'s environment', ['drush', 'dr'])]
+#[AsCommand(name: 'remote:drush', description: 'Run a Drush command remotely on a application\'s environment', aliases: ['drush', 'dr'])]
 class DrushCommand extends SshBaseCommand {
 
   protected function configure(): void {

--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Remote;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * A command to proxy Drush commands on an environment using SSH.
  */
+#[RequireAuth]
 #[AsCommand(name: 'remote:drush', description: 'Run a Drush command remotely on a application\'s environment', aliases: ['drush', 'dr'])]
 class DrushCommand extends SshBaseCommand {
 

--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * A command to proxy Drush commands on an environment using SSH.
  */
-#[AsCommand(name: 'remote:ssh', 'Use SSH to open a shell or run a command in a Cloud Platform environment', ['ssh'])]
+#[AsCommand(name: 'remote:ssh', description: 'Use SSH to open a shell or run a command in a Cloud Platform environment', aliases: ['ssh'])]
 class SshCommand extends SshBaseCommand {
 
   protected function configure(): void {

--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -16,8 +16,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'remote:ssh')]
 class SshCommand extends SshBaseCommand {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Use SSH to open a shell or run a command in a Cloud Platform environment';
+
   protected function configure(): void {
-    $this->setDescription('Use SSH to open a shell or run a command in a Cloud Platform environment')
+    $this
       ->setAliases(['ssh'])
       ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
       ->addArgument('ssh_command', InputArgument::IS_ARRAY, 'Command to run via SSH (if not provided, opens a shell in the site directory)')

--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Remote;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * A command to proxy Drush commands on an environment using SSH.
  */
+#[RequireAuth]
 #[AsCommand(name: 'remote:ssh', description: 'Use SSH to open a shell or run a command in a Cloud Platform environment', aliases: ['ssh'])]
 class SshCommand extends SshBaseCommand {
 

--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -13,18 +13,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * A command to proxy Drush commands on an environment using SSH.
  */
-#[AsCommand(name: 'remote:ssh')]
+#[AsCommand(name: 'remote:ssh', 'Use SSH to open a shell or run a command in a Cloud Platform environment', ['ssh'])]
 class SshCommand extends SshBaseCommand {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Use SSH to open a shell or run a command in a Cloud Platform environment';
 
   protected function configure(): void {
     $this
-      ->setAliases(['ssh'])
       ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
       ->addArgument('ssh_command', InputArgument::IS_ARRAY, 'Command to run via SSH (if not provided, opens a shell in the site directory)')
       ->addUsage("myapp.dev # open a shell in the myapp.dev environment")

--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[RequireAuth]
 #[AsCommand(name: 'remote:ssh', description: 'Use SSH to open a shell or run a command in a Cloud Platform environment', aliases: ['ssh'])]
-class SshCommand extends SshBaseCommand {
+final class SshCommand extends SshBaseCommand {
 
   protected function configure(): void {
     $this

--- a/src/Command/Self/ClearCacheCommand.php
+++ b/src/Command/Self/ClearCacheCommand.php
@@ -15,8 +15,14 @@ use Symfony\Component\Filesystem\Path;
 #[AsCommand(name: 'self:clear-caches')]
 class ClearCacheCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Clears local Acquia CLI caches';
+
   protected function configure(): void {
-    $this->setDescription('Clears local Acquia CLI caches')
+    $this
       ->setAliases(['cc', 'cr']);
   }
 

--- a/src/Command/Self/ClearCacheCommand.php
+++ b/src/Command/Self/ClearCacheCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Self;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
+#[RequireAuth]
 #[AsCommand(name: 'self:clear-caches', description: 'Clears local Acquia CLI caches', aliases: ['cc', 'cr'])]
 class ClearCacheCommand extends CommandBase {
 

--- a/src/Command/Self/ClearCacheCommand.php
+++ b/src/Command/Self/ClearCacheCommand.php
@@ -12,11 +12,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
-#[AsCommand(name: 'self:clear-caches', 'Clears local Acquia CLI caches', ['cc', 'cr'])]
+#[AsCommand(name: 'self:clear-caches', description: 'Clears local Acquia CLI caches', aliases: ['cc', 'cr'])]
 class ClearCacheCommand extends CommandBase {
 
-  protected function configure(): void
-  {
+  protected function configure(): void {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/ClearCacheCommand.php
+++ b/src/Command/Self/ClearCacheCommand.php
@@ -12,18 +12,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
-#[AsCommand(name: 'self:clear-caches')]
+#[AsCommand(name: 'self:clear-caches', 'Clears local Acquia CLI caches', ['cc', 'cr'])]
 class ClearCacheCommand extends CommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Clears local Acquia CLI caches';
-
-  protected function configure(): void {
-    $this
-      ->setAliases(['cc', 'cr']);
+  protected function configure(): void
+  {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/ClearCacheCommand.php
+++ b/src/Command/Self/ClearCacheCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Filesystem\Path;
 
 #[RequireAuth]
 #[AsCommand(name: 'self:clear-caches', description: 'Clears local Acquia CLI caches', aliases: ['cc', 'cr'])]
-class ClearCacheCommand extends CommandBase {
+final class ClearCacheCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     self::clearCaches();

--- a/src/Command/Self/ClearCacheCommand.php
+++ b/src/Command/Self/ClearCacheCommand.php
@@ -15,9 +15,6 @@ use Symfony\Component\Filesystem\Path;
 #[AsCommand(name: 'self:clear-caches', description: 'Clears local Acquia CLI caches', aliases: ['cc', 'cr'])]
 class ClearCacheCommand extends CommandBase {
 
-  protected function configure(): void {
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     self::clearCaches();
     $output->writeln('Acquia CLI caches were cleared.');

--- a/src/Command/Self/ListCommand.php
+++ b/src/Command/Self/ListCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'list', description: NULL, aliases: ['self:list'])]
-class ListCommand extends \Symfony\Component\Console\Command\ListCommand {
+final class ListCommand extends \Symfony\Component\Console\Command\ListCommand {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     foreach (['api', 'acsf'] as $prefix) {

--- a/src/Command/Self/ListCommand.php
+++ b/src/Command/Self/ListCommand.php
@@ -12,13 +12,11 @@ use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'list')]
+#[AsCommand(name: 'list', null, ['self:list'])]
 class ListCommand extends \Symfony\Component\Console\Command\ListCommand {
 
   protected function configure(): void {
     parent::configure();
-    $this
-      ->setAliases(['self:list']);
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/ListCommand.php
+++ b/src/Command/Self/ListCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'list', null, ['self:list'])]
+#[AsCommand(name: 'list', description: NULL, aliases: ['self:list'])]
 class ListCommand extends \Symfony\Component\Console\Command\ListCommand {
 
   protected function configure(): void {

--- a/src/Command/Self/ListCommand.php
+++ b/src/Command/Self/ListCommand.php
@@ -15,10 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'list', description: NULL, aliases: ['self:list'])]
 class ListCommand extends \Symfony\Component\Console\Command\ListCommand {
 
-  protected function configure(): void {
-    parent::configure();
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     foreach (['api', 'acsf'] as $prefix) {
       if ($input->getArgument('namespace') !== $prefix) {

--- a/src/Command/Self/ListCommand.php
+++ b/src/Command/Self/ListCommand.php
@@ -6,17 +6,19 @@ namespace Acquia\Cli\Command\Self;
 
 use Acquia\Cli\Command\Acsf\AcsfListCommandBase;
 use Acquia\Cli\Command\Api\ApiListCommandBase;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'list')]
 class ListCommand extends \Symfony\Component\Console\Command\ListCommand {
 
   protected function configure(): void {
     parent::configure();
-    $this->setName('self:list')
-      ->setAliases(['list']);
+    $this
+      ->setAliases(['self:list']);
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/MakeDocsCommand.php
+++ b/src/Command/Self/MakeDocsCommand.php
@@ -11,14 +11,8 @@ use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'self:make-docs')]
+#[AsCommand(name: 'self:make-docs', 'Generate documentation for all ACLI commands')]
 class MakeDocsCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Generate documentation for all ACLI commands';
 
   protected function configure(): void {
     $this

--- a/src/Command/Self/MakeDocsCommand.php
+++ b/src/Command/Self/MakeDocsCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'self:make-docs', description: 'Generate documentation for all ACLI commands')]
-class MakeDocsCommand extends CommandBase {
+final class MakeDocsCommand extends CommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Self/MakeDocsCommand.php
+++ b/src/Command/Self/MakeDocsCommand.php
@@ -13,13 +13,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
-#[AsCommand(name: 'self:make-docs', description: 'Generate documentation for all ACLI commands')]
+#[AsCommand(name: 'self:make-docs', description: 'Generate documentation for all ACLI commands', hidden: TRUE)]
 final class MakeDocsCommand extends CommandBase {
-
-  protected function configure(): void {
-    $this
-      ->setHidden();
-  }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $helper = new DescriptorHelper();

--- a/src/Command/Self/MakeDocsCommand.php
+++ b/src/Command/Self/MakeDocsCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'self:make-docs', 'Generate documentation for all ACLI commands')]
+#[AsCommand(name: 'self:make-docs', description: 'Generate documentation for all ACLI commands')]
 class MakeDocsCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Self/MakeDocsCommand.php
+++ b/src/Command/Self/MakeDocsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Self;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'self:make-docs', description: 'Generate documentation for all ACLI commands')]
 class MakeDocsCommand extends CommandBase {
 

--- a/src/Command/Self/MakeDocsCommand.php
+++ b/src/Command/Self/MakeDocsCommand.php
@@ -14,8 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'self:make-docs')]
 class MakeDocsCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Generate documentation for all ACLI commands';
+
   protected function configure(): void {
-    $this->setDescription('Generate documentation for all ACLI commands')
+    $this
       ->setHidden();
   }
 

--- a/src/Command/Self/TelemetryCommand.php
+++ b/src/Command/Self/TelemetryCommand.php
@@ -11,15 +11,14 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'self:telemetry:toggle', 'Toggle anonymous sharing of usage and performance data', ['telemetry'])]
+#[AsCommand(name: 'self:telemetry:toggle', description: 'Toggle anonymous sharing of usage and performance data', aliases: ['telemetry'])]
 class TelemetryCommand extends CommandBase {
 
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
-  protected function configure(): void
-  {
+  protected function configure(): void {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/TelemetryCommand.php
+++ b/src/Command/Self/TelemetryCommand.php
@@ -18,9 +18,6 @@ class TelemetryCommand extends CommandBase {
     return FALSE;
   }
 
-  protected function configure(): void {
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $datastore = $this->datastoreCloud;
     if ($datastore->get(DataStoreContract::SEND_TELEMETRY)) {

--- a/src/Command/Self/TelemetryCommand.php
+++ b/src/Command/Self/TelemetryCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'self:telemetry:toggle', description: 'Toggle anonymous sharing of usage and performance data', aliases: ['telemetry'])]
-class TelemetryCommand extends CommandBase {
+final class TelemetryCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $datastore = $this->datastoreCloud;

--- a/src/Command/Self/TelemetryCommand.php
+++ b/src/Command/Self/TelemetryCommand.php
@@ -14,12 +14,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'self:telemetry:toggle')]
 class TelemetryCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Toggle anonymous sharing of usage and performance data';
+
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
   protected function configure(): void {
-    $this->setDescription('Toggle anonymous sharing of usage and performance data')
+    $this
       ->setAliases(['telemetry']);
   }
 

--- a/src/Command/Self/TelemetryCommand.php
+++ b/src/Command/Self/TelemetryCommand.php
@@ -11,22 +11,15 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'self:telemetry:toggle')]
+#[AsCommand(name: 'self:telemetry:toggle', 'Toggle anonymous sharing of usage and performance data', ['telemetry'])]
 class TelemetryCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Toggle anonymous sharing of usage and performance data';
 
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
-  protected function configure(): void {
-    $this
-      ->setAliases(['telemetry']);
+  protected function configure(): void
+  {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/TelemetryCommand.php
+++ b/src/Command/Self/TelemetryCommand.php
@@ -14,10 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'self:telemetry:toggle', description: 'Toggle anonymous sharing of usage and performance data', aliases: ['telemetry'])]
 class TelemetryCommand extends CommandBase {
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $datastore = $this->datastoreCloud;
     if ($datastore->get(DataStoreContract::SEND_TELEMETRY)) {

--- a/src/Command/Self/TelemetryDisableCommand.php
+++ b/src/Command/Self/TelemetryDisableCommand.php
@@ -18,9 +18,6 @@ class TelemetryDisableCommand extends CommandBase {
     return FALSE;
   }
 
-  protected function configure(): void {
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $datastore = $this->datastoreCloud;
     $datastore->set(DataStoreContract::SEND_TELEMETRY, FALSE);

--- a/src/Command/Self/TelemetryDisableCommand.php
+++ b/src/Command/Self/TelemetryDisableCommand.php
@@ -14,12 +14,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'self:telemetry:disable')]
 class TelemetryDisableCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Disable anonymous sharing of usage and performance data';
+
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
   protected function configure(): void {
-    $this->setDescription('Disable anonymous sharing of usage and performance data')
+    $this
       ->setAliases(['telemetry:disable']);
   }
 

--- a/src/Command/Self/TelemetryDisableCommand.php
+++ b/src/Command/Self/TelemetryDisableCommand.php
@@ -11,22 +11,15 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'self:telemetry:disable')]
+#[AsCommand(name: 'self:telemetry:disable', 'Disable anonymous sharing of usage and performance data', ['telemetry:disable'])]
 class TelemetryDisableCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Disable anonymous sharing of usage and performance data';
 
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
-  protected function configure(): void {
-    $this
-      ->setAliases(['telemetry:disable']);
+  protected function configure(): void
+  {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/TelemetryDisableCommand.php
+++ b/src/Command/Self/TelemetryDisableCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'self:telemetry:disable', description: 'Disable anonymous sharing of usage and performance data', aliases: ['telemetry:disable'])]
-class TelemetryDisableCommand extends CommandBase {
+final class TelemetryDisableCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $datastore = $this->datastoreCloud;

--- a/src/Command/Self/TelemetryDisableCommand.php
+++ b/src/Command/Self/TelemetryDisableCommand.php
@@ -11,15 +11,14 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'self:telemetry:disable', 'Disable anonymous sharing of usage and performance data', ['telemetry:disable'])]
+#[AsCommand(name: 'self:telemetry:disable', description: 'Disable anonymous sharing of usage and performance data', aliases: ['telemetry:disable'])]
 class TelemetryDisableCommand extends CommandBase {
 
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
-  protected function configure(): void
-  {
+  protected function configure(): void {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/TelemetryDisableCommand.php
+++ b/src/Command/Self/TelemetryDisableCommand.php
@@ -14,10 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'self:telemetry:disable', description: 'Disable anonymous sharing of usage and performance data', aliases: ['telemetry:disable'])]
 class TelemetryDisableCommand extends CommandBase {
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $datastore = $this->datastoreCloud;
     $datastore->set(DataStoreContract::SEND_TELEMETRY, FALSE);

--- a/src/Command/Self/TelemetryEnableCommand.php
+++ b/src/Command/Self/TelemetryEnableCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'self:telemetry:enable', description: 'Enable anonymous sharing of usage and performance data', aliases: ['telemetry:enable'])]
-class TelemetryEnableCommand extends CommandBase {
+final class TelemetryEnableCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $datastore = $this->datastoreCloud;

--- a/src/Command/Self/TelemetryEnableCommand.php
+++ b/src/Command/Self/TelemetryEnableCommand.php
@@ -14,10 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'self:telemetry:enable', description: 'Enable anonymous sharing of usage and performance data', aliases: ['telemetry:enable'])]
 class TelemetryEnableCommand extends CommandBase {
 
-  protected function commandRequiresAuthentication(): bool {
-    return FALSE;
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $datastore = $this->datastoreCloud;
     $datastore->set(DataStoreContract::SEND_TELEMETRY, TRUE);

--- a/src/Command/Self/TelemetryEnableCommand.php
+++ b/src/Command/Self/TelemetryEnableCommand.php
@@ -11,15 +11,14 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'self:telemetry:enable', 'Enable anonymous sharing of usage and performance data', ['telemetry:enable'])]
+#[AsCommand(name: 'self:telemetry:enable', description: 'Enable anonymous sharing of usage and performance data', aliases: ['telemetry:enable'])]
 class TelemetryEnableCommand extends CommandBase {
 
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
-  protected function configure(): void
-  {
+  protected function configure(): void {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/TelemetryEnableCommand.php
+++ b/src/Command/Self/TelemetryEnableCommand.php
@@ -14,12 +14,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'self:telemetry:enable')]
 class TelemetryEnableCommand extends CommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Enable anonymous sharing of usage and performance data';
+
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
   protected function configure(): void {
-    $this->setDescription('Enable anonymous sharing of usage and performance data')
+    $this
       ->setAliases(['telemetry:enable']);
   }
 

--- a/src/Command/Self/TelemetryEnableCommand.php
+++ b/src/Command/Self/TelemetryEnableCommand.php
@@ -11,22 +11,15 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'self:telemetry:enable')]
+#[AsCommand(name: 'self:telemetry:enable', 'Enable anonymous sharing of usage and performance data', ['telemetry:enable'])]
 class TelemetryEnableCommand extends CommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Enable anonymous sharing of usage and performance data';
 
   protected function commandRequiresAuthentication(): bool {
     return FALSE;
   }
 
-  protected function configure(): void {
-    $this
-      ->setAliases(['telemetry:enable']);
+  protected function configure(): void
+  {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Self/TelemetryEnableCommand.php
+++ b/src/Command/Self/TelemetryEnableCommand.php
@@ -18,9 +18,6 @@ class TelemetryEnableCommand extends CommandBase {
     return FALSE;
   }
 
-  protected function configure(): void {
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $datastore = $this->datastoreCloud;
     $datastore->set(DataStoreContract::SEND_TELEMETRY, TRUE);

--- a/src/Command/Ssh/SshKeyCreateCommand.php
+++ b/src/Command/Ssh/SshKeyCreateCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ssh-key:create', description: 'Create an SSH key on your local machine')]
-class SshKeyCreateCommand extends SshKeyCommandBase {
+final class SshKeyCreateCommand extends SshKeyCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Ssh/SshKeyCreateCommand.php
+++ b/src/Command/Ssh/SshKeyCreateCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:create', 'Create an SSH key on your local machine')]
+#[AsCommand(name: 'ssh-key:create', description: 'Create an SSH key on your local machine')]
 class SshKeyCreateCommand extends SshKeyCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Ssh/SshKeyCreateCommand.php
+++ b/src/Command/Ssh/SshKeyCreateCommand.php
@@ -4,12 +4,14 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ssh;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ssh-key:create', description: 'Create an SSH key on your local machine')]
 class SshKeyCreateCommand extends SshKeyCommandBase {
 

--- a/src/Command/Ssh/SshKeyCreateCommand.php
+++ b/src/Command/Ssh/SshKeyCreateCommand.php
@@ -10,14 +10,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:create')]
+#[AsCommand(name: 'ssh-key:create', 'Create an SSH key on your local machine')]
 class SshKeyCreateCommand extends SshKeyCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Create an SSH key on your local machine';
 
   protected function configure(): void {
     $this

--- a/src/Command/Ssh/SshKeyCreateCommand.php
+++ b/src/Command/Ssh/SshKeyCreateCommand.php
@@ -13,8 +13,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ssh-key:create')]
 class SshKeyCreateCommand extends SshKeyCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Create an SSH key on your local machine';
+
   protected function configure(): void {
-    $this->setDescription('Create an SSH key on your local machine')
+    $this
       ->addOption('filename', NULL, InputOption::VALUE_REQUIRED, 'The filename of the SSH key')
       ->addOption('password', NULL, InputOption::VALUE_REQUIRED, 'The password for the SSH key');
   }

--- a/src/Command/Ssh/SshKeyCreateUploadCommand.php
+++ b/src/Command/Ssh/SshKeyCreateUploadCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:create-upload', 'Create an SSH key on your local machine and upload it to the Cloud Platform')]
+#[AsCommand(name: 'ssh-key:create-upload', description: 'Create an SSH key on your local machine and upload it to the Cloud Platform')]
 class SshKeyCreateUploadCommand extends SshKeyCreateCommand {
 
   protected function configure(): void {

--- a/src/Command/Ssh/SshKeyCreateUploadCommand.php
+++ b/src/Command/Ssh/SshKeyCreateUploadCommand.php
@@ -4,12 +4,14 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ssh;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ssh-key:create-upload', description: 'Create an SSH key on your local machine and upload it to the Cloud Platform')]
 class SshKeyCreateUploadCommand extends SshKeyCreateCommand {
 

--- a/src/Command/Ssh/SshKeyCreateUploadCommand.php
+++ b/src/Command/Ssh/SshKeyCreateUploadCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ssh-key:create-upload', description: 'Create an SSH key on your local machine and upload it to the Cloud Platform')]
-class SshKeyCreateUploadCommand extends SshKeyCreateCommand {
+final class SshKeyCreateUploadCommand extends SshKeyCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Ssh/SshKeyCreateUploadCommand.php
+++ b/src/Command/Ssh/SshKeyCreateUploadCommand.php
@@ -10,14 +10,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:create-upload')]
+#[AsCommand(name: 'ssh-key:create-upload', 'Create an SSH key on your local machine and upload it to the Cloud Platform')]
 class SshKeyCreateUploadCommand extends SshKeyCreateCommand {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Create an SSH key on your local machine and upload it to the Cloud Platform';
 
   protected function configure(): void {
     $this

--- a/src/Command/Ssh/SshKeyCreateUploadCommand.php
+++ b/src/Command/Ssh/SshKeyCreateUploadCommand.php
@@ -13,8 +13,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ssh-key:create-upload')]
 class SshKeyCreateUploadCommand extends SshKeyCreateCommand {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Create an SSH key on your local machine and upload it to the Cloud Platform';
+
   protected function configure(): void {
-    $this->setDescription('Create an SSH key on your local machine and upload it to the Cloud Platform')
+    $this
       ->addOption('filename', NULL, InputOption::VALUE_REQUIRED, 'The filename of the SSH key')
       ->addOption('password', NULL, InputOption::VALUE_REQUIRED, 'The password for the SSH key')
       ->addOption('label', NULL, InputOption::VALUE_REQUIRED, 'The SSH key label to be used with the Cloud Platform')

--- a/src/Command/Ssh/SshKeyDeleteCommand.php
+++ b/src/Command/Ssh/SshKeyDeleteCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:delete', 'Delete an SSH key')]
+#[AsCommand(name: 'ssh-key:delete', description: 'Delete an SSH key')]
 class SshKeyDeleteCommand extends SshKeyCommandBase {
 
   use SshCommandTrait;

--- a/src/Command/Ssh/SshKeyDeleteCommand.php
+++ b/src/Command/Ssh/SshKeyDeleteCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ssh-key:delete', description: 'Delete an SSH key')]
-class SshKeyDeleteCommand extends SshKeyCommandBase {
+final class SshKeyDeleteCommand extends SshKeyCommandBase {
 
   use SshCommandTrait;
 

--- a/src/Command/Ssh/SshKeyDeleteCommand.php
+++ b/src/Command/Ssh/SshKeyDeleteCommand.php
@@ -13,10 +13,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ssh-key:delete')]
 class SshKeyDeleteCommand extends SshKeyCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Delete an SSH key';
   use SshCommandTrait;
 
   protected function configure(): void {
-    $this->setDescription('Delete an SSH key')
+    $this
       ->addOption('cloud-key-uuid', 'uuid', InputOption::VALUE_REQUIRED);
   }
 

--- a/src/Command/Ssh/SshKeyDeleteCommand.php
+++ b/src/Command/Ssh/SshKeyDeleteCommand.php
@@ -10,14 +10,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:delete')]
+#[AsCommand(name: 'ssh-key:delete', 'Delete an SSH key')]
 class SshKeyDeleteCommand extends SshKeyCommandBase {
 
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Delete an SSH key';
   use SshCommandTrait;
 
   protected function configure(): void {

--- a/src/Command/Ssh/SshKeyDeleteCommand.php
+++ b/src/Command/Ssh/SshKeyDeleteCommand.php
@@ -4,12 +4,14 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ssh;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Helpers\SshCommandTrait;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ssh-key:delete', description: 'Delete an SSH key')]
 class SshKeyDeleteCommand extends SshKeyCommandBase {
 

--- a/src/Command/Ssh/SshKeyInfoCommand.php
+++ b/src/Command/Ssh/SshKeyInfoCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ssh-key:info', description: 'Print information about an SSH key')]
-class SshKeyInfoCommand extends SshKeyCommandBase {
+final class SshKeyInfoCommand extends SshKeyCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Ssh/SshKeyInfoCommand.php
+++ b/src/Command/Ssh/SshKeyInfoCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ssh;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Endpoints\SshKeys;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ssh-key:info', description: 'Print information about an SSH key')]
 class SshKeyInfoCommand extends SshKeyCommandBase {
 

--- a/src/Command/Ssh/SshKeyInfoCommand.php
+++ b/src/Command/Ssh/SshKeyInfoCommand.php
@@ -13,14 +13,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:info')]
+#[AsCommand(name: 'ssh-key:info', 'Print information about an SSH key')]
 class SshKeyInfoCommand extends SshKeyCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Print information about an SSH key';
 
   protected function configure(): void {
     $this

--- a/src/Command/Ssh/SshKeyInfoCommand.php
+++ b/src/Command/Ssh/SshKeyInfoCommand.php
@@ -16,8 +16,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ssh-key:info')]
 class SshKeyInfoCommand extends SshKeyCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Print information about an SSH key';
+
   protected function configure(): void {
-    $this->setDescription('Print information about an SSH key')
+    $this
       ->addOption('fingerprint', NULL, InputOption::VALUE_REQUIRED, 'sha256 fingerprint')
       ->addUsage('--fingerprint=pyarUa1mt2ln4fmrp7alWKpv1IPneqFwE+ErTC71IvY=');
   }

--- a/src/Command/Ssh/SshKeyInfoCommand.php
+++ b/src/Command/Ssh/SshKeyInfoCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:info', 'Print information about an SSH key')]
+#[AsCommand(name: 'ssh-key:info', description: 'Print information about an SSH key')]
 class SshKeyInfoCommand extends SshKeyCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ssh-key:list', description: 'List your local and remote SSH keys')]
-class SshKeyListCommand extends SshKeyCommandBase {
+final class SshKeyListCommand extends SshKeyCommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $acquiaCloudClient = $this->cloudApiClientService->getClient();

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ssh;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use AcquiaCloudApi\Endpoints\SshKeys;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ssh-key:list', description: 'List your local and remote SSH keys')]
 class SshKeyListCommand extends SshKeyCommandBase {
 

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -14,8 +14,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ssh-key:list')]
 class SshKeyListCommand extends SshKeyCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'List your local and remote SSH keys';
+
   protected function configure(): void {
-    $this->setDescription('List your local and remote SSH keys');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -14,9 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ssh-key:list', description: 'List your local and remote SSH keys')]
 class SshKeyListCommand extends SshKeyCommandBase {
 
-  protected function configure(): void {
-  }
-
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $acquiaCloudClient = $this->cloudApiClientService->getClient();
     $sshKeys = new SshKeys($acquiaCloudClient);

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:list', 'List your local and remote SSH keys')]
+#[AsCommand(name: 'ssh-key:list', description: 'List your local and remote SSH keys')]
 class SshKeyListCommand extends SshKeyCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Ssh/SshKeyListCommand.php
+++ b/src/Command/Ssh/SshKeyListCommand.php
@@ -11,14 +11,8 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:list')]
+#[AsCommand(name: 'ssh-key:list', 'List your local and remote SSH keys')]
 class SshKeyListCommand extends SshKeyCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'List your local and remote SSH keys';
 
   protected function configure(): void {
   }

--- a/src/Command/Ssh/SshKeyUploadCommand.php
+++ b/src/Command/Ssh/SshKeyUploadCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:upload', 'Upload a local SSH key to the Cloud Platform')]
+#[AsCommand(name: 'ssh-key:upload', description: 'Upload a local SSH key to the Cloud Platform')]
 class SshKeyUploadCommand extends SshKeyCommandBase {
 
   protected function configure(): void {

--- a/src/Command/Ssh/SshKeyUploadCommand.php
+++ b/src/Command/Ssh/SshKeyUploadCommand.php
@@ -4,12 +4,14 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command\Ssh;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[RequireAuth]
 #[AsCommand(name: 'ssh-key:upload', description: 'Upload a local SSH key to the Cloud Platform')]
 class SshKeyUploadCommand extends SshKeyCommandBase {
 

--- a/src/Command/Ssh/SshKeyUploadCommand.php
+++ b/src/Command/Ssh/SshKeyUploadCommand.php
@@ -10,14 +10,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'ssh-key:upload')]
+#[AsCommand(name: 'ssh-key:upload', 'Upload a local SSH key to the Cloud Platform')]
 class SshKeyUploadCommand extends SshKeyCommandBase {
-
-  /**
-   * @var string
-   */
-  // phpcs:ignore
-  protected static $defaultDescription = 'Upload a local SSH key to the Cloud Platform';
 
   protected function configure(): void {
     $this

--- a/src/Command/Ssh/SshKeyUploadCommand.php
+++ b/src/Command/Ssh/SshKeyUploadCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
 #[AsCommand(name: 'ssh-key:upload', description: 'Upload a local SSH key to the Cloud Platform')]
-class SshKeyUploadCommand extends SshKeyCommandBase {
+final class SshKeyUploadCommand extends SshKeyCommandBase {
 
   protected function configure(): void {
     $this

--- a/src/Command/Ssh/SshKeyUploadCommand.php
+++ b/src/Command/Ssh/SshKeyUploadCommand.php
@@ -13,8 +13,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'ssh-key:upload')]
 class SshKeyUploadCommand extends SshKeyCommandBase {
 
+  /**
+   * @var string
+   */
+  // phpcs:ignore
+  protected static $defaultDescription = 'Upload a local SSH key to the Cloud Platform';
+
   protected function configure(): void {
-    $this->setDescription('Upload a local SSH key to the Cloud Platform')
+    $this
       ->addOption('filepath', NULL, InputOption::VALUE_REQUIRED, 'The filepath of the public SSH key to upload')
       ->addOption('label', NULL, InputOption::VALUE_REQUIRED, 'The SSH key label to be used with the Cloud Platform')
       ->addOption('no-wait', NULL, InputOption::VALUE_NONE, "Don't wait for the SSH key to be uploaded to the Cloud Platform");

--- a/src/Command/WizardCommandBase.php
+++ b/src/Command/WizardCommandBase.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Command;
 
+use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\Ssh\SshKeyCommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Endpoints\SshKeys;
@@ -16,7 +17,8 @@ abstract class WizardCommandBase extends SshKeyCommandBase {
   abstract protected function validateEnvironment(): void;
 
   protected function initialize(InputInterface $input, OutputInterface $output): void {
-    if ($this->commandRequiresAuthentication() && !$this->cloudApiClientService->isMachineAuthenticated()) {
+    $reflectionClass = new \ReflectionClass($this);
+    if ($reflectionClass->getAttributes(RequireAuth::class) && !$this->cloudApiClientService->isMachineAuthenticated()) {
       $commandName = 'auth:login';
       $command = $this->getApplication()->find($commandName);
       $arguments = ['command' => $commandName];

--- a/src/Command/WizardCommandBase.php
+++ b/src/Command/WizardCommandBase.php
@@ -17,8 +17,7 @@ abstract class WizardCommandBase extends SshKeyCommandBase {
   abstract protected function validateEnvironment(): void;
 
   protected function initialize(InputInterface $input, OutputInterface $output): void {
-    $reflectionClass = new \ReflectionClass($this);
-    if ($reflectionClass->getAttributes(RequireAuth::class) && !$this->cloudApiClientService->isMachineAuthenticated()) {
+    if ((new \ReflectionClass(static::class))->getAttributes(RequireAuth::class) && !$this->cloudApiClientService->isMachineAuthenticated()) {
       $commandName = 'auth:login';
       $command = $this->getApplication()->find($commandName);
       $arguments = ['command' => $commandName];

--- a/tests/phpunit/src/Application/KernelTest.php
+++ b/tests/phpunit/src/Application/KernelTest.php
@@ -39,6 +39,7 @@ Available commands:
   completion               Dump the shell completion script
   docs                     Open Acquia product documentation in a web browser
   help                     Display help for a command
+  list                     [self:list] List commands
  acsf
   acsf:list                [acsf] List all Acquia Cloud Site Factory commands
  api
@@ -99,7 +100,6 @@ EOD;
   remote:ssh               [ssh] Use SSH to open a shell or run a command in a Cloud Platform environment
  self
   self:clear-caches        [cc|cr] Clears local Acquia CLI caches
-  self:list                [list] List commands
   self:telemetry:disable   [telemetry:disable] Disable anonymous sharing of usage and performance data
   self:telemetry:enable    [telemetry:enable] Enable anonymous sharing of usage and performance data
   self:telemetry:toggle    [telemetry] Toggle anonymous sharing of usage and performance data


### PR DESCRIPTION
I wanted to more radically strip `configure()` into attributes, but it turns out Symfony doesn't support that natively. The goal of AsCommand is only to replace static properties like the name and description, not all of the possible methods in `configure()`.

Drush accomplishes this using consolidation annotated commands. It's a work of art, but I'd rather stick with pure Symfony patterns for now.