### PR TITLE
CLI-1286: [app:task-wait] typeerror for invalid notification uuid

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1757,7 +1757,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface {
         $this->writeCompletedMessage($notification);
       };
     }
-    LoopHelper::getLoopy($this->output, $this->io, $this->logger, $message, $checkNotificationStatus, $success);
+    LoopHelper::getLoopy($this->output, $this->io, $message, $checkNotificationStatus, $success);
     return $notification->status === 'completed';
   }
 

--- a/src/Command/Ide/IdeCreateCommand.php
+++ b/src/Command/Ide/IdeCreateCommand.php
@@ -103,7 +103,7 @@ final class IdeCreateCommand extends IdeCommandBase {
     $checkIdeStatus = function () use (&$ideCreated, $ideUrl) {
       // Ideally we'd set $ideUrl as the Guzzle base_url, but that requires creating a client factory.
       // @see https://stackoverflow.com/questions/28277889/guzzlehttp-client-change-base-url-dynamically
-      $response = $this->httpClient->request('GET', "$ideUrl/health");
+      $response = $this->httpClient->request('GET', "$ideUrl/health", ['http_errors' => FALSE]);
       // Mutating this will result in an infinite loop and timeout.
       // @infection-ignore-all
       if ($response->getStatusCode() === 200) {
@@ -119,7 +119,7 @@ final class IdeCreateCommand extends IdeCommandBase {
       $this->writeIdeLinksToScreen();
     };
     $spinnerMessage = 'Waiting for the IDE to be ready. This usually takes 2 - 15 minutes.';
-    LoopHelper::getLoopy($this->output, $this->io, $this->logger, $spinnerMessage, $checkIdeStatus, $doneCallback);
+    LoopHelper::getLoopy($this->output, $this->io, $spinnerMessage, $checkIdeStatus, $doneCallback);
 
     return Command::SUCCESS;
   }

--- a/src/Helpers/LoopHelper.php
+++ b/src/Helpers/LoopHelper.php
@@ -5,8 +5,6 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Helpers;
 
 use Acquia\Cli\Output\Spinner\Spinner;
-use Exception;
-use Psr\Log\LoggerInterface;
 use React\EventLoop\Loop;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -16,7 +14,7 @@ class LoopHelper {
   /**
    * @param callable $statusCallback A TRUE return value will cause the loop to exit and call $doneCallback.
    */
-  public static function getLoopy(OutputInterface $output, SymfonyStyle $io, LoggerInterface $logger, string $spinnerMessage, callable $statusCallback, callable $doneCallback): void {
+  public static function getLoopy(OutputInterface $output, SymfonyStyle $io, string $spinnerMessage, callable $statusCallback, callable $doneCallback): void {
     $timers = [];
     $spinner = new Spinner($output, 4);
     $spinner->setMessage($spinnerMessage);
@@ -28,16 +26,11 @@ class LoopHelper {
       $timers = [];
       $spinner->finish();
     };
-    $periodicCallback = static function () use ($logger, $statusCallback, $doneCallback, $cancelTimers): void {
-      try {
-        // @infection-ignore-all
-        if ($statusCallback()) {
-          $cancelTimers();
-          $doneCallback();
-        }
-      }
-      catch (Exception $e) {
-        $logger->debug($e->getMessage());
+    $periodicCallback = static function () use ($statusCallback, $doneCallback, $cancelTimers): void {
+      // @infection-ignore-all
+      if ($statusCallback()) {
+        $cancelTimers();
+        $doneCallback();
       }
     };
 

--- a/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeCreateCommandTest.php
@@ -55,7 +55,7 @@ class IdeCreateCommandTest extends CommandTestBase {
     /** @var \Prophecy\Prophecy\ObjectProphecy|\GuzzleHttp\Psr7\Response $guzzleResponse */
     $guzzleResponse = $this->prophet->prophesize(Response::class);
     $guzzleResponse->getStatusCode()->willReturn(200);
-    $this->httpClientProphecy->request('GET', 'https://215824ff-272a-4a8c-9027-df32ed1d68a9.ides.acquia.com/health')->willReturn($guzzleResponse->reveal())->shouldBeCalled();
+    $this->httpClientProphecy->request('GET', 'https://215824ff-272a-4a8c-9027-df32ed1d68a9.ides.acquia.com/health', ['http_errors' => FALSE])->willReturn($guzzleResponse->reveal())->shouldBeCalled();
 
     $inputs = [
       // Would you like Acquia CLI to search for a Cloud application that matches your local git config?


### PR DESCRIPTION
We were swallowing the CloudApiException that would otherwise alert the user to the invalid notification id.