### PR TITLE
CLI-1296: auth:login on 2.23.1 > Invalid key in Cloud datastore fixed

### DIFF
--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -27,7 +27,7 @@ final class AuthLoginCommand extends CommandBase {
     $keys = $this->datastoreCloud->get('keys');
     $activeKey = $this->datastoreCloud->get('acli_key');
     // @todo this validation should really be enforced as a schema on the datastore.
-    if (count($keys) != 0 && !array_key_exists($activeKey, $keys)) {
+    if ( is_array($keys) && !empty($keys) != 0 && !array_key_exists($activeKey, $keys)) {
       throw new AcquiaCliException('Invalid key in Cloud datastore; run acli auth:logout && acli auth:login to fix');
     }
     if ($activeKey) {

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -27,7 +27,7 @@ final class AuthLoginCommand extends CommandBase {
     $keys = $this->datastoreCloud->get('keys');
     $activeKey = $this->datastoreCloud->get('acli_key');
     // @todo this validation should really be enforced as a schema on the datastore.
-    if (is_array($keys) && !array_key_exists($activeKey, $keys)) {
+    if (count($keys) != 0 && !array_key_exists($activeKey, $keys)) {
       throw new AcquiaCliException('Invalid key in Cloud datastore; run acli auth:logout && acli auth:login to fix');
     }
     if ($activeKey) {

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -26,8 +26,7 @@ final class AuthLoginCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $keys = $this->datastoreCloud->get('keys');
     $activeKey = $this->datastoreCloud->get('acli_key');
-    // @todo this validation should really be enforced as a schema on the datastore.
-    if ( is_array($keys) && !empty($keys) != 0 && !array_key_exists($activeKey, $keys)) {
+    if (is_array($keys) && !empty($keys) && !array_key_exists($activeKey, $keys)) {
       throw new AcquiaCliException('Invalid key in Cloud datastore; run acli auth:logout && acli auth:login to fix');
     }
     if ($activeKey) {


### PR DESCRIPTION
**Motivation**
When using the latest version of acli which is 2.23.1 the command auth:login [-k|--key KEY] [-s|--secret SECRET] no longer works and generates the following error. This occurs when `acli -n telemetry:disable` is set before auth for CI/CD pipelines.

The issue is triggered during CI/CD pipeline by set some settings for the CLI before auth function such as switching on/off the telemetry.

Fixes #1708 

**Proposed changes**
if condition fix, update the cli only.

**Alternatives considered**
reduce the number of required changes in code

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Disable telemetry `acli -n telemetry:disable` to create the `~/.acquia/cloud_api.conf`
4. Login using `auth:login [-k|--key KEY] [-s|--secret SECRET]`
5. Exception should not be raised and the authentication is a success
