### PR TITLE
CLI-1245: Use REMOTEIDE_LABEL to bypass API call

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -25,7 +25,6 @@ use AcquiaCloudApi\Connector\Connector;
 use AcquiaCloudApi\Endpoints\Account;
 use AcquiaCloudApi\Endpoints\Applications;
 use AcquiaCloudApi\Endpoints\Environments;
-use AcquiaCloudApi\Endpoints\Ides;
 use AcquiaCloudApi\Endpoints\Notifications;
 use AcquiaCloudApi\Endpoints\Organizations;
 use AcquiaCloudApi\Endpoints\Subscriptions;
@@ -790,6 +789,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return getenv('REMOTEIDE_UUID');
   }
 
+  public static function getThisCloudIdeLabel(): false|string {
+    return getenv('REMOTEIDE_LABEL');
+  }
+
   protected function getCloudApplication(string $applicationUuid): ApplicationResponse {
     $applicationsResource = new Applications($this->cloudApiClientService->getClient());
     return $applicationsResource->get($applicationUuid);
@@ -908,9 +911,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
   protected function findIdeSshKeyOnCloud(string $ideUuid): ?stdClass {
     $acquiaCloudClient = $this->cloudApiClientService->getClient();
     $cloudKeys = $acquiaCloudClient->request('get', '/account/ssh-keys');
-    $idesResource = new Ides($acquiaCloudClient);
-    $ide = $idesResource->get($ideUuid);
-    $sshKeyLabel = SshKeyCommandBase::getIdeSshKeyLabel($ide);
+    $sshKeyLabel = SshKeyCommandBase::getIdeSshKeyLabel();
     foreach ($cloudKeys as $cloudKey) {
       if ($cloudKey->label === $sshKeyLabel) {
         return $cloudKey;

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -785,11 +785,11 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
    *
    * This command assumes it is being run inside a Cloud IDE.
    */
-  public static function getThisCloudIdeUuid(): false|string {
+  protected static function getThisCloudIdeUuid(): false|string {
     return getenv('REMOTEIDE_UUID');
   }
 
-  public static function getThisCloudIdeLabel(): false|string {
+  protected static function getThisCloudIdeLabel(): false|string {
     return getenv('REMOTEIDE_LABEL');
   }
 

--- a/src/Command/Ide/Wizard/IdeWizardCommandBase.php
+++ b/src/Command/Ide/Wizard/IdeWizardCommandBase.php
@@ -6,7 +6,6 @@ namespace Acquia\Cli\Command\Ide\Wizard;
 
 use Acquia\Cli\Command\WizardCommandBase;
 use Acquia\Cli\Helpers\SshCommandTrait;
-use AcquiaCloudApi\Endpoints\Ides;
 use AcquiaCloudApi\Response\IdeResponse;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -25,12 +24,8 @@ abstract class IdeWizardCommandBase extends WizardCommandBase {
   protected function initialize(InputInterface $input, OutputInterface $output): void {
     parent::initialize($input, $output);
 
-    $this->ideUuid = $this::getThisCloudIdeUuid();
-    $this->setSshKeyFilepath(self::getSshKeyFilename($this->ideUuid));
+    $this->setSshKeyFilepath(self::getSshKeyFilename($this::getThisCloudIdeUuid()));
     $this->passphraseFilepath = $this->localMachineHelper->getLocalFilepath('~/.passphrase');
-    $acquiaCloudClient = $this->cloudApiClientService->getClient();
-    $idesResource = new Ides($acquiaCloudClient);
-    $this->ide = $idesResource->get($this->ideUuid);
   }
 
   public static function getSshKeyFilename(mixed $ideUuid): string {
@@ -42,7 +37,7 @@ abstract class IdeWizardCommandBase extends WizardCommandBase {
   }
 
   protected function getSshKeyLabel(): string {
-    return $this::getIdeSshKeyLabel($this->ide);
+    return $this::getIdeSshKeyLabel();
   }
 
   protected function deleteThisSshKeyFromCloud(mixed $output): void {

--- a/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
+++ b/src/Command/Ide/Wizard/IdeWizardCreateSshKeyCommand.php
@@ -72,7 +72,6 @@ final class IdeWizardCreateSshKeyCommand extends IdeWizardCommandBase {
       // the local key, delete remote key!
       $this->deleteThisSshKeyFromCloud($output);
       $publicKey = $this->localMachineHelper->readFile($this->publicSshKeyFilepath);
-      $chosenLocalKey = basename($this->publicSshKeyFilepath);
       $this->uploadSshKey($this->getSshKeyLabel(), $publicKey);
 
       $checklist->completePreviousItem();

--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -10,7 +10,6 @@ use Acquia\Cli\Helpers\SshCommandTrait;
 use Acquia\Cli\Output\Spinner\Spinner;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Endpoints\SshKeys;
-use AcquiaCloudApi\Response\IdeResponse;
 use React\EventLoop\Loop;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -40,8 +39,8 @@ abstract class SshKeyCommandBase extends CommandBase {
     $this->publicSshKeyFilepath = $this->privateSshKeyFilepath . '.pub';
   }
 
-  public static function getIdeSshKeyLabel(IdeResponse $ide): string {
-    return self::normalizeSshKeyLabel('IDE_' . $ide->label . '_' . $ide->uuid);
+  public static function getIdeSshKeyLabel(): string {
+    return self::normalizeSshKeyLabel('IDE_' . self::getThisCloudIdeLabel() . '_' . self::getThisCloudIdeUuid());
   }
 
   public static function normalizeSshKeyLabel(?string $label): string|null {

--- a/tests/phpunit/src/Commands/Ide/IdeDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeDeleteCommandTest.php
@@ -8,7 +8,6 @@ use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ide\IdeDeleteCommand;
 use Acquia\Cli\Command\Ssh\SshKeyDeleteCommand;
 use Acquia\Cli\Tests\CommandTestBase;
-use AcquiaCloudApi\Response\IdeResponse;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -39,9 +38,7 @@ class IdeDeleteCommandTest extends CommandTestBase {
     $this->mockRequest('getApplicationByUuid', $applications[0]->uuid);
     $ides = $this->mockRequest('getApplicationIdes', $applications[0]->uuid);
     $this->mockRequest('deleteIde', $ides[0]->uuid, NULL, 'De-provisioning IDE');
-    $ideGetResponse = $this->mockRequest('getIde', $ides[0]->uuid);
-    $ide = new IdeResponse((object) $ideGetResponse);
-    $sshKeyGetResponse = $this->mockListSshKeysRequestWithIdeKey($ide);
+    $sshKeyGetResponse = $this->mockListSshKeysRequestWithIdeKey();
 
     $this->mockDeleteSshKeyRequest($sshKeyGetResponse->{'_embedded'}->items[0]->uuid);
 

--- a/tests/phpunit/src/Commands/Ide/IdeHelper.php
+++ b/tests/phpunit/src/Commands/Ide/IdeHelper.php
@@ -25,6 +25,7 @@ class IdeHelper {
     return [
       'ACQUIA_USER_UUID' => '4acf8956-45df-3cf4-5106-065b62cf1ac8',
       'AH_SITE_ENVIRONMENT' => 'IDE',
+      'REMOTEIDE_LABEL' => 'ExampleIDE',
       'REMOTEIDE_UUID' => self::$remoteIdeUuid,
     ];
   }

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardCreateSshKeyCommandTest.php
@@ -7,7 +7,6 @@ namespace Acquia\Cli\Tests\Commands\Ide\Wizard;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ide\Wizard\IdeWizardCreateSshKeyCommand;
 use Acquia\Cli\Tests\Commands\Ide\IdeHelper;
-use AcquiaCloudApi\Response\IdeResponse;
 
 /**
  * @property \Acquia\Cli\Command\Ide\Wizard\IdeWizardCreateSshKeyCommand $command
@@ -15,15 +14,12 @@ use AcquiaCloudApi\Response\IdeResponse;
  */
 class IdeWizardCreateSshKeyCommandTest extends IdeWizardTestBase {
 
-  protected IdeResponse $ide;
-
   public function setUp(): void {
     parent::setUp();
     $applicationResponse = $this->mockApplicationRequest();
     $this->mockListSshKeysRequest();
     $this->mockRequest('getAccount');
     $this->mockPermissionsRequest($applicationResponse);
-    $this->ide = $this->mockIdeRequest();
     $this->sshKeyFileName = IdeWizardCreateSshKeyCommand::getSshKeyFilename(IdeHelper::$remoteIdeUuid);
   }
 
@@ -32,12 +28,6 @@ class IdeWizardCreateSshKeyCommandTest extends IdeWizardTestBase {
    */
   protected function createCommand(): CommandBase {
     return $this->injectCommand(IdeWizardCreateSshKeyCommand::class);
-  }
-
-  protected function mockIdeRequest(): IdeResponse {
-    $ideResponse = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
-    $this->clientProphecy->request('get', '/ides/' . IdeHelper::$remoteIdeUuid)->willReturn($ideResponse)->shouldBeCalled();
-    return new IdeResponse($ideResponse);
   }
 
   public function testCreate(): void {

--- a/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardDeleteSshKeyCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/Wizard/IdeWizardDeleteSshKeyCommandTest.php
@@ -7,7 +7,6 @@ namespace Acquia\Cli\Tests\Commands\Ide\Wizard;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ide\Wizard\IdeWizardDeleteSshKeyCommand;
 use Acquia\Cli\Tests\Commands\Ide\IdeHelper;
-use AcquiaCloudApi\Response\IdeResponse;
 
 /**
  * @property \Acquia\Cli\Command\Ide\Wizard\IdeWizardCreateSshKeyCommand $command
@@ -15,11 +14,7 @@ use AcquiaCloudApi\Response\IdeResponse;
 class IdeWizardDeleteSshKeyCommandTest extends IdeWizardTestBase {
 
   public function testDelete(): void {
-    // Request for IDE data.
-    $ideResponse = $this->getMockResponseFromSpec('/ides/{ideUuid}', 'get', '200');
-    $this->clientProphecy->request('get', '/ides/' . IdeHelper::$remoteIdeUuid)->willReturn($ideResponse)->shouldBeCalled();
-    $ide = new IdeResponse((object) $ideResponse);
-    $mockBody = $this->mockListSshKeysRequestWithIdeKey($ide);
+    $mockBody = $this->mockListSshKeysRequestWithIdeKey();
 
     $this->mockDeleteSshKeyRequest($mockBody->{'_embedded'}->items[0]->uuid);
 
@@ -29,7 +24,7 @@ class IdeWizardDeleteSshKeyCommandTest extends IdeWizardTestBase {
     $this->fs->dumpFile($this->sshDir . '/' . $sshKeyFilename . '.pub', $mockBody->{'_embedded'}->items[0]->public_key);
 
     // Run it!
-    $this->executeCommand([]);
+    $this->executeCommand();
 
     $this->assertFileDoesNotExist($this->sshDir . '/' . $sshKeyFilename);
   }

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -20,7 +20,6 @@ use Acquia\Cli\Helpers\SshHelper;
 use Acquia\Cli\Helpers\TelemetryHelper;
 use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Exception\ApiErrorException;
-use AcquiaCloudApi\Response\IdeResponse;
 use AcquiaLogstream\LogstreamManager;
 use Closure;
 use GuzzleHttp\Psr7\Response;
@@ -591,9 +590,9 @@ abstract class TestBase extends TestCase {
     return $this->mockRequest('getAccountSshKeys');
   }
 
-  protected function mockListSshKeysRequestWithIdeKey(IdeResponse $ide): object {
+  protected function mockListSshKeysRequestWithIdeKey(): object {
     $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
-    $mockBody->{'_embedded'}->items[0]->label = SshKeyCommandBase::getIdeSshKeyLabel($ide);
+    $mockBody->{'_embedded'}->items[0]->label = SshKeyCommandBase::getIdeSshKeyLabel();
     $this->clientProphecy->request('get', '/account/ssh-keys')
       ->willReturn($mockBody->{'_embedded'}->items)
       ->shouldBeCalled();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
This API call is unnecessary. More importantly, it makes QA of IDE changes difficult because it's the only API call to the IDE endpoint associated with IDE creation.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Use REMOTEIDE_LABEL instead of calling the API.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `ide:wizard` in a new IDE, see that an SSH key is created successfully with the same label as before.
