### PR TITLE
GL-2582 : Remove schedule pipelines for node projects.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCommandTrait.php
+++ b/src/Command/CodeStudio/CodeStudioCommandTrait.php
@@ -236,7 +236,9 @@ trait CodeStudioCommandTrait {
   private function getGitLabProjectDefaults(): array {
     return [
       'container_registry_access_level' => 'disabled',
+      'default_branch' => 'main',
       'description' => $this->gitLabProjectDescription,
+      'initialize_with_readme' => TRUE,
       'topics' => 'Acquia Cloud Application',
     ];
   }

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -118,6 +118,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase {
     switch ($projectSelected) {
       case "Drupal_project":
         $this->setGitLabCiCdVariablesForPhpProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $phpVersion);
+        $this->createScheduledPipeline($project);
         break;
       case "Node_project":
         $parameters = [
@@ -128,7 +129,6 @@ final class CodeStudioWizardCommand extends WizardCommandBase {
         $this->setGitLabCiCdVariablesForNodeProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion);
         break;
     }
-    $this->createScheduledPipeline($project);
 
     $this->io->success([
       "Successfully configured the Code Studio project!",

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -297,7 +297,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $projects = $this->mockGetGitLabProjects($this::$applicationUuid, $this->gitLabProjectId, $mockedGitlabProjects);
     $parameters = [
       'container_registry_access_level' => 'disabled',
+      'default_branch' => 'main',
       'description' => 'Source repository for Acquia Cloud Platform application <comment>a47ac10b-58cc-4372-a567-0e02b2c3d470</comment>',
+      'initialize_with_readme' => TRUE,
       'namespace_id' => 47,
       'topics' => 'Acquia Cloud Application',
     ];
@@ -305,7 +307,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
     $this->mockGitLabProjectsTokens($projects);
     $parameters = [
       'container_registry_access_level' => 'disabled',
+      'default_branch' => 'main',
       'description' => 'Source repository for Acquia Cloud Platform application <comment>a47ac10b-58cc-4372-a567-0e02b2c3d470</comment>',
+      'initialize_with_readme' => TRUE,
       'topics' => 'Acquia Cloud Application',
     ];
     $projects->update($this->gitLabProjectId, $parameters)->shouldBeCalled();


### PR DESCRIPTION
As of now schedule pipelines are configured for both node projects and drupal projects. But those are only required for Drupal Projects. Hence removing it form node projects.