### PR TITLE
Fix: DDEV + WSL2 Local Development Database Import Error

### DIFF
--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -554,7 +554,7 @@ abstract class PullCommandBase extends CommandBase {
   }
 
   private function importRemoteDatabase(DatabaseResponse $database, string $localFilepath, Closure $outputCallback = NULL): void {
-    if ($database->flags->default) {
+    if ($database->flags->default || getenv('IS_LOCAL')) {
       // Easy case, import the default db into the default db.
       $this->doImportRemoteDatabase($this->getLocalDbHost(), $this->getLocalDbUser(), $this->getLocalDbName(), $this->getLocalDbPassword(), $localFilepath, $outputCallback);
     }


### PR DESCRIPTION
**Motivation**
Fixes #1745 
Running 1 site instead of multisite in my environment with DDEV and WSL2.

**Proposed changes**
Add IS_LOCAL environment control for import database operation in DDEV and WSL2 environment.
