### PR TITLE
CLI-1257: pull:db fails with too many tables

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -382,7 +382,7 @@ abstract class PullCommandBase extends CommandBase {
     $tables = $this->listTablesQuoted($process->getOutput());
     if ($tables) {
       $sql = 'DROP TABLE ' . implode(', ', $tables);
-      $tempnam = $this->localMachineHelper->getFilesystem()->tempnam(sys_get_temp_dir(), 'acli_drop_table', 'sql');
+      $tempnam = $this->localMachineHelper->getFilesystem()->tempnam(sys_get_temp_dir(), 'acli_drop_table_', '.sql');
       $this->localMachineHelper->getFilesystem()->dumpFile($tempnam, $sql);
       $command = [
         'mysql',

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -382,6 +382,8 @@ abstract class PullCommandBase extends CommandBase {
     $tables = $this->listTablesQuoted($process->getOutput());
     if ($tables) {
       $sql = 'DROP TABLE ' . implode(', ', $tables);
+      $tempnam = $this->localMachineHelper->getFilesystem()->tempnam(sys_get_temp_dir(), 'acli_drop_table', 'sql');
+      $this->localMachineHelper->getFilesystem()->dumpFile($tempnam, $sql);
       $command = [
         'mysql',
         '--host',
@@ -390,7 +392,7 @@ abstract class PullCommandBase extends CommandBase {
         $dbUser,
         $dbName,
         '-e',
-        $sql,
+        'source ' . $tempnam,
       ];
       $process = $this->localMachineHelper->execute($command, $outputCallback, NULL, FALSE, NULL, ['MYSQL_PWD' => $dbPassword]);
       if (!$process->isSuccessful()) {


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
