### PR TITLE
Normalize ah_env telemetry.

### DIFF
--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -107,6 +107,29 @@ class TelemetryHelper {
     }
   }
 
+  private function normalizeAhEnv(): string {
+    $ah_env = AcquiaDrupalEnvironmentDetector::getAhEnv();
+    if (AcquiaDrupalEnvironmentDetector::isAcsfEnv()) {
+      return 'acsf';
+    }
+    if (AcquiaDrupalEnvironmentDetector::isAhProdEnv($ah_env)) {
+      return 'prod';
+    }
+    if (AcquiaDrupalEnvironmentDetector::isAhStageEnv($ah_env)) {
+      return 'stage';
+    }
+    if (AcquiaDrupalEnvironmentDetector::isAhDevEnv($ah_env)) {
+      return 'dev';
+    }
+    if (AcquiaDrupalEnvironmentDetector::isAhOdeEnv($ah_env)) {
+      return 'ode';
+    }
+    if (AcquiaDrupalEnvironmentDetector::isAhIdeEnv($ah_env)) {
+      return 'ide';
+    }
+    return AcquiaDrupalEnvironmentDetector::getAhEnv();
+  }
+
   /**
    * Get telemetry user data.
    *
@@ -115,7 +138,7 @@ class TelemetryHelper {
   private function getTelemetryUserData(): array {
     $data = [
       'ah_app_uuid' => getenv('AH_APPLICATION_UUID'),
-      'ah_env' => AcquiaDrupalEnvironmentDetector::getAhEnv(),
+      'ah_env' => $this->normalizeAhEnv(),
       'ah_group' => AcquiaDrupalEnvironmentDetector::getAhGroup(),
       'ah_non_production' => getenv('AH_NON_PRODUCTION'),
       'ah_realm' => getenv('AH_REALM'),


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->

Our ahv_env data has values like ode1, ode37, etc. These should be normalized.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

Normalize ah_env using provided methods from AcquiaDrupalEnvironmentDetector.