### PR TITLE
GL-2639: Initialise project with default branch and readme file.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -236,7 +236,9 @@ trait CodeStudioCommandTrait {
   private function getGitLabProjectDefaults(): array {
     return [
       'container_registry_access_level' => 'disabled',
+      'default_branch' => 'main',
       'description' => $this->gitLabProjectDescription,
+      'initialize_with_readme' => TRUE,
       'topics' => 'Acquia Cloud Application',
     ];
   }

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -297,7 +297,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $projects = $this->mockGetGitLabProjects($this::$applicationUuid, $this->gitLabProjectId, $mockedGitlabProjects);
     $parameters = [
       'container_registry_access_level' => 'disabled',
+      'default_branch' => 'main',
       'description' => 'Source repository for Acquia Cloud Platform application <comment>a47ac10b-58cc-4372-a567-0e02b2c3d470</comment>',
+      'initialize_with_readme' => TRUE,
       'namespace_id' => 47,
       'topics' => 'Acquia Cloud Application',
     ];
@@ -305,7 +307,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->mockGitLabProjectsTokens($projects);
     $parameters = [
       'container_registry_access_level' => 'disabled',
+      'default_branch' => 'main',
       'description' => 'Source repository for Acquia Cloud Platform application <comment>a47ac10b-58cc-4372-a567-0e02b2c3d470</comment>',
+      'initialize_with_readme' => TRUE,
       'topics' => 'Acquia Cloud Application',
     ];
     $projects->update($this->gitLabProjectId, $parameters)->shouldBeCalled();


### PR DESCRIPTION
**Motivation**
After gitlab upgrade to v17.0, cs-wizard started failing due to one of bug fix by gitlab which allows scheduling pipelines even when project has no branch. 

**Proposed changes**
Project will have default branch main on which schedule pipelines can be configured.

**Testing steps**
Tried executing cs-wizard command project creation works fine with latest upgrade.


