### PR TITLE
CLI-1292: Catch Cloud API type errors

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -4,6 +4,8 @@ namespace PHPSTORM_META {
   use AcquiaCloudApi\Response\AccountResponse;
   use AcquiaCloudApi\Response\ApplicationResponse;
   use AcquiaCloudApi\Response\ApplicationsResponse;
+  use AcquiaCloudApi\Response\CronResponse;
+  use AcquiaCloudApi\Response\CronsResponse;
   use AcquiaCloudApi\Response\DatabasesResponse;
   use AcquiaCloudApi\Response\EnvironmentResponse;
   use AcquiaCloudApi\Response\EnvironmentsResponse;
@@ -14,7 +16,9 @@ namespace PHPSTORM_META {
     'getApplicationByUuid' => ApplicationResponse::class,
     'getApplicationEnvironments' => EnvironmentsResponse::class,
     'getEnvironmentsDatabases' => DatabasesResponse::class,
-    'getEnvironment' => EnvironmentResponse::class
+    'getEnvironment' => EnvironmentResponse::class,
+    'getCron' => CronResponse::class,
+    'getCronJobsByEnvironmentId' => CronsResponse::class
   ]));
 
 }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -79,6 +79,10 @@ class ExceptionListener {
       }
     }
 
+    if ($error instanceof \TypeError && str_contains($error->getMessage(), 'AcquiaCloudApi\Response')) {
+      $newErrorMessage = 'Cloud API returned an unexpected data type; this could indicate a problem with your Cloud application.';
+    }
+
     $this->helpMessages[] = "You can find Acquia CLI documentation at https://docs.acquia.com/acquia-cli/";
     $this->writeUpdateHelp($event);
     $this->writeSupportTicketHelp($event);

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -80,7 +80,7 @@ class ExceptionListener {
     }
 
     if ($error instanceof \TypeError && str_contains($error->getMessage(), 'AcquiaCloudApi\Response')) {
-      $newErrorMessage = 'Cloud API returned an unexpected data type; this could indicate a problem with your Cloud application.';
+      $newErrorMessage = 'Cloud Platform API returned an unexpected data type. This is not an issue with Acquia CLI but could indicate a problem with your Cloud Platform application.';
     }
 
     $this->helpMessages[] = "You can find Acquia CLI documentation at https://docs.acquia.com/acquia-cli/";

--- a/tests/phpunit/src/Application/ExceptionApplicationTest.php
+++ b/tests/phpunit/src/Application/ExceptionApplicationTest.php
@@ -93,4 +93,21 @@ class ExceptionApplicationTest extends ApplicationTestBase {
     self::assertStringContainsString('An alias consists of an application name', $buffer);
   }
 
+  /**
+   * @group serial
+   */
+  public function testApiTypeError(): void {
+    $tamper = function ($response): void {
+      $response[0]->server = [];
+    };
+    $this->mockRequest('getCronJobsByEnvironmentId', '24-a47ac10b-58cc-4372-a567-0e02b2c3d470', NULL, NULL, $tamper);
+    $this->setInput([
+      'command' => 'env:cron-copy',
+      'dest_env' => '24-a47ac10b-58cc-4372-a567-0e02b2c3d471',
+      'source_env' => '24-a47ac10b-58cc-4372-a567-0e02b2c3d470',
+    ]);
+    $buffer = $this->runApp();
+    self::assertStringContainsString('Cloud Platform API returned an unexpected data type.', $buffer);
+  }
+
 }


### PR DESCRIPTION
@anavarre your opinion on messaging?

Typically a type error does indicate a problem with the application, i.e. some kind of broken configuration or environment. Sometimes it's a more general problem, which is actually true for CLI-1292. There's nothing wrong with the customer application in CLI-1292; the API will pretty much always return cron information that violates the published spec.