### PR TITLE
Allow other descriptor formats to be used to render docs.

### DIFF
--- a/src/Command/Self/MakeDocsCommand.php
+++ b/src/Command/Self/MakeDocsCommand.php
@@ -6,6 +6,7 @@ namespace Acquia\Cli\Command\Self;
 
 use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
+use Composer\Console\Input\InputOption;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\DescriptorHelper;
@@ -16,11 +17,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'self:make-docs', description: 'Generate documentation for all ACLI commands', hidden: TRUE)]
 final class MakeDocsCommand extends CommandBase {
 
+  protected function configure(): void {
+    $this->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'The format to describe the docs in.', 'rst');
+  }
+
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $helper = new DescriptorHelper();
 
     $helper->describe($output, $this->getApplication(), [
-      'format' => 'rst',
+      'format' => $input->getOption('format'),
     ]);
 
     return Command::SUCCESS;

--- a/src/Command/Self/MakeDocsCommand.php
+++ b/src/Command/Self/MakeDocsCommand.php
@@ -6,11 +6,11 @@ namespace Acquia\Cli\Command\Self;
 
 use Acquia\Cli\Attribute\RequireAuth;
 use Acquia\Cli\Command\CommandBase;
-use Composer\Console\Input\InputOption;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]


### PR DESCRIPTION
**Motivation**
Opens up options to render docs in other formats while maintaining current approach.

**Proposed changes**
Add an option for format.
