### PR TITLE
GL-2753 : CS Wizard updated node version select values

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -60,10 +60,10 @@ final class CodeStudioWizardCommand extends WizardCommandBase {
           break;
       case "Node_project":
         $nodeVersions = [
-            'NODE_version_18.17.1' => "18.17.1",
-            'NODE_version_20.5.1' => "20.5.1",
+            'NODE_version_18' => "18",
+            'NODE_version_20' => "20",
           ];
-        $project = $this->io->choice('Select a NODE version', array_values($nodeVersions), "18.17.1");
+        $project = $this->io->choice('Select a NODE version', array_values($nodeVersions), "20");
         $project = array_search($project, $nodeVersions, TRUE);
         $nodeVersion = $nodeVersions[$project];
           break;

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -141,7 +141,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           'y',
           // Select a project type Node_project.
           '1',
-          // Select NODE version 18.17.1.
+          // Select NODE version 18.
           '0',
           // Do you want to continue?
           'y',
@@ -163,7 +163,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           'y',
           // Select a project type Node_project.
           '1',
-          // Select NODE version 20.5.1.
+          // Select NODE version 20.
           '1',
           // Do you want to continue?
           'y',
@@ -228,7 +228,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           $this->secret,
           // Select a project type Node_project.
           '1',
-          // Select NODE version 18.17.1.
+          // Select NODE version 18.
           '0',
           // Do you want to continue?
           'y',
@@ -270,7 +270,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase {
           $this->secret,
           // Select a project type Node_project.
           '1',
-          // Select NODE version 20.5.1.
+          // Select NODE version 20.
           '1',
           // Do you want to continue?
           'y',


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
The current values provided in NODE_VERSION need to be update as for better onboarding flow to user on Node Project. Also the default value for the select needed to be changed.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Following steps can be taken to verify the changes:

- Run the following command `acli cs:wizard`.
- Please enter Cloud Key and Secret to login 
- Select Node_project in project type.
- In next select, the updated values will be visible for NODE version selection
