### PR TITLE
CLI-1334: TypeError in auth:login

### DIFF
--- a/src/Command/Auth/AuthLoginCommand.php
+++ b/src/Command/Auth/AuthLoginCommand.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Acquia\Cli\Command\Auth;
 
 use Acquia\Cli\Command\CommandBase;
-use Acquia\Cli\Exception\AcquiaCliException;
 use AcquiaCloudApi\Endpoints\Account;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -26,9 +25,6 @@ final class AuthLoginCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $keys = $this->datastoreCloud->get('keys');
     $activeKey = $this->datastoreCloud->get('acli_key');
-    if (is_array($keys) && !empty($keys) && !array_key_exists($activeKey, $keys)) {
-      throw new AcquiaCliException('Invalid key in datastore at {filepath}', ['filepath' => $this->datastoreCloud->filepath]);
-    }
     if ($activeKey) {
       $activeKeyLabel = $keys[$activeKey]['label'];
       $output->writeln("The following Cloud Platform API key is active: <options=bold>$activeKeyLabel</>");

--- a/src/Command/Auth/AuthLogoutCommand.php
+++ b/src/Command/Auth/AuthLogoutCommand.php
@@ -22,9 +22,6 @@ final class AuthLogoutCommand extends CommandBase {
   protected function execute(InputInterface $input, OutputInterface $output): int {
     $keys = $this->datastoreCloud->get('keys');
     $activeKey = $this->datastoreCloud->get('acli_key');
-    if (is_array($keys) && !empty($keys) && !array_key_exists($activeKey, $keys)) {
-      throw new AcquiaCliException('Invalid key in datastore at {filepath}', ['filepath' => $this->datastoreCloud->filepath]);
-    }
     if (!$activeKey) {
       throw new AcquiaCliException('There is no active Cloud Platform API key');
     }

--- a/src/Config/CloudDataConfig.php
+++ b/src/Config/CloudDataConfig.php
@@ -33,7 +33,7 @@ class CloudDataConfig implements ConfigurationInterface {
                 ->children()
                   ->scalarNode('label')->end()
                   ->scalarNode('uuid')->end()
-                  ->scalarNode('secret')->end()
+                  ->scalarNode('secret')->isRequired()->end()
                 ->end()
             ->end()
         ->end()
@@ -68,7 +68,12 @@ class CloudDataConfig implements ConfigurationInterface {
 
         ->scalarNode('acsf_active_factory')->end()
 
-      ->end();
+      ->end()
+      ->validate()
+      ->ifTrue(function ($config) {
+        return is_array($config['keys']) && !empty($config['keys']) && !array_key_exists($config['acli_key'], $config['keys']);
+      })
+      ->thenInvalid('acli_key must exist in keys');
     return $treeBuilder;
   }
 

--- a/src/DataStore/Datastore.php
+++ b/src/DataStore/Datastore.php
@@ -67,7 +67,9 @@ abstract class Datastore implements DataStoreInterface {
       );
     }
     catch (InvalidConfigurationException $e) {
-      throw new AcquiaCliException("Configuration file at the following path contains invalid keys: $path. {$e->getMessage()}");
+      throw new AcquiaCliException(
+        'Configuration file at the following path contains invalid keys: {path} {error}',
+        ['path' => $path, 'error' => $e->getMessage()]);
     }
   }
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -70,9 +70,6 @@ class ExceptionListener {
         case 'Could not extract aliases to {destination}':
           $this->helpMessages[] = 'Check that you have write access to the directory';
           break;
-        case 'Invalid key in datastore at {filepath}':
-          $this->helpMessages[] = 'Delete the datastore and run this command again.';
-          break;
       }
     }
 

--- a/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
@@ -99,11 +99,9 @@ class AuthLoginCommandTest extends CommandTestBase {
       ],
     ];
     $this->fs->dumpFile($this->cloudConfigFilepath, json_encode($data));
-    $this->createDataStores();
-    $this->command = $this->createCommand();
     $this->expectException(AcquiaCliException::class);
-    $this->expectExceptionMessage("Invalid key in datastore at $this->cloudConfigFilepath");
-    $this->executeCommand();
+    $this->expectExceptionMessage("Configuration file at the following path contains invalid keys: $this->cloudConfigFilepath Invalid configuration for path \"cloud_api\": acli_key must exist in keys");
+    $this->createDataStores();
   }
 
   protected function assertInteractivePrompts(string $output): void {

--- a/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLogoutCommandTest.php
@@ -6,8 +6,6 @@ namespace Acquia\Cli\Tests\Commands\Auth;
 
 use Acquia\Cli\Command\Auth\AuthLogoutCommand;
 use Acquia\Cli\Command\CommandBase;
-use Acquia\Cli\Config\CloudDataConfig;
-use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\CommandTestBase;
 
@@ -24,9 +22,6 @@ class AuthLogoutCommandTest extends CommandTestBase {
     $this->executeCommand();
     $output = $this->getDisplay();
     $this->assertFileExists($this->cloudConfigFilepath);
-    $config = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $this->cloudConfigFilepath);
-    $this->assertFalse($config->exists('acli_key'));
-    $this->assertNotEmpty($config->get('keys'));
     $this->assertStringContainsString('The key Test Key will be deactivated on this machine.', $output);
     $this->assertStringContainsString('Do you want to delete the active Cloud Platform API credentials (option --delete)? (yes/no) [no]:', $output);
     $this->assertStringContainsString('The active Cloud Platform API credentials were deactivated', $output);
@@ -46,11 +41,9 @@ class AuthLogoutCommandTest extends CommandTestBase {
       ],
     ];
     $this->fs->dumpFile($this->cloudConfigFilepath, json_encode($data));
-    $this->createDataStores();
-    $this->command = $this->createCommand();
     $this->expectException(AcquiaCliException::class);
-    $this->expectExceptionMessage("Invalid key in datastore at $this->cloudConfigFilepath");
-    $this->executeCommand();
+    $this->expectExceptionMessage("Configuration file at the following path contains invalid keys: $this->cloudConfigFilepath Invalid configuration for path \"cloud_api\": acli_key must exist in keys");
+    $this->createDataStores();
   }
 
 }

--- a/tests/phpunit/src/Misc/ExceptionListenerTest.php
+++ b/tests/phpunit/src/Misc/ExceptionListenerTest.php
@@ -96,10 +96,6 @@ class ExceptionListenerTest extends TestBase {
         'Check that you have write access to the directory',
       ],
       [
-        new AcquiaCliException('Invalid key in datastore at {filepath}'),
-        'Delete the datastore and run this command again.',
-      ],
-      [
         new ApiErrorException((object) ['error' => '', 'message' => "There are no available Cloud IDEs for this application.\n"]),
         'Delete an existing IDE via <bg=blue;fg=white;options=bold>acli ide:delete</> or contact your Account Manager or Acquia Sales to purchase additional IDEs.',
       ],


### PR DESCRIPTION
Unfortunately validation exceptions occur during container builds and therefore bypass our lovely error handler. Not much we can do about that except to write a whole new error handler just for the container build step.