### PR TITLE
CLI-1212: [auth:logout] remove secrets

### DIFF
--- a/src/Command/Auth/AuthAcsfLoginCommand.php
+++ b/src/Command/Auth/AuthAcsfLoginCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:acsf-login', description: 'Register your Site Factory API key and secret to use API functionality')]
+#[AsCommand(name: 'auth:acsf-login', description: 'Register Acquia Site Factory API credentials')]
 final class AuthAcsfLoginCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Auth/AuthAcsfLogoutCommand.php
+++ b/src/Command/Auth/AuthAcsfLogoutCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:acsf-logout', description: 'Remove your Site Factory key and secret from your local machine.')]
+#[AsCommand(name: 'auth:acsf-logout', description: 'Remove Acquia Site Factory API credentials')]
 final class AuthAcsfLogoutCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:login', description: 'Register your Cloud API key and secret to use API functionality', aliases: ['login'])]
+#[AsCommand(name: 'auth:login', description: 'Register Acquia Cloud API credentials', aliases: ['login'])]
 final class AuthLoginCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -5,24 +5,35 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\Auth;
 
 use Acquia\Cli\Command\CommandBase;
+use Acquia\Cli\Exception\AcquiaCliException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'auth:logout', description: 'Remove Cloud API key and secret from local machine.', aliases: ['logout'])]
+#[AsCommand(name: 'auth:logout', description: 'Remove Acquia Cloud API credentials', aliases: ['logout'])]
 final class AuthLogoutCommand extends CommandBase {
 
-  protected function execute(InputInterface $input, OutputInterface $output): int {
-    if ($this->cloudApiClientService->isMachineAuthenticated()) {
-      $answer = $this->io->confirm('Are you sure you\'d like to unset the Acquia Cloud API key for Acquia CLI?');
-      if (!$answer) {
-        return Command::SUCCESS;
-      }
-    }
-    $this->datastoreCloud->remove('acli_key');
+  protected function configure(): void {
+    $this->addOption('delete', NULL, InputOption::VALUE_NEGATABLE, 'Delete the active Acquia Cloud API credentials');
+  }
 
-    $output->writeln("Unset the Acquia Cloud API key for Acquia CLI</info>");
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    if (!$this->cloudApiClientService->isMachineAuthenticated()) {
+      throw new AcquiaCliException('You are not authenticated and therefore cannot logout');
+    }
+    $activeKey = $this->datastoreCloud->get('acli_key');
+    $output->writeln("<info>The active key <options=bold>$activeKey</> will be unset. You may also delete the active credentials entirely.</info>");
+    $delete = $this->determineOption('delete', FALSE, NULL, NULL, TRUE);
+    $this->datastoreCloud->remove('acli_key');
+    if ($delete) {
+      $this->datastoreCloud->remove("keys.$activeKey");
+      $output->writeln("The active Acquia Cloud API credentials were deleted</info>");
+    }
+    else {
+      $output->writeln("The active Acquia Cloud API credentials were unset</info>");
+    }
 
     return Command::SUCCESS;
   }

--- a/tests/phpunit/src/Application/KernelTest.php
+++ b/tests/phpunit/src/Application/KernelTest.php
@@ -60,10 +60,10 @@ EOD;
  archive
   archive:export           Export an archive of the Drupal application including code, files, and database
  auth
-  auth:acsf-login          Register your Site Factory API key and secret to use API functionality
-  auth:acsf-logout         Remove your Site Factory key and secret from your local machine.
-  auth:login               [login] Register your Cloud API key and secret to use API functionality
-  auth:logout              [logout] Remove Cloud API key and secret from local machine.
+  auth:acsf-login          Register Acquia Site Factory API credentials
+  auth:acsf-logout         Remove Acquia Site Factory API credentials
+  auth:login               [login] Register Acquia Cloud API credentials
+  auth:logout              [logout] Remove Acquia Cloud API credentials
  codestudio
   codestudio:php-version   Change the PHP version in Code Studio
   codestudio:wizard        [cs:wizard] Create and/or configure a new Code Studio project for a given Acquia Cloud application

--- a/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
@@ -27,6 +27,8 @@ class AuthLogoutCommandTest extends CommandTestBase {
     $config = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $this->cloudConfigFilepath);
     $this->assertFalse($config->exists('acli_key'));
     $this->assertEmpty($config->get('keys'));
+    $this->assertStringContainsString('The active key 17feaf34-5d04-402b-9a67-15d5161d24e1 will be unset.', $output);
+    $this->assertStringContainsString('Do you want to delete the active Acquia Cloud API credentials (option --delete)? (yes/no) [yes]:', $output);
     $this->assertStringContainsString('The active Acquia Cloud API credentials were deleted', $output);
   }
 


### PR DESCRIPTION
@anavarre can you take this for a spin and provide feedback on the new UX and messaging?

I'm trying to give customers the flexibility to either "unset" the active key (so that they can re-use it by running `auth:login` again without having to re-input credentials) or to "delete" it entirely.

I'm not sure if "unset" and "delete" are entirely clear in this context. I'm open to feedback.

Delete credentials (the default option):

https://github.com/acquia/cli/assets/1984514/2ddb0fc9-de41-4f79-bc97-68bb775451cb


Unset credentials (interactive):


https://github.com/acquia/cli/assets/1984514/d658c899-02c5-4460-b9e4-6e7faa0dd413



Unset credentials (via `--no-delete` option)


https://github.com/acquia/cli/assets/1984514/030d3648-3bd2-450e-96b2-775d74d55f65

