### PR TITLE
Example to support / Push to multiple git remotes.

### DIFF
--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -60,7 +60,8 @@ final class PushArtifactCommand extends CommandBase
                 . 'To run additional build or sanitization steps (e.g. <options=bold>npm install</>), add a <options=bold>post-install-cmd</> script to your <options=bold>composer.json</> file: https://getcomposer.org/doc/articles/scripts.md#command-events')
             ->addUsage('--destination-git-branch=main-build')
             ->addUsage('--source-git-tag=foo-build --destination-git-tag=1.0.0')
-            ->addUsage('--destination-git-urls=example@svn-1.prod.hosting.acquia.com:example.git --destination-git-branch=main-build');
+            ->addUsage('--destination-git-urls=example@svn-1.prod.hosting.acquia.com:example.git --destination-git-branch=main-build')
+            ->addUsage('--destination-git-urls=example@svn-1.prod.hosting.acquia.com:example.git --destination-git-urls=example@svn-2.prod.hosting.acquia.com:example.git --destination-git-branch=main-build');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void


### PR DESCRIPTION
I have noticed about the confusion to push / use multiple git remotes the artifact.

This MR is adding an example/usage  in command help for same.

<img width="1391" alt="Screenshot 2024-08-28 at 10 17 34 AM" src="https://github.com/user-attachments/assets/46d945dc-c2ee-4d6b-8d7d-5185f937bf70">

Will this automatic generate / update doc https://docs.acquia.com/acquia-cloud-platform/add-ons/acquia-cli/commands/push:artifact or thats separate?
