### PR TITLE
CLI-1219: API key labels should be email addresses

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,12 +1,14 @@
 <?php
 namespace PHPSTORM_META {
 
+  use AcquiaCloudApi\Response\AccountResponse;
   use AcquiaCloudApi\Response\ApplicationResponse;
   use AcquiaCloudApi\Response\ApplicationsResponse;
   use AcquiaCloudApi\Response\DatabasesResponse;
   use AcquiaCloudApi\Response\EnvironmentsResponse;
 
   override(\Acquia\Cli\Tests\TestBase::mockRequest(), map([
+    'getAccount' => AccountResponse::class,
     'getApplications' => ApplicationsResponse::class,
     'getApplicationByUuid' => ApplicationResponse::class,
     'getApplicationEnvironments' => EnvironmentsResponse::class,

--- a/assets/acquia-spec.yaml
+++ b/assets/acquia-spec.yaml
@@ -17157,6 +17157,7 @@ paths:
           application/json:
             schema:
               type: object
+
               required:
                 - label
                 - sources

--- a/assets/acquia-spec.yaml
+++ b/assets/acquia-spec.yaml
@@ -17157,7 +17157,6 @@ paths:
           application/json:
             schema:
               type: object
-
               required:
                 - label
                 - sources

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\Auth;
 
 use Acquia\Cli\Command\CommandBase;
+use AcquiaCloudApi\Endpoints\Account;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -61,10 +62,11 @@ final class AuthLoginCommand extends CommandBase {
   }
 
   private function writeApiCredentialsToDisk(string $apiKey, string $apiSecret): void {
-    $tokenInfo = $this->cloudApiClientService->getClient()->request('get', "/account/tokens/$apiKey");
+    $account = new Account($this->cloudApiClientService->getClient());
+    $accountInfo = $account->get();
     $keys = $this->datastoreCloud->get('keys');
     $keys[$apiKey] = [
-      'label' => $tokenInfo->label,
+      'label' => $accountInfo->mail,
       'secret' => $apiSecret,
       'uuid' => $apiKey,
     ];

--- a/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
@@ -7,7 +7,6 @@ namespace Acquia\Cli\Tests\Commands\Acsf;
 use Acquia\Cli\AcsfApi\AcsfClient;
 use Acquia\Cli\AcsfApi\AcsfClientService;
 use Acquia\Cli\AcsfApi\AcsfCredentials;
-use Acquia\Cli\CloudApi\ClientService;
 use Acquia\Cli\Command\Acsf\AcsfApiBaseCommand;
 use Acquia\Cli\Command\Acsf\AcsfCommandFactory;
 use Acquia\Cli\Command\CommandBase;
@@ -32,7 +31,7 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
   protected function createCommand(): CommandBase {
     $this->createMockCloudConfigFile($this->getAcsfCredentialsFileContents());
     $this->cloudCredentials = new AcsfCredentials($this->datastoreCloud);
-    $this->setClientProphecies(AcsfClientService::class);
+    $this->setClientProphecies();
     return $this->injectCommand(AcsfApiBaseCommand::class);
   }
 
@@ -119,11 +118,11 @@ class AcsfApiCommandTest extends AcsfCommandTestBase {
     $contents = json_decode($output, TRUE);
   }
 
-  protected function setClientProphecies(?string $clientServiceClass = ClientService::class): void {
+  protected function setClientProphecies(): void {
     $this->clientProphecy = $this->prophet->prophesize(AcsfClient::class);
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN']);
     $this->clientProphecy->addOption('debug', Argument::type(OutputInterface::class));
-    $this->clientServiceProphecy = $this->prophet->prophesize($clientServiceClass);
+    $this->clientServiceProphecy = $this->prophet->prophesize(AcsfClientService::class);
     $this->clientServiceProphecy->getClient()
       ->willReturn($this->clientProphecy->reveal());
     $this->clientServiceProphecy->isMachineAuthenticated()

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -731,11 +731,11 @@ abstract class TestBase extends TestCase {
     return $guzzleClient;
   }
 
-  protected function setClientProphecies(?string $clientServiceClass = ClientService::class): void {
+  protected function setClientProphecies(): void {
     $this->clientProphecy = $this->prophet->prophesize(Client::class);
     $this->clientProphecy->addOption('headers', ['User-Agent' => 'acli/UNKNOWN']);
     $this->clientProphecy->addOption('debug', Argument::type(OutputInterface::class));
-    $this->clientServiceProphecy = $this->prophet->prophesize($clientServiceClass);
+    $this->clientServiceProphecy = $this->prophet->prophesize(ClientService::class);
     $this->clientServiceProphecy->getClient()
       ->willReturn($this->clientProphecy->reveal());
     $this->clientServiceProphecy->isMachineAuthenticated()


### PR DESCRIPTION
Fix #1635 