### PR TITLE
CLI-1294: [auth:logout] warning when key is invalid

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -24,7 +24,7 @@ class Application extends \Symfony\Component\Console\Application {
     return $this->helpMessages;
   }
 
-  public function setHelpMessages(mixed $helpMessages): void {
+  public function setHelpMessages(array $helpMessages): void {
     $this->helpMessages = $helpMessages;
   }
 

--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -27,7 +27,7 @@ final class AuthLoginCommand extends CommandBase {
     $keys = $this->datastoreCloud->get('keys');
     $activeKey = $this->datastoreCloud->get('acli_key');
     if (is_array($keys) && !empty($keys) && !array_key_exists($activeKey, $keys)) {
-      throw new AcquiaCliException('Invalid key in Cloud datastore; run acli auth:logout && acli auth:login to fix');
+      throw new AcquiaCliException('Invalid key in datastore at {filepath}', ['filepath' => $this->datastoreCloud->filepath]);
     }
     if ($activeKey) {
       $activeKeyLabel = $keys[$activeKey]['label'];

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -22,6 +22,9 @@ final class AuthLogoutCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $keys = $this->datastoreCloud->get('keys');
     $activeKey = $this->datastoreCloud->get('acli_key');
+    if (is_array($keys) && !empty($keys) && !array_key_exists($activeKey, $keys)) {
+      throw new AcquiaCliException('Invalid key in datastore at {filepath}', ['filepath' => $this->datastoreCloud->filepath]);
+    }
     if (!$activeKey) {
       throw new AcquiaCliException('There is no active Cloud Platform API key');
     }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -67,6 +67,9 @@ class ExceptionListener {
         case 'This machine is not yet authenticated with Site Factory.':
           $this->helpMessages[] = 'Run `acli auth:acsf-login` to re-authenticate with Site Factory.';
           break;
+        case 'Invalid key in datastore at {filepath}':
+          $this->helpMessages[] = 'Delete the datastore and run this command again.';
+          break;
       }
     }
 
@@ -89,6 +92,9 @@ class ExceptionListener {
       $newErrorMessage = 'Cloud Platform API returned an unexpected data type. This is not an issue with Acquia CLI but could indicate a problem with your Cloud Platform application.';
     }
 
+    if (!empty($this->helpMessages)) {
+      $this->helpMessages[0] = '<options=bold>How to fix it:</> ' . $this->helpMessages[0];
+    }
     $this->helpMessages[] = "You can find Acquia CLI documentation at https://docs.acquia.com/acquia-cli/";
     $this->writeUpdateHelp($event);
     $this->writeSupportTicketHelp($event);

--- a/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
@@ -102,7 +102,7 @@ class AuthLoginCommandTest extends CommandTestBase {
     $this->createDataStores();
     $this->command = $this->createCommand();
     $this->expectException(AcquiaCliException::class);
-    $this->expectExceptionMessage('Invalid key in Cloud datastore; run acli auth:logout && acli auth:login to fix');
+    $this->expectExceptionMessage("Invalid key in datastore at $this->cloudConfigFilepath");
     $this->executeCommand();
   }
 

--- a/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
@@ -8,6 +8,7 @@ use Acquia\Cli\Command\Auth\AuthLogoutCommand;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Config\CloudDataConfig;
 use Acquia\Cli\DataStore\CloudDataStore;
+use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\CommandTestBase;
 
 /**
@@ -29,6 +30,27 @@ class AuthLogoutCommandTest extends CommandTestBase {
     $this->assertStringContainsString('The key Test Key will be deactivated on this machine.', $output);
     $this->assertStringContainsString('Do you want to delete the active Cloud Platform API credentials (option --delete)? (yes/no) [no]:', $output);
     $this->assertStringContainsString('The active Cloud Platform API credentials were deactivated', $output);
+  }
+
+  public function testAuthLogoutInvalidDatastore(): void {
+    $this->clientServiceProphecy->isMachineAuthenticated()->willReturn(FALSE);
+    $this->removeMockCloudConfigFile();
+    $data = [
+      'acli_key' => 'key2',
+      'keys' => [
+        'key1' => [
+          'label' => 'foo',
+          'secret' => 'foo',
+          'uuid' => 'foo',
+        ],
+      ],
+    ];
+    $this->fs->dumpFile($this->cloudConfigFilepath, json_encode($data));
+    $this->createDataStores();
+    $this->command = $this->createCommand();
+    $this->expectException(AcquiaCliException::class);
+    $this->expectExceptionMessage("Invalid key in datastore at $this->cloudConfigFilepath");
+    $this->executeCommand();
   }
 
 }

--- a/tests/phpunit/src/Misc/ExceptionListenerTest.php
+++ b/tests/phpunit/src/Misc/ExceptionListenerTest.php
@@ -33,6 +33,7 @@ class ExceptionListenerTest extends TestBase {
     else {
       $messages = array_merge([$helpText], $messages1);
     }
+    $messages[0] = "<options=bold>How to fix it:</> $messages[0]";
     $applicationProphecy->setHelpMessages($messages)->shouldBeCalled();
     $commandProphecy->getApplication()->willReturn($applicationProphecy->reveal());
     $consoleErrorEvent = new ConsoleErrorEvent($this->input, $this->output, $error, $commandProphecy->reveal());
@@ -89,6 +90,10 @@ class ExceptionListenerTest extends TestBase {
       [
         new AcquiaCliException('This machine is not yet authenticated with Site Factory.'),
         'Run `acli auth:acsf-login` to re-authenticate with Site Factory.',
+      ],
+      [
+        new AcquiaCliException('Invalid key in datastore at {filepath}'),
+        'Delete the datastore and run this command again.',
       ],
       [
         new ApiErrorException((object) ['error' => '', 'message' => "There are no available Cloud IDEs for this application.\n"]),


### PR DESCRIPTION
@anavarre I'm trying to emphasize the self-help instructions for known exceptions by adding a bold "How to fix it" header, since it's otherwise easy to overlook. How do you feel about this?

<img width="602" alt="Screenshot 2024-03-29 at 1 43 08 PM" src="https://github.com/acquia/cli/assets/1984514/34801741-ec94-4df3-9a1f-ce6794966cd1">
<img width="711" alt="Screenshot 2024-03-29 at 1 44 13 PM" src="https://github.com/acquia/cli/assets/1984514/021422dd-4448-4fcb-b8c7-becc7155d292">

For general exceptions where we can't offer specific help, you get just the second and third sentences about docs and support.