### PR TITLE
CLI-1362: [push:db] mysqldump failure not surfaced

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1692,10 +1692,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
             $outputCallback('out', "Dumping MySQL database to $localFilepath on this machine");
         }
         if ($this->localMachineHelper->commandExists('pv')) {
-            $command = "MYSQL_PWD={$dbPassword} mysqldump --host={$dbHost} --user={$dbUser} {$dbName} | pv --rate --bytes | gzip -9 > $localFilepath";
+            $command = "bash -c \"set -o pipefail; MYSQL_PWD={$dbPassword} mysqldump --host={$dbHost} --user={$dbUser} {$dbName} | pv --rate --bytes | gzip -9 > $localFilepath\"";
         } else {
             $this->io->warning('Install `pv` to see progress bar');
-            $command = "MYSQL_PWD={$dbPassword} mysqldump --host={$dbHost} --user={$dbUser} {$dbName} | gzip -9 > $localFilepath";
+            $command = "bash -c \"set -o pipefail; MYSQL_PWD={$dbPassword} mysqldump --host={$dbHost} --user={$dbUser} {$dbName} | gzip -9 > $localFilepath\"";
         }
 
         $process = $this->localMachineHelper->executeFromCmd($command, $outputCallback, null, ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL));

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -420,7 +420,7 @@ abstract class CommandTestBase extends TestBase
             ->shouldBeCalled();
         $process = $this->mockProcess();
         $process->getOutput()->willReturn('');
-        $command = 'MYSQL_PWD=drupal mysqldump --host=localhost --user=drupal drupal | pv --rate --bytes | gzip -9 > ' . sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz';
+        $command = 'bash -c "set -o pipefail; MYSQL_PWD=drupal mysqldump --host=localhost --user=drupal drupal | pv --rate --bytes | gzip -9 > ' . sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz"';
         $localMachineHelper->executeFromCmd($command, Argument::type('callable'), null, $printOutput)
             ->willReturn($process->reveal())
             ->shouldBeCalled();

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -414,13 +414,17 @@ abstract class CommandTestBase extends TestBase
         return $this->mockRequest('getNotificationByUuid', $uuid);
     }
 
-    protected function mockCreateMySqlDumpOnLocal(ObjectProphecy $localMachineHelper, bool $printOutput = true): void
+    protected function mockCreateMySqlDumpOnLocal(ObjectProphecy $localMachineHelper, bool $printOutput = true, bool $pv = true): void
     {
         $localMachineHelper->checkRequiredBinariesExist(["mysqldump", "gzip"])
             ->shouldBeCalled();
         $process = $this->mockProcess();
         $process->getOutput()->willReturn('');
-        $command = 'bash -c "set -o pipefail; MYSQL_PWD=drupal mysqldump --host=localhost --user=drupal drupal | pv --rate --bytes | gzip -9 > ' . sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz"';
+        if ($pv) {
+            $command = 'bash -c "set -o pipefail; MYSQL_PWD=drupal mysqldump --host=localhost --user=drupal drupal | pv --rate --bytes | gzip -9 > ' . sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz"';
+        } else {
+            $command = 'bash -c "set -o pipefail; MYSQL_PWD=drupal mysqldump --host=localhost --user=drupal drupal | gzip -9 > ' . sys_get_temp_dir() . '/acli-mysql-dump-drupal.sql.gz"';
+        }
         $localMachineHelper->executeFromCmd($command, Argument::type('callable'), null, $printOutput)
             ->willReturn($process->reveal())
             ->shouldBeCalled();

--- a/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
@@ -26,8 +26,8 @@ class PushDatabaseCommandTest extends CommandTestBase
     public function providerTestPushDatabase(): array
     {
         return [
-            [OutputInterface::VERBOSITY_NORMAL, false],
-            [OutputInterface::VERBOSITY_VERY_VERBOSE, true],
+            [OutputInterface::VERBOSITY_NORMAL, false, false],
+            [OutputInterface::VERBOSITY_VERY_VERBOSE, true, true],
         ];
     }
 
@@ -51,7 +51,7 @@ class PushDatabaseCommandTest extends CommandTestBase
     /**
      * @dataProvider providerTestPushDatabase
      */
-    public function testPushDatabase(int $verbosity, bool $printOutput): void
+    public function testPushDatabase(int $verbosity, bool $printOutput, bool $pv): void
     {
         $applications = $this->mockRequest('getApplications');
         $application = $this->mockRequest('getApplicationByUuid', $applications[self::$INPUT_DEFAULT_CHOICE]->uuid);
@@ -72,8 +72,8 @@ class PushDatabaseCommandTest extends CommandTestBase
         $this->mockGetAcsfSitesLMH($localMachineHelper);
 
         // Database.
-        $this->mockExecutePvExists($localMachineHelper);
-        $this->mockCreateMySqlDumpOnLocal($localMachineHelper, $printOutput);
+        $this->mockExecutePvExists($localMachineHelper, $pv);
+        $this->mockCreateMySqlDumpOnLocal($localMachineHelper, $printOutput, $pv);
         $this->mockUploadDatabaseDump($localMachineHelper, $process, $printOutput);
         $this->mockImportDatabaseDumpOnRemote($localMachineHelper, $process, $printOutput);
 


### PR DESCRIPTION
Turns out we aren't the first ones to have this problem: https://github.com/drush-ops/drush/issues/3816

If Drush does it this way, it's good enough for me! 😄 

Testing steps:
- Set max_allowed_packet extremely low, or import a db with huge row sizes
- Run `push:db -vvv`

Before this PR, see that the push continues past the local dump despite an error about packet size. After this error, see that the push stops with the following exception:
```
In CommandBase.php line 1703:
                                                  
  [Acquia\Cli\Exception\AcquiaCliException]       
  Unable to create a dump of the local database.  
```