### PR TITLE
CLI-1263: [ide:share] remove unnecessary API call

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -965,6 +965,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
     return getenv('REMOTEIDE_LABEL');
   }
 
+  protected static function getThisCloudIdeWebUrl(): false|string {
+    return getenv('REMOTEIDE_WEB_HOST');
+  }
+
   protected function getCloudApplication(string $applicationUuid): ApplicationResponse {
     $applicationsResource = new Applications($this->cloudApiClientService->getClient());
     return $applicationsResource->get($applicationUuid);

--- a/src/Command/Ide/IdeShareCommand.php
+++ b/src/Command/Ide/IdeShareCommand.php
@@ -6,7 +6,6 @@ namespace Acquia\Cli\Command\Ide;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
-use AcquiaCloudApi\Endpoints\Ides;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -36,12 +35,10 @@ final class IdeShareCommand extends CommandBase {
     }
 
     $shareUuid = $this->localMachineHelper->readFile($this->getShareCodeFilepaths()[0]);
-    $acquiaCloudClient = $this->cloudApiClientService->getClient();
-    $idesResource = new Ides($acquiaCloudClient);
-    $ide = $idesResource->get($this::getThisCloudIdeUuid());
+    $webUrl = self::getThisCloudIdeWebUrl();
 
     $this->output->writeln('');
-    $this->output->writeln("<comment>Your IDE Share URL:</comment> <href={$ide->links->web->href}>{$ide->links->web->href}?share=$shareUuid</>");
+    $this->output->writeln("<comment>Your IDE Share URL:</comment> <href=https://$webUrl>https://$webUrl?share=$shareUuid</>");
 
     return Command::SUCCESS;
   }

--- a/tests/phpunit/src/Commands/Ide/IdeShareCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeShareCommandTest.php
@@ -7,7 +7,6 @@ namespace Acquia\Cli\Tests\Commands\Ide;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ide\IdeShareCommand;
 use Acquia\Cli\Tests\CommandTestBase;
-use AcquiaCloudApi\Response\IdeResponse;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -41,24 +40,14 @@ class IdeShareCommandTest extends CommandTestBase {
   }
 
   public function testIdeShareCommand(): void {
-    $ideGetResponse = $this->mockRequest('getIde', IdeHelper::$remoteIdeUuid);
-    $ide = new IdeResponse((object) $ideGetResponse);
     $this->executeCommand();
-
-    // Assert.
-
     $output = $this->getDisplay();
     $this->assertStringContainsString('Your IDE Share URL: ', $output);
     $this->assertStringContainsString($this->shareCode, $output);
   }
 
   public function testIdeShareRegenerateCommand(): void {
-    $ideGetResponse = $this->mockRequest('getIde', IdeHelper::$remoteIdeUuid);
-    $ide = new IdeResponse((object) $ideGetResponse);
-    $this->executeCommand(['--regenerate' => TRUE], []);
-
-    // Assert.
-
+    $this->executeCommand(['--regenerate' => TRUE]);
     $output = $this->getDisplay();
     $this->assertStringContainsString('Your IDE Share URL: ', $output);
     $this->assertStringNotContainsString($this->shareCode, $output);


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
This API call is unnecessary and hinders testing, let's simplify it.

**Proposed changes**
Use env var instead.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions in `acli ide:share`
