### PR TITLE
Track environment provider in telemetry.

### DIFF
--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -201,7 +201,7 @@ class TelemetryHelper {
   }
 
   /**
-   * @return array[]
+   * @return array<mixed>
    *   An array of providers and their associated environment variables.
    */
   public static function getProviders(): array {

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -138,12 +138,6 @@ class TelemetryHelper {
   public static function getEnvironmentProvider(): ?string {
     $providers = self::getProviders();
 
-    // Check for an Acquia environment first as it uses a method call rather than getenv.
-    // Under the hood, this checks the AH_SITE_ENVIRONMENT environment variable. This is set by Cloud IDE and Lando.
-    if (AcquiaDrupalEnvironmentDetector::getAhEnv()) {
-      return 'acquia';
-    }
-
     // Check for environment variables.
     foreach ($providers as $provider => $vars) {
       foreach ($vars as $var) {
@@ -205,12 +199,17 @@ class TelemetryHelper {
    * @infection-ignore-all
    *   Skipping infection testing for this because, it most cases, we expect that when a row from this array is changed
    *   it won't affect the return value.
+   *
    * @return array<mixed>
    *   An array of providers and their associated environment variables.
    */
   public static function getProviders(): array {
     // Define the environment variables associated with each provider.
     return [
+      'lando' => ['LANDO'],
+      'ddev' => ['IS_DDEV_PROJECT'],
+      // Check Lando and DDEV first because the hijack AH_SITE_ENVIRONMENT.
+      'acquia' => ['AH_SITE_ENVIRONMENT'],
       'bamboo' => ['BAMBOO_BUILDNUMBER'],
       'beanstalk' => ['BEANSTALK_ENVIRONMENT'],
       'bitbucket' => ['BITBUCKET_BUILD_NUMBER'],
@@ -218,20 +217,17 @@ class TelemetryHelper {
       'buddy' => ['BUDDY_WORKSPACE_ID'],
       'circleci' => ['CIRCLECI'],
       'codebuild' => ['CODEBUILD_BUILD_ID'],
-      'ddev' => ['IS_DDEV_PROJECT'],
+      'docksal' => ['DOCKSAL_VERSION'],
       'drone' => ['DRONE'],
       'github' => ['GITHUB_ACTIONS'],
       'gitlab' => ['GITLAB_CI'],
       'heroku' => ['HEROKU_TEST_RUN_ID'],
       'jenkins' => ['JENKINS_URL'],
-      'lando' => ['LANDO'],
       'pantheon' => ['PANTHEON_ENVIRONMENT'],
       'pipelines' => ['PIPELINE_ENV'],
       'platformsh' => ['PLATFORM_ENVIRONMENT'],
       'teamcity' => ['TEAMCITY_VERSION'],
       'travis' => ['TRAVIS'],
-      // docksal?
-      // docker?
     ];
   }
 

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -201,6 +201,9 @@ class TelemetryHelper {
   }
 
   /**
+   * @infection-ignore-all
+   *   Skipping infection testing for this because, it most cases, we expect that when a row from this array is changed
+   *   it won't affect the return value.
    * @return array<mixed>
    *   An array of providers and their associated environment variables.
    */

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -230,6 +230,8 @@ class TelemetryHelper {
       'platformsh' => ['PLATFORM_ENVIRONMENT'],
       'teamcity' => ['TEAMCITY_VERSION'],
       'travis' => ['TRAVIS'],
+      // docksal?
+      // docker?
     ];
   }
 

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -139,6 +139,7 @@ class TelemetryHelper {
     $providers = self::getProviders();
 
     // Check for an Acquia environment first as it uses a method call rather than getenv.
+    // Under the hood, this checks the AH_SITE_ENVIRONMENT environment variable. This is set by Cloud IDE and Lando.
     if (AcquiaDrupalEnvironmentDetector::getAhEnv()) {
       return 'acquia';
     }
@@ -217,11 +218,13 @@ class TelemetryHelper {
       'buddy' => ['BUDDY_WORKSPACE_ID'],
       'circleci' => ['CIRCLECI'],
       'codebuild' => ['CODEBUILD_BUILD_ID'],
+      'ddev' => ['IS_DDEV_PROJECT'],
       'drone' => ['DRONE'],
       'github' => ['GITHUB_ACTIONS'],
       'gitlab' => ['GITLAB_CI'],
       'heroku' => ['HEROKU_TEST_RUN_ID'],
       'jenkins' => ['JENKINS_URL'],
+      'lando' => ['LANDO'],
       'pantheon' => ['PANTHEON_ENVIRONMENT'],
       'pipelines' => ['PIPELINE_ENV'],
       'platformsh' => ['PLATFORM_ENVIRONMENT'],

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -211,7 +211,10 @@ class TelemetryHelper {
     // Define the environment variables associated with each provider.
     return [
       'bamboo' => ['BAMBOO_BUILDNUMBER'],
-      'bitbucket' => ['BITBUCKET_BRANCH'],
+      'beanstalk' => ['BEANSTALK_ENVIRONMENT'],
+      'bitbucket' => ['BITBUCKET_BUILD_NUMBER'],
+      'bitrise' => ['BITRISE_IO'],
+      'buddy' => ['BUDDY_WORKSPACE_ID'],
       'circleci' => ['CIRCLECI'],
       'codebuild' => ['CODEBUILD_BUILD_ID'],
       'drone' => ['DRONE'],
@@ -219,7 +222,9 @@ class TelemetryHelper {
       'gitlab' => ['GITLAB_CI'],
       'heroku' => ['HEROKU_TEST_RUN_ID'],
       'jenkins' => ['JENKINS_URL'],
-      'octopus' => ['OCTOPUS_DEPLOYMENT_ID'],
+      'pantheon' => ['PANTHEON_ENVIRONMENT'],
+      'pipelines' => ['PIPELINE_ENV'],
+      'platformsh' => ['PLATFORM_ENVIRONMENT'],
       'teamcity' => ['TEAMCITY_VERSION'],
       'travis' => ['TRAVIS'],
     ];

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -199,12 +199,12 @@ class TelemetryHelper {
    * @infection-ignore-all
    *   Skipping infection testing for this because, it most cases, we expect that when a row from this array is changed
    *   it won't affect the return value.
-   *
    * @return array<mixed>
    *   An array of providers and their associated environment variables.
    */
   public static function getProviders(): array {
     // Define the environment variables associated with each provider.
+    // phpcs:ignore SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys.IncorrectKeyOrder
     return [
       'lando' => ['LANDO'],
       'ddev' => ['IS_DDEV_PROJECT'],

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -120,6 +120,7 @@ class TelemetryHelper {
       'ah_non_production' => getenv('AH_NON_PRODUCTION'),
       'ah_realm' => getenv('AH_REALM'),
       'CI' => getenv('CI'),
+      'env_provider' => $this->getEnvironmentProvider(),
       'php_version' => PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
     ];
     try {
@@ -132,6 +133,41 @@ class TelemetryHelper {
       // If something is wrong with the Cloud API client, don't bother users.
     }
     return $data;
+  }
+
+  private function getEnvironmentProvider(): ?string {
+    // Define the environment variables associated with each provider.
+    $providers = [
+      // Assuming Acquia has a specific environment variable, just for example purposes.
+      'acquia'    => ['ACQUIA_ENVIRONMENT'],
+      'bamboo'    => ['BAMBOO_BUILDNUMBER'],
+      'bitbucket' => ['BITBUCKET_BRANCH'],
+      'circleci'  => ['CIRCLECI'],
+      'codebuild' => ['CODEBUILD_BUILD_ID'],
+      'drone'     => ['DRONE'],
+      'github'    => ['GITHUB_ACTIONS'],
+      'gitlab'    => ['GITLAB_CI'],
+      'heroku'    => ['HEROKU_TEST_RUN_ID'],
+      'jenkins'   => ['JENKINS_URL'],
+      'octopus'   => ['OCTOPUS_DEPLOYMENT_ID'],
+      'teamcity'  => ['TEAMCITY_VERSION'],
+      'travis'    => ['TRAVIS'],
+    ];
+
+    // Check for an Acquia environment first as it uses a method call rather than getenv.
+    if (AcquiaDrupalEnvironmentDetector::getAhEnv()) {
+      return 'acquia';
+    }
+
+    // Check for CI/CD environment variables.
+    foreach ($providers as $provider => $vars) {
+      foreach ($vars as $var) {
+        if (getenv($var) !== FALSE)
+          return $provider;
+      }
+    }
+
+    return NULL;
   }
 
   private function getUserId(): ?string {

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -135,31 +135,15 @@ class TelemetryHelper {
     return $data;
   }
 
-  private function getEnvironmentProvider(): ?string {
-    // Define the environment variables associated with each provider.
-    $providers = [
-      // Assuming Acquia has a specific environment variable, just for example purposes.
-      'acquia'    => ['ACQUIA_ENVIRONMENT'],
-      'bamboo'    => ['BAMBOO_BUILDNUMBER'],
-      'bitbucket' => ['BITBUCKET_BRANCH'],
-      'circleci'  => ['CIRCLECI'],
-      'codebuild' => ['CODEBUILD_BUILD_ID'],
-      'drone'     => ['DRONE'],
-      'github'    => ['GITHUB_ACTIONS'],
-      'gitlab'    => ['GITLAB_CI'],
-      'heroku'    => ['HEROKU_TEST_RUN_ID'],
-      'jenkins'   => ['JENKINS_URL'],
-      'octopus'   => ['OCTOPUS_DEPLOYMENT_ID'],
-      'teamcity'  => ['TEAMCITY_VERSION'],
-      'travis'    => ['TRAVIS'],
-    ];
+  public static function getEnvironmentProvider(): ?string {
+    $providers = self::getProviders();
 
     // Check for an Acquia environment first as it uses a method call rather than getenv.
     if (AcquiaDrupalEnvironmentDetector::getAhEnv()) {
       return 'acquia';
     }
 
-    // Check for CI/CD environment variables.
+    // Check for environment variables.
     foreach ($providers as $provider => $vars) {
       foreach ($vars as $var) {
         if (getenv($var) !== FALSE)
@@ -213,6 +197,28 @@ class TelemetryHelper {
     return [
       'is_acquian' => str_ends_with($account->get()->mail, 'acquia.com'),
       'uuid' => $account->get()->uuid,
+    ];
+  }
+
+  /**
+   * @return array[]
+   *   An array of providers and their associated environment variables.
+   */
+  public static function getProviders(): array {
+    // Define the environment variables associated with each provider.
+    return [
+      'bamboo' => ['BAMBOO_BUILDNUMBER'],
+      'bitbucket' => ['BITBUCKET_BRANCH'],
+      'circleci' => ['CIRCLECI'],
+      'codebuild' => ['CODEBUILD_BUILD_ID'],
+      'drone' => ['DRONE'],
+      'github' => ['GITHUB_ACTIONS'],
+      'gitlab' => ['GITLAB_CI'],
+      'heroku' => ['HEROKU_TEST_RUN_ID'],
+      'jenkins' => ['JENKINS_URL'],
+      'octopus' => ['OCTOPUS_DEPLOYMENT_ID'],
+      'teamcity' => ['TEAMCITY_VERSION'],
+      'travis' => ['TRAVIS'],
     ];
   }
 

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -14,7 +14,7 @@ class TelemetryHelperTest extends CommandTestBase {
 
   public function tearDown(): void {
     parent::tearDown();
-    $envVars = [];
+    $envVars = ['AH_SITE_ENVIRONMENT' => 'test'];
     foreach ($this->providerTestEnvironmentProvider() as $args) {
       $envVars = array_merge($envVars, $args[1]);
     }
@@ -55,12 +55,20 @@ class TelemetryHelperTest extends CommandTestBase {
    * Test the getEnvironmentProvider method when no environment provider is detected.
    */
   public function testGetEnvironmentProviderWithoutAnyEnvSet(): void {
-    // Ensure no environment variables are set.
-    $providersList = TelemetryHelper::getProviders();
-    TestBase::unsetEnvVars($providersList);
-
     // Expect null since no provider environment variables are set.
     $this->assertNull(TelemetryHelper::getEnvironmentProvider());
+  }
+
+  /**
+   * Test the getEnvironmentProvider method when Acquia environment is detected.
+   */
+  public function testGetEnvironmentProviderWithAcquia(): void {
+    TestBase::setEnvVars(['AH_SITE_ENVIRONMENT' => 'test']);
+
+    // We need to make sure our mocked method is used. Depending on the implementation,
+    // this could involve setting it statically or using dependency injection.
+    // Expect 'acquia' to be returned since Acquia environment is mocked to be present.
+    $this->assertEquals('acquia', TelemetryHelper::getEnvironmentProvider());
   }
 
 }

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 
 namespace Acquia\Cli\Tests\Misc;
 
-use Acquia\Cli\Command\CommandBase;
-use Acquia\Cli\Command\Self\ClearCacheCommand;
 use Acquia\Cli\Helpers\TelemetryHelper;
 use Acquia\Cli\Tests\TestBase;
 
@@ -15,7 +13,7 @@ class TelemetryHelperTest extends TestBase {
 
   public function tearDown(): void {
     parent::tearDown();
-    $envVars = ['AH_SITE_ENVIRONMENT' => 'test'];
+    $envVars = [];
     foreach ($this->providerTestEnvironmentProvider() as $args) {
       $envVars = array_merge($envVars, $args[1]);
     }
@@ -68,18 +66,6 @@ class TelemetryHelperTest extends TestBase {
 
     // Expect null since no provider environment variables are set.
     $this->assertNull(TelemetryHelper::getEnvironmentProvider());
-  }
-
-  /**
-   * Test the getEnvironmentProvider method when Acquia environment is detected.
-   */
-  public function testGetEnvironmentProviderWithAcquia(): void {
-    // We test this separately from testEnvironmentProvider() because AH_SITE_ENVIRONMENT isn't in
-    // TelemetryHelper::getProviders(). Instead, we rely on AcquiaDrupalEnvironmentDetector::getAhEnv() in
-    // getEnvironmentProvider() to indirectly tell us if AH_SITE_ENVIRONMENT is set. This allows
-    // AcquiaDrupalEnvironmentDetector to handle any changes to the logic of detecting Acquia environments.
-    TestBase::setEnvVars(['AH_SITE_ENVIRONMENT' => self::ENV_VAR_DEFAULT_VALUE]);
-    $this->assertEquals('acquia', TelemetryHelper::getEnvironmentProvider());
   }
 
 }

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -27,7 +27,7 @@ class TelemetryHelperTest extends CommandTestBase {
   }
 
   /**
-   * @return array[]
+   * @return array<mixed>
    */
   public function providerTestEnvironmentProvider(): array {
     $providersList = TelemetryHelper::getProviders();

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -51,4 +51,16 @@ class TelemetryHelperTest extends CommandTestBase {
     $this->assertEquals($provider, TelemetryHelper::getEnvironmentProvider());
   }
 
+  /**
+   * Test the getEnvironmentProvider method when no environment provider is detected.
+   */
+  public function testGetEnvironmentProviderWithoutAnyEnvSet(): void {
+    // Ensure no environment variables are set.
+    $providersList = TelemetryHelper::getProviders();
+    TestBase::unsetEnvVars($providersList);
+
+    // Expect null since no provider environment variables are set.
+    $this->assertNull(TelemetryHelper::getEnvironmentProvider());
+  }
+
 }

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -12,6 +12,8 @@ use Acquia\Cli\Tests\TestBase;
 
 class TelemetryHelperTest extends CommandTestBase {
 
+  const ENV_VAR_DEFAULT_VALUE = 'test';
+
   public function tearDown(): void {
     parent::tearDown();
     $envVars = ['AH_SITE_ENVIRONMENT' => 'test'];
@@ -35,7 +37,7 @@ class TelemetryHelperTest extends CommandTestBase {
     foreach ($providersList as $provider => $envVars) {
       $env_vars_with_values = [];
       foreach ($envVars as $var_name) {
-        $env_vars_with_values[$var_name] = 'test';
+        $env_vars_with_values[$var_name] = self::ENV_VAR_DEFAULT_VALUE;
       }
       $providersArray[] = [$provider, $env_vars_with_values];
     }
@@ -55,6 +57,16 @@ class TelemetryHelperTest extends CommandTestBase {
    * Test the getEnvironmentProvider method when no environment provider is detected.
    */
   public function testGetEnvironmentProviderWithoutAnyEnvSet(): void {
+    $providers = TelemetryHelper::getProviders();
+
+    // Since we actually run our own tests on GitHub, getEnvironmentProvider() will return 'github' unless we unset it.
+    $github_env_vars = [];
+    foreach ($providers['github'] as $var) {
+      $github_env_vars[$var] = self::ENV_VAR_DEFAULT_VALUE;
+    }
+
+    TestBase::unsetEnvVars($github_env_vars);
+
     // Expect null since no provider environment variables are set.
     $this->assertNull(TelemetryHelper::getEnvironmentProvider());
   }
@@ -63,7 +75,7 @@ class TelemetryHelperTest extends CommandTestBase {
    * Test the getEnvironmentProvider method when Acquia environment is detected.
    */
   public function testGetEnvironmentProviderWithAcquia(): void {
-    TestBase::setEnvVars(['AH_SITE_ENVIRONMENT' => 'test']);
+    TestBase::setEnvVars(['AH_SITE_ENVIRONMENT' => self::ENV_VAR_DEFAULT_VALUE]);
 
     // We need to make sure our mocked method is used. Depending on the implementation,
     // this could involve setting it statically or using dependency injection.

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -75,11 +75,11 @@ class TelemetryHelperTest extends CommandTestBase {
    * Test the getEnvironmentProvider method when Acquia environment is detected.
    */
   public function testGetEnvironmentProviderWithAcquia(): void {
+    // We test this separately from testEnvironmentProvider() because AH_SITE_ENVIRONMENT isn't in
+    // TelemetryHelper::getProviders(). Instead, we rely on AcquiaDrupalEnvironmentDetector::getAhEnv() in
+    // getEnvironmentProvider() to indirectly tell us if AH_SITE_ENVIRONMENT is set. This allows
+    // AcquiaDrupalEnvironmentDetector to handle any changes to the logic of detecting Acquia environments.
     TestBase::setEnvVars(['AH_SITE_ENVIRONMENT' => self::ENV_VAR_DEFAULT_VALUE]);
-
-    // We need to make sure our mocked method is used. Depending on the implementation,
-    // this could involve setting it statically or using dependency injection.
-    // Expect 'acquia' to be returned since Acquia environment is mocked to be present.
     $this->assertEquals('acquia', TelemetryHelper::getEnvironmentProvider());
   }
 

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Acquia\Cli\Tests\Misc;
+
+use Acquia\Cli\Command\CommandBase;
+use Acquia\Cli\Command\Self\ClearCacheCommand;
+use Acquia\Cli\Helpers\TelemetryHelper;
+use Acquia\Cli\Tests\CommandTestBase;
+use Acquia\Cli\Tests\TestBase;
+
+class TelemetryHelperTest extends CommandTestBase {
+
+  public function tearDown(): void {
+    parent::tearDown();
+    $envVars = [];
+    foreach ($this->providerTestEnvironmentProvider() as $args) {
+      $envVars = array_merge($envVars, $args[1]);
+    }
+
+    TestBase::unsetEnvVars($envVars);
+  }
+
+  protected function createCommand(): CommandBase {
+    return $this->injectCommand(ClearCacheCommand::class);
+  }
+
+  /**
+   * @return array[]
+   */
+  public function providerTestEnvironmentProvider(): array {
+    $providersList = TelemetryHelper::getProviders();
+    $providersArray = [];
+    foreach ($providersList as $provider => $envVars) {
+      $env_vars_with_values = [];
+      foreach ($envVars as $var_name) {
+        $env_vars_with_values[$var_name] = 'test';
+      }
+      $providersArray[] = [$provider, $env_vars_with_values];
+    }
+
+    return $providersArray;
+  }
+
+  /**
+   * @dataProvider providerTestEnvironmentProvider()
+   */
+  public function testEnvironmentProvider(string $provider, array $envVars): void {
+    TestBase::setEnvVars($envVars);
+    $this->assertEquals($provider, TelemetryHelper::getEnvironmentProvider());
+  }
+
+}

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -24,6 +24,17 @@ class TelemetryHelperTest extends CommandTestBase {
     TestBase::unsetEnvVars($envVars);
   }
 
+  public function unsetGitHubEnvVars(): void {
+    $providers = TelemetryHelper::getProviders();
+
+    // Since we actually run our own tests on GitHub, getEnvironmentProvider() will return 'github' unless we unset it.
+    $github_env_vars = [];
+    foreach ($providers['github'] as $var) {
+      $github_env_vars[$var] = self::ENV_VAR_DEFAULT_VALUE;
+    }
+    TestBase::unsetEnvVars($github_env_vars);
+  }
+
   protected function createCommand(): CommandBase {
     return $this->injectCommand(ClearCacheCommand::class);
   }
@@ -50,6 +61,9 @@ class TelemetryHelperTest extends CommandTestBase {
    */
   public function testEnvironmentProvider(string $provider, array $envVars): void {
     TestBase::setEnvVars($envVars);
+    if ($provider !== 'github') {
+      $this->unsetGitHubEnvVars();
+    }
     $this->assertEquals($provider, TelemetryHelper::getEnvironmentProvider());
   }
 
@@ -57,15 +71,7 @@ class TelemetryHelperTest extends CommandTestBase {
    * Test the getEnvironmentProvider method when no environment provider is detected.
    */
   public function testGetEnvironmentProviderWithoutAnyEnvSet(): void {
-    $providers = TelemetryHelper::getProviders();
-
-    // Since we actually run our own tests on GitHub, getEnvironmentProvider() will return 'github' unless we unset it.
-    $github_env_vars = [];
-    foreach ($providers['github'] as $var) {
-      $github_env_vars[$var] = self::ENV_VAR_DEFAULT_VALUE;
-    }
-
-    TestBase::unsetEnvVars($github_env_vars);
+    $this->unsetGitHubEnvVars();
 
     // Expect null since no provider environment variables are set.
     $this->assertNull(TelemetryHelper::getEnvironmentProvider());

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -60,10 +60,8 @@ class TelemetryHelperTest extends CommandTestBase {
    * @dataProvider providerTestEnvironmentProvider()
    */
   public function testEnvironmentProvider(string $provider, array $envVars): void {
+    $this->unsetGitHubEnvVars();
     TestBase::setEnvVars($envVars);
-    if ($provider !== 'github') {
-      $this->unsetGitHubEnvVars();
-    }
     $this->assertEquals($provider, TelemetryHelper::getEnvironmentProvider());
   }
 

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -7,10 +7,9 @@ namespace Acquia\Cli\Tests\Misc;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Self\ClearCacheCommand;
 use Acquia\Cli\Helpers\TelemetryHelper;
-use Acquia\Cli\Tests\CommandTestBase;
 use Acquia\Cli\Tests\TestBase;
 
-class TelemetryHelperTest extends CommandTestBase {
+class TelemetryHelperTest extends TestBase {
 
   const ENV_VAR_DEFAULT_VALUE = 'test';
 
@@ -33,10 +32,6 @@ class TelemetryHelperTest extends CommandTestBase {
       $github_env_vars[$var] = self::ENV_VAR_DEFAULT_VALUE;
     }
     TestBase::unsetEnvVars($github_env_vars);
-  }
-
-  protected function createCommand(): CommandBase {
-    return $this->injectCommand(ClearCacheCommand::class);
   }
 
   /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
We often don't know if ACLI is running in Code Studio, on local, or elsewhere.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
 Add an "env_provider" data point to telemetry, based on env variables, to determine env provider.
