### PR TITLE
Pass default domain to remote drush command

### DIFF
--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -31,10 +31,16 @@ final class DrushCommand extends SshBaseCommand {
     $environment = $this->determineEnvironment($input, $output);
     $alias = self::getEnvironmentAlias($environment);
     $acliArguments = $input->getArguments();
+    $drushArguments = (array) $acliArguments['drush_command'];
+    // When available, provide the default domain to drush
+    if (!empty($environment->default_domain)) {
+      // Insert at the beginning so a user-supplied --uri arg will override
+      array_unshift($drushArguments, "--uri=http://{$environment->default_domain}");
+    }
     $drushCommandArguments = [
       "cd /var/www/html/$alias/docroot; ",
       'drush',
-      implode(' ', (array) $acliArguments['drush_command']),
+      implode(' ', $drushArguments),
     ];
 
     return $this->sshHelper->executeCommand($environment, $drushCommandArguments)->getExitCode();

--- a/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
@@ -56,7 +56,7 @@ class DrushCommandTest extends SshCommandTestBase {
       '-o LogLevel=ERROR',
       'cd /var/www/html/site.dev/docroot; ',
       'drush',
-      'status --fields=db-status',
+      '--uri=http://sitedev.hosted.acquia-sites.com status --fields=db-status',
     ];
     $localMachineHelper
       ->execute($sshCommand, Argument::type('callable'), NULL, TRUE, NULL)


### PR DESCRIPTION
**Motivation**
As a manager of a dozen applications at Acquia, I want to use `acli remote:drush` to perform routine tasks (especially `uli` login) on multiple remote applications without remembering to type the correct `--uri` every time. Previously with Drupal 7/drush 8/Acquia Cloud API v1 one could use `drush acquia-update` to easily keep local aliases up-to-date, but this is no longer an option.

**Proposed changes**
Since `remote:drush` is already fetching the Acquia environment information behind the scenes for the alias provided, it should pass along the `default_domain` parameter when none is given by the user. Allow the user to continue to provide their own `--uri` parameter if the default isn't sufficient (on a drush command, the last duplicate parameter wins).

**Alternatives considered**
Manually typing the correct `--uri` flag when needed for a drush command like `uli` is redundant and painful.

**Testing steps/example usage**
`acli remote:drush site.dev -- status --fields=uri`

> Before: `http://default`
> After: `http://sitedev.prod.acquia-sites.com`
> 

`acli remote:drush site.dev -- uli`

> Before: `http://default/user/reset/1/.../login`
> After: `http://sitedev.prod.acquia-sites.com/user/reset/1/.../login`
> 

`acli remote:drush site.dev -- uli --uri=https://example.com`

> Before: `https://example.com/user/reset/1/.../login`
> After: `https://example.com/user/reset/1/.../login` (no change; the user override was unaffected)
> 
