### PR TITLE
CLI-1272: remote:drush fails with realm alias

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -5,6 +5,7 @@ namespace PHPSTORM_META {
   use AcquiaCloudApi\Response\ApplicationResponse;
   use AcquiaCloudApi\Response\ApplicationsResponse;
   use AcquiaCloudApi\Response\DatabasesResponse;
+  use AcquiaCloudApi\Response\EnvironmentResponse;
   use AcquiaCloudApi\Response\EnvironmentsResponse;
 
   override(\Acquia\Cli\Tests\TestBase::mockRequest(), map([
@@ -12,7 +13,8 @@ namespace PHPSTORM_META {
     'getApplications' => ApplicationsResponse::class,
     'getApplicationByUuid' => ApplicationResponse::class,
     'getApplicationEnvironments' => EnvironmentsResponse::class,
-    'getEnvironmentsDatabases' => DatabasesResponse::class
+    'getEnvironmentsDatabases' => DatabasesResponse::class,
+    'getEnvironment' => EnvironmentResponse::class
   ]));
 
 }

--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -47,14 +47,14 @@ final class LogTailCommand extends CommandBase {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $environmentId = $this->determineCloudEnvironment();
+    $environment = $this->determineEnvironment($input, $output);
     $acquiaCloudClient = $this->cloudApiClientService->getClient();
     $logs = $this->promptChooseLogs();
     $logTypes = array_map(static function (mixed $log) {
       return $log['type'];
     }, $logs);
     $logsResource = new Logs($acquiaCloudClient);
-    $stream = $logsResource->stream($environmentId);
+    $stream = $logsResource->stream($environment->uuid);
     $this->logstreamManager->setParams($stream->logstream->params);
     $this->logstreamManager->setColourise(TRUE);
     $this->logstreamManager->setLogTypeFilter($logTypes);

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'codestudio:wizard', description: 'Create and/or configure a new Code Studio project for a given Acquia Cloud application', aliases: ['cs:wizard'])]
+#[AsCommand(name: 'codestudio:wizard', description: 'Create and/or configure a new Code Studio project for a given Cloud Platform application', aliases: ['cs:wizard'])]
 final class CodeStudioWizardCommand extends WizardCommandBase {
 
   use CodeStudioCommandTrait;

--- a/src/Command/Env/EnvCertCreateCommand.php
+++ b/src/Command/Env/EnvCertCreateCommand.php
@@ -31,7 +31,7 @@ final class EnvCertCreateCommand extends CommandBase {
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $acquiaCloudClient = $this->cloudApiClientService->getClient();
-    $envUuid = $this->determineCloudEnvironment();
+    $environment = $this->determineEnvironment($input, $output);
     $certificate = $input->getArgument('certificate');
     $privateKey = $input->getArgument('private-key');
     $label = $this->determineOption('label');
@@ -42,7 +42,7 @@ final class EnvCertCreateCommand extends CommandBase {
 
     $sslCertificates = new SslCertificates($acquiaCloudClient);
     $response = $sslCertificates->create(
-      $envUuid,
+      $environment->uuid,
       $label,
       $this->localMachineHelper->readFile($certificate),
       $this->localMachineHelper->readFile($privateKey),

--- a/src/Command/Env/EnvCopyCronCommand.php
+++ b/src/Command/Env/EnvCopyCronCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[RequireAuth]
-#[AsCommand(name: 'env:cron-copy', description: 'Copy all cron tasks from one Acquia Cloud Platform environment to another')]
+#[AsCommand(name: 'env:cron-copy', description: 'Copy all cron tasks from one Cloud Platform environment to another')]
 final class EnvCopyCronCommand extends CommandBase {
 
   protected function configure(): void {

--- a/src/Command/Push/PushDatabaseCommand.php
+++ b/src/Command/Push/PushDatabaseCommand.php
@@ -60,8 +60,8 @@ final class PushDatabaseCommand extends PushCommandBase {
     string $localFilepath,
     callable $outputCallback
   ): string {
-    $sitegroup = self::getSiteGroupFromSshUrl($environment->sshUrl);
-    $remoteFilepath = "/mnt/tmp/{$sitegroup}.{$environment->name}/" . basename($localFilepath);
+    $envAlias = self::getEnvironmentAlias($environment);
+    $remoteFilepath = "/mnt/tmp/$envAlias/" . basename($localFilepath);
     $this->logger->debug("Uploading database dump to $remoteFilepath on remote machine");
     $this->localMachineHelper->checkRequiredBinariesExist(['rsync']);
     $command = [

--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -14,13 +14,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  * A command to proxy Drush commands on an environment using SSH.
  */
 #[RequireAuth]
-#[AsCommand(name: 'remote:drush', description: 'Run a Drush command remotely on a application\'s environment', aliases: ['drush', 'dr'])]
+#[AsCommand(name: 'remote:drush', description: 'Run a Drush command remotely on a Cloud Platform environment', aliases: ['drush', 'dr'])]
 final class DrushCommand extends SshBaseCommand {
 
   protected function configure(): void {
     $this
       ->setHelp('<fg=black;bg=cyan>Pay close attention to the argument syntax! Note the usage of <options=bold;bg=cyan>--</> to separate the drush command arguments and options.</>')
-      ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
+      ->acceptEnvironmentId()
       ->addArgument('drush_command', InputArgument::IS_ARRAY, 'Drush command')
       ->addUsage('<app>.<env> -- <command>')
       ->addUsage('myapp.dev -- uli 1')
@@ -28,14 +28,11 @@ final class DrushCommand extends SshBaseCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): ?int {
-    $alias = $input->getArgument('alias');
-    $alias = $this->normalizeAlias($alias);
-    $alias = self::validateEnvironmentAlias($alias);
-    $environment = $this->getEnvironmentFromAliasArg($alias);
-
+    $environment = $this->determineEnvironment($input, $output);
+    $alias = self::getEnvironmentAlias($environment);
     $acliArguments = $input->getArguments();
     $drushCommandArguments = [
-      "cd /var/www/html/{$alias}/docroot; ",
+      "cd /var/www/html/$alias/docroot; ",
       'drush',
       implode(' ', (array) $acliArguments['drush_command']),
     ];

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -104,17 +104,6 @@ class ExceptionApplicationTest extends ApplicationTestBase {
   /**
    * @group serial
    */
-  public function testMissingEnvironmentUuid(): void {
-    $this->setInput([
-      'command' => 'log:tail',
-    ]);
-    $buffer = $this->runApp();
-    self::assertStringContainsString('can also be a site alias.', $buffer);
-  }
-
-  /**
-   * @group serial
-   */
   public function testInvalidEnvironmentUuid(): void {
     $this->mockRequest('getAccount');
     $this->mockRequest('getApplications');

--- a/tests/phpunit/src/Application/KernelTest.php
+++ b/tests/phpunit/src/Application/KernelTest.php
@@ -68,14 +68,14 @@ EOD;
   auth:logout              [logout] Remove Cloud Platform API credentials
  codestudio
   codestudio:php-version   Change the PHP version in Code Studio
-  codestudio:wizard        [cs:wizard] Create and/or configure a new Code Studio project for a given Acquia Cloud application
+  codestudio:wizard        [cs:wizard] Create and/or configure a new Code Studio project for a given Cloud Platform application
  email
   email:configure          [ec] Configure Platform email for one or more applications
   email:info               Print information related to Platform Email set up in a subscription.
  env
   env:certificate-create   Install an SSL certificate.
   env:create               Create a new Continuous Delivery Environment (CDE)
-  env:cron-copy            Copy all cron tasks from one Acquia Cloud Platform environment to another
+  env:cron-copy            Copy all cron tasks from one Cloud Platform environment to another
   env:delete               Delete a Continuous Delivery Environment (CDE)
   env:mirror               Makes one environment identical to another in terms of code, database, files, and configuration.
  ide
@@ -98,7 +98,7 @@ EOD;
  remote
   remote:aliases:download  Download Drush aliases for the Cloud Platform
   remote:aliases:list      [aliases|sa] List all aliases for the Cloud Platform environments
-  remote:drush             [drush|dr] Run a Drush command remotely on a application's environment
+  remote:drush             [drush|dr] Run a Drush command remotely on a Cloud Platform environment
   remote:ssh               [ssh] Use SSH to open a shell or run a command in a Cloud Platform environment
  self
   self:clear-caches        [cc|cr] Clears local Acquia CLI caches

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -265,7 +265,7 @@ abstract class CommandTestBase extends TestBase {
     $acsfMultisiteFetchProcess->getOutput()->willReturn($multisiteConfig)->shouldBeCalled();
     $sshHelper->executeCommand(
       Argument::type('object'),
-      ['cat', '/var/www/site-php/profserv2.dev/multisite-config.json'],
+      ['cat', '/var/www/site-php/profserv2.01dev/multisite-config.json'],
       FALSE
     )->willReturn($acsfMultisiteFetchProcess->reveal())->shouldBeCalled();
     return json_decode($multisiteConfig, TRUE);
@@ -274,7 +274,8 @@ abstract class CommandTestBase extends TestBase {
   protected function mockGetCloudSites(mixed $sshHelper, mixed $environment): void {
     $cloudMultisiteFetchProcess = $this->mockProcess();
     $cloudMultisiteFetchProcess->getOutput()->willReturn("\nbar\ndefault\nfoo\n")->shouldBeCalled();
-    $sitegroup = CommandBase::getSiteGroupFromSshUrl($environment->ssh_url);
+    $parts = explode('.', $environment->ssh_url);
+    $sitegroup = reset($parts);
     $sshHelper->executeCommand(
       Argument::type('object'),
       ['ls', "/mnt/files/$sitegroup.{$environment->name}/sites"],

--- a/tests/phpunit/src/Commands/App/LogTailCommandTest.php
+++ b/tests/phpunit/src/Commands/App/LogTailCommandTest.php
@@ -62,6 +62,7 @@ class LogTailCommandTest extends CommandTestBase {
   }
 
   public function testLogTailCommandWithEnvArg(): void {
+    $this->mockRequest('getEnvironment', '24-a47ac10b-58cc-4372-a567-0e02b2c3d470');
     $this->mockLogStreamRequest();
     $this->executeCommand(
       ['environmentId' => '24-a47ac10b-58cc-4372-a567-0e02b2c3d470'],

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -413,7 +413,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase {
   }
 
   protected function mockDownloadMySqlDump(ObjectProphecy $localMachineHelper, mixed $success): void {
-    $process = $this->mockProcess($success);
+    $this->mockProcess($success);
     $localMachineHelper->writeFile(
       Argument::containingString("dev-profserv2-profserv201dev-something.sql.gz"),
       'backupfilecontents'

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -42,7 +42,7 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $this->mockGetAcsfSites($sshHelper);
     $localMachineHelper = $this->mockLocalMachineHelper();
     $this->mockGetFilesystem($localMachineHelper);
-    $this->mockExecuteRsync($localMachineHelper, $selectedEnvironment, '/mnt/files/profserv2.dev/sites/g/files/jxr5000596dev/files/', $this->projectDir . '/docroot/sites/jxr5000596dev/files');
+    $this->mockExecuteRsync($localMachineHelper, $selectedEnvironment, '/mnt/files/profserv2.01dev/sites/g/files/jxr5000596dev/files/', $this->projectDir . '/docroot/sites/jxr5000596dev/files');
 
     $this->command->sshHelper = $sshHelper->reveal();
 
@@ -78,7 +78,8 @@ class PullFilesCommandTest extends PullCommandTestBase {
     $this->mockGetCloudSites($sshHelper, $selectedEnvironment);
     $localMachineHelper = $this->mockLocalMachineHelper();
     $this->mockGetFilesystem($localMachineHelper);
-    $sitegroup = CommandBase::getSiteGroupFromSshUrl($selectedEnvironment->ssh_url);
+    $parts = explode('.', $selectedEnvironment->ssh_url);
+    $sitegroup = reset($parts);
     $this->mockExecuteRsync($localMachineHelper, $selectedEnvironment, '/mnt/files/' . $sitegroup . '.' . $selectedEnvironment->name . '/sites/bar/files/', $this->projectDir . '/docroot/sites/bar/files');
 
     $this->command->sshHelper = $sshHelper->reveal();

--- a/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
@@ -85,7 +85,7 @@ class PushDatabaseCommandTest extends CommandTestBase {
       '-tDvPhe',
       'ssh -o StrictHostKeyChecking=no',
       sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz',
-      'profserv2.01dev@profserv201dev.ssh.enterprise-g1.acquia-sites.com:/mnt/tmp/profserv2.dev/acli-mysql-dump-drupal.sql.gz',
+      'profserv2.01dev@profserv201dev.ssh.enterprise-g1.acquia-sites.com:/mnt/tmp/profserv2.01dev/acli-mysql-dump-drupal.sql.gz',
     ];
     $localMachineHelper->execute($command, Argument::type('callable'), NULL, TRUE, NULL)
       ->willReturn($process->reveal())
@@ -99,7 +99,7 @@ class PushDatabaseCommandTest extends CommandTestBase {
   ): void {
     $sshHelper->executeCommand(
       new EnvironmentResponse($environmentsResponse),
-      ['pv /mnt/tmp/profserv2.dev/acli-mysql-dump-drupal.sql.gz --bytes --rate | gunzip | MYSQL_PWD=password mysql --host=fsdb-74.enterprise-g1.hosting.acquia.com.enterprise-g1.hosting.acquia.com --user=s164 profserv2db14390'],
+      ['pv /mnt/tmp/profserv2.01dev/acli-mysql-dump-drupal.sql.gz --bytes --rate | gunzip | MYSQL_PWD=password mysql --host=fsdb-74.enterprise-g1.hosting.acquia.com.enterprise-g1.hosting.acquia.com --user=s164 profserv2db14390'],
       TRUE,
       NULL
     )

--- a/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
@@ -134,7 +134,8 @@ class PushFilesCommandTest extends CommandTestBase {
     mixed $environment
   ): void {
     $localMachineHelper->checkRequiredBinariesExist(['rsync'])->shouldBeCalled();
-    $sitegroup = CommandBase::getSiteGroupFromSshUrl($environment->ssh_url);
+    $parts = explode('.', $environment->ssh_url);
+    $sitegroup = reset($parts);
     $command = [
       'rsync',
       '-avPhze',
@@ -158,7 +159,7 @@ class PushFilesCommandTest extends CommandTestBase {
       '-avPhze',
       'ssh -o StrictHostKeyChecking=no',
       $this->projectDir . '/docroot/sites/' . $site . '/files/',
-      'profserv2.01dev@profserv201dev.ssh.enterprise-g1.acquia-sites.com:/mnt/files/profserv2.dev/sites/g/files/' . $site . '/files',
+      'profserv2.01dev@profserv201dev.ssh.enterprise-g1.acquia-sites.com:/mnt/files/profserv2.01dev/sites/g/files/' . $site . '/files',
     ];
     $localMachineHelper->execute($command, Argument::type('callable'), NULL, TRUE)
       ->willReturn($process->reveal())

--- a/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
@@ -6,7 +6,6 @@ namespace Acquia\Cli\Tests\Commands\Remote;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Remote\DrushCommand;
-use Acquia\Cli\Command\Self\ClearCacheCommand;
 use Acquia\Cli\Helpers\SshHelper;
 use Prophecy\Argument;
 
@@ -27,14 +26,12 @@ class DrushCommandTest extends SshCommandTestBase {
       [
         [
           '-vvv' => '',
-          'alias' => 'devcloud2.dev',
           'drush_command' => 'status --fields=db-status',
         ],
       ],
       [
         [
           '-vvv' => '',
-          'alias' => '@devcloud2.dev',
           'drush_command' => 'status --fields=db-status',
         ],
       ],
@@ -47,8 +44,7 @@ class DrushCommandTest extends SshCommandTestBase {
    * @group serial
    */
   public function testRemoteDrushCommand(array $args): void {
-    ClearCacheCommand::clearCaches();
-    $this->mockForGetEnvironmentFromAliasArg();
+    $this->mockGetEnvironment();
     [$process, $localMachineHelper] = $this->mockForExecuteCommand();
     $localMachineHelper->checkRequiredBinariesExist(['ssh'])->shouldBeCalled();
     $sshCommand = [
@@ -58,7 +54,7 @@ class DrushCommandTest extends SshCommandTestBase {
       '-o StrictHostKeyChecking=no',
       '-o AddressFamily inet',
       '-o LogLevel=ERROR',
-      'cd /var/www/html/devcloud2.dev/docroot; ',
+      'cd /var/www/html/site.dev/docroot; ',
       'drush',
       'status --fields=db-status',
     ];
@@ -68,7 +64,7 @@ class DrushCommandTest extends SshCommandTestBase {
       ->shouldBeCalled();
 
     $this->command->sshHelper = new SshHelper($this->output, $localMachineHelper->reveal(), $this->logger);
-    $this->executeCommand($args);
+    $this->executeCommand($args, self::inputChooseEnvironment());
 
     // Assert.
 


### PR DESCRIPTION
I let refactoring get the best of me on this one, but it's for the better... not only does this allow several commands to be run with the standard environment prompt, I think this actually fixes a similar bug on ACSF environments with numeric prefixes (01dev). I confirmed that the expected directories in that case are `/var/www/site-php/profserv2.01dev`, not `/var/www/site-php/profserv2.dev` as our code and tests previously expected.