### PR TITLE
CLI-1336: Isolate cache dir per test

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -37,6 +37,12 @@ class Kernel extends BaseKernel {
     $this->registerExtensionConfiguration($loader);
   }
 
+  /** @infection-ignore-all */
+  public function getCacheDir(): string {
+    $testToken = getenv('TEST_TOKEN') ?? '';
+    return parent::getCacheDir() . $testToken;
+  }
+
   protected function registerExtensionConfiguration(mixed $loader): void {
     // Search for plugins.
     $finder = new Finder();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
