### PR TITLE
GL-2582 : Remove schedule pipelines for node projects

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -118,6 +118,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase {
     switch ($projectSelected) {
       case "Drupal_project":
         $this->setGitLabCiCdVariablesForPhpProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $phpVersion);
+        $this->createScheduledPipeline($project);
         break;
       case "Node_project":
         $parameters = [
@@ -128,7 +129,6 @@ final class CodeStudioWizardCommand extends WizardCommandBase {
         $this->setGitLabCiCdVariablesForNodeProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion);
         break;
     }
-    $this->createScheduledPipeline($project);
 
     $this->io->success([
       "Successfully configured the Code Studio project!",

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -325,25 +325,28 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
       ];
       $projects->update($this->gitLabProjectId, $parameters)->shouldBeCalled();
     }
-    $schedules = $this->prophet->prophesize(Schedules::class);
-    $schedules->showAll($this->gitLabProjectId)->willReturn([]);
-    $pipeline = ['id' => 1];
-    $parameters = [
-      // Every Thursday at midnight.
-      'cron' => '0 0 * * 4',
-      'description' => 'Code Studio Automatic Updates',
-      'ref' => 'master',
-    ];
-    $schedules->create($this->gitLabProjectId, $parameters)->willReturn($pipeline);
-    $schedules->addVariable($this->gitLabProjectId, $pipeline['id'], [
-      'key' => 'ACQUIA_JOBS_DEPRECATED_UPDATE',
-      'value' => 'true',
-    ])->shouldBeCalled();
-    $schedules->addVariable($this->gitLabProjectId, $pipeline['id'], [
-      'key' => 'ACQUIA_JOBS_COMPOSER_UPDATE',
-      'value' => 'true',
-    ])->shouldBeCalled();
-    $gitlabClient->schedules()->willReturn($schedules->reveal());
+    else {
+      $schedules = $this->prophet->prophesize(Schedules::class);
+      $schedules->showAll($this->gitLabProjectId)->willReturn([]);
+      $pipeline = ['id' => 1];
+      $parameters = [
+        // Every Thursday at midnight.
+        'cron' => '0 0 * * 4',
+        'description' => 'Code Studio Automatic Updates',
+        'ref' => 'master',
+      ];
+      $schedules->create($this->gitLabProjectId, $parameters)->willReturn($pipeline);
+      $schedules->addVariable($this->gitLabProjectId, $pipeline['id'], [
+        'key' => 'ACQUIA_JOBS_DEPRECATED_UPDATE',
+        'value' => 'true',
+      ])->shouldBeCalled();
+      $schedules->addVariable($this->gitLabProjectId, $pipeline['id'], [
+        'key' => 'ACQUIA_JOBS_COMPOSER_UPDATE',
+        'value' => 'true',
+      ])->shouldBeCalled();
+      $gitlabClient->schedules()->willReturn($schedules->reveal());
+    }
+
     $gitlabClient->projects()->willReturn($projects);
 
     $this->command->setGitLabClient($gitlabClient->reveal());


### PR DESCRIPTION
As of now schedule pipelines are configured for both node projects and drupal projects. But those are only required for Drupal Projects. Hence removing it from node projects.

Manual tests:
1. With the Node project selected in the `cs:wizard` command, the resultant Node project in Gitlab should not have a pre-configured scheduled pipeline
2. Regression test: With this update, the Drupal selection flow should not be impacted (i.e. creation, variables etc. along with a configured scheduled pipeline should be validated)