### PR TITLE
CLI-1290: [auth:login] php warning

### DIFF
--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\Auth;
 
 use Acquia\Cli\Command\CommandBase;
+use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Endpoints\Account;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -25,6 +26,9 @@ final class AuthLoginCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $keys = $this->datastoreCloud->get('keys');
     $activeKey = $this->datastoreCloud->get('acli_key');
+    if (is_array($keys) && !array_key_exists($activeKey, $keys)) {
+      throw new AcquiaCliException('Invalid key in Cloud datastore; run acli auth:logout && acli auth:login to fix');
+    }
     if ($activeKey) {
       $activeKeyLabel = $keys[$activeKey]['label'];
       $output->writeln("The following Cloud Platform API key is active: <options=bold>$activeKeyLabel</>");

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -26,6 +26,7 @@ final class AuthLoginCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $keys = $this->datastoreCloud->get('keys');
     $activeKey = $this->datastoreCloud->get('acli_key');
+    // @todo this validation should really be enforced as a schema on the datastore.
     if (is_array($keys) && !array_key_exists($activeKey, $keys)) {
       throw new AcquiaCliException('Invalid key in Cloud datastore; run acli auth:logout && acli auth:login to fix');
     }

--- a/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
@@ -8,6 +8,7 @@ use Acquia\Cli\Command\Auth\AuthLoginCommand;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Config\CloudDataConfig;
 use Acquia\Cli\DataStore\CloudDataStore;
+use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\CommandTestBase;
 use AcquiaCloudApi\Connector\Connector;
 use Generator;
@@ -66,6 +67,18 @@ class AuthLoginCommandTest extends CommandTestBase {
     $this->command = $this->createCommand();
     $this->expectException(ValidatorException::class);
     $this->executeCommand($args, $inputs);
+  }
+
+  public function testAuthLoginInvalidDatastore(): void {
+    $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
+    $this->removeMockCloudConfigFile();
+    $this->createDataStores();
+    $this->datastoreCloud->set('keys', ['key1']);
+    $this->datastoreCloud->set('acli_key', 'key2');
+    $this->command = $this->createCommand();
+    $this->expectException(AcquiaCliException::class);
+    $this->expectExceptionMessage('Invalid key in Cloud datastore; run acli auth:logout && acli auth:login to fix');
+    $this->executeCommand();
   }
 
   protected function assertInteractivePrompts(string $output): void {


### PR DESCRIPTION
I couldn't find any reason in the code for the datastore to be corrupted... presumably someone mucking with cloud_api.conf