### PR TITLE
CLI-1130: Workaround for broken Drush SQL import

### DIFF
--- a/src/Helpers/SshHelper.php
+++ b/src/Helpers/SshHelper.php
@@ -59,7 +59,6 @@ class SshHelper implements LoggerAwareInterface {
 
   private function sendCommand(?string $url, array $command, bool $printOutput, ?int $timeout = NULL): Process {
     $command = array_values($this->getSshCommand($url, $command));
-    $this->localMachineHelper->checkRequiredBinariesExist(['ssh']);
 
     return $this->localMachineHelper->execute($command, $this->getOutputCallback(), NULL, $printOutput, $timeout);
   }

--- a/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
@@ -50,7 +50,6 @@ class DrushCommandTest extends SshCommandTestBase {
     ClearCacheCommand::clearCaches();
     $this->mockForGetEnvironmentFromAliasArg();
     [$process, $localMachineHelper] = $this->mockForExecuteCommand();
-    $localMachineHelper->checkRequiredBinariesExist(['ssh'])->shouldBeCalled();
     $sshCommand = [
       'ssh',
       'site.dev@sitedev.ssh.hosted.acquia-sites.com',

--- a/tests/phpunit/src/Commands/Remote/SshCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTest.php
@@ -26,7 +26,6 @@ class SshCommandTest extends SshCommandTestBase {
     ClearCacheCommand::clearCaches();
     $this->mockForGetEnvironmentFromAliasArg();
     [$process, $localMachineHelper] = $this->mockForExecuteCommand();
-    $localMachineHelper->checkRequiredBinariesExist(['ssh'])->shouldBeCalled();
     $sshCommand = [
       'ssh',
       'site.dev@sitedev.ssh.hosted.acquia-sites.com',


### PR DESCRIPTION
Seems like stdin is being sent to the _first_ process run in the stack, which is actually `which ssh`.