### PR TITLE
GL-2530 : PHP 8.3 support for CodeStudio

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -52,6 +52,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase {
         $phpVersions = [
             'PHP_version_8.1' => "8.1",
             'PHP_version_8.2' => "8.2",
+            'PHP_version_8.3' => "8.3",
           ];
         $project = $this->io->choice('Select a PHP version', array_values($phpVersions), "8.1");
         $project = array_search($project, $phpVersions, TRUE);


### PR DESCRIPTION
This PR contain changes to support PHP 8.3 version for `acli cs:wizard` command for code studio.

Testing Steps:
Ran acli cs:wizard command locally and got an option to select php version 8.3
<img width="327" alt="Screenshot 2024-04-30 at 3 12 03 PM" src="https://github.com/acquia/cli/assets/62992590/d3cf941a-1f97-4955-9d1c-14871fe424c9">

Logged in to code studio UI and check for CI/CD variable for project, PHP_VERSION env variable is being set as 8.3.
<img width="1452" alt="Screenshot 2024-04-30 at 3 14 57 PM" src="https://github.com/acquia/cli/assets/62992590/c3d89cb6-63b9-4fc0-a232-ebda8d5aec13">
