### PR TITLE
CLI-1389: Catch datastore validation errors in tests

### DIFF
--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -16,8 +16,6 @@ use Exception;
 use Gitlab\Api\Projects;
 use Gitlab\Api\Users;
 use Gitlab\Exception\RuntimeException;
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Constraint\StringContains;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;

--- a/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
+++ b/tests/phpunit/src/Commands/App/AppOpenCommandTest.php
@@ -30,17 +30,11 @@ class AppOpenCommandTest extends CommandTestBase
         $this->executeCommand(['applicationUuid' => $applicationUuid]);
     }
 
-    /**
-     * @group brokenProphecy
-     */
     public function testAppOpenNoBrowser(): void
     {
-        $applicationUuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
         $localMachineHelper = $this->mockLocalMachineHelper();
         $localMachineHelper->isBrowserAvailable()->willReturn(false);
 
-        $this->mockApplicationRequest();
-        $this->createMockAcliConfigFile($applicationUuid);
         $this->expectException(AcquiaCliException::class);
         $this->expectExceptionMessage('No browser is available on this machine');
         $this->executeCommand();

--- a/tests/phpunit/src/Commands/App/LinkCommandTest.php
+++ b/tests/phpunit/src/Commands/App/LinkCommandTest.php
@@ -43,6 +43,8 @@ class LinkCommandTest extends CommandTestBase
     public function testLinkCommandAlreadyLinked(): void
     {
         $this->createMockAcliConfigFile('a47ac10b-58cc-4372-a567-0e02b2c3d470');
+        $this->createDataStores();
+        $this->command = $this->injectCommand(LinkCommand::class);
         $this->mockApplicationRequest();
         $this->executeCommand();
         $output = $this->getDisplay();

--- a/tests/phpunit/src/Commands/App/UnlinkCommandTest.php
+++ b/tests/phpunit/src/Commands/App/UnlinkCommandTest.php
@@ -29,6 +29,8 @@ class UnlinkCommandTest extends CommandTestBase
         $cloudApplication = $applicationsResponse->{'_embedded'}->items[0];
         $cloudApplicationUuid = $cloudApplication->uuid;
         $this->createMockAcliConfigFile($cloudApplicationUuid);
+        $this->createDataStores();
+        $this->command = $this->injectCommand(UnlinkCommand::class);
         $this->mockApplicationRequest();
 
         // Assert we set it correctly.

--- a/tests/phpunit/src/Commands/CommandBaseTest.php
+++ b/tests/phpunit/src/Commands/CommandBaseTest.php
@@ -41,9 +41,10 @@ class CommandBaseTest extends CommandTestBase
 
     public function testCloudAppFromLocalConfig(): void
     {
-        $this->command = $this->injectCommand(IdeListCommand::class);
         $this->mockRequest('getApplicationIdes', 'a47ac10b-58cc-4372-a567-0e02b2c3d470');
         $this->createMockAcliConfigFile('a47ac10b-58cc-4372-a567-0e02b2c3d470');
+        $this->createDataStores();
+        $this->command = $this->injectCommand(IdeListCommand::class);
         $this->executeCommand();
     }
 

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -122,12 +122,15 @@ class PushArtifactCommandTest extends PullCommandTestBase
 
     public function testPushArtifactWithAcquiaCliFile(): void
     {
-        $this->datastoreAcli->set('push.artifact.destination_git_urls', [
+        $destinationGitUrls = [
             'https://github.com/example1/cli.git',
             'https://github.com/example2/cli.git',
-        ]);
+        ];
+        $this->createMockAcliConfigFile(['push' => ['artifact' => ['destination_git_urls' => $destinationGitUrls],],]);
+        $this->createDataStores();
+        $this->command = $this->injectCommand(PushArtifactCommand::class);
         $localMachineHelper = $this->mockLocalMachineHelper();
-        $this->setUpPushArtifact($localMachineHelper, 'master', $this->datastoreAcli->get('push.artifact.destination_git_urls'));
+        $this->setUpPushArtifact($localMachineHelper, 'master', $destinationGitUrls);
         $this->executeCommand([
             '--destination-git-branch' => 'master',
         ]);

--- a/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
@@ -77,6 +77,8 @@ class AliasesDownloadCommandTest extends CommandTestBase
             $cloudApplication = $applicationsResponse->{'_embedded'}->items[0];
             $cloudApplicationUuid = $cloudApplication->uuid;
             $this->createMockAcliConfigFile($cloudApplicationUuid);
+            $this->createDataStores();
+            $this->command = $this->injectCommand(AliasesDownloadCommand::class);
             $this->mockApplicationRequest();
         }
 

--- a/tests/phpunit/src/Commands/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/TelemetryCommandTest.php
@@ -68,8 +68,7 @@ class TelemetryCommandTest extends CommandTestBase
      */
     public function testTelemetryPrompt(array $inputs, mixed $message): void
     {
-        $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => null];
-        $this->createMockConfigFiles();
+        $this->createMockCloudConfigFile([DataStoreContract::SEND_TELEMETRY => null]);
         $this->createMockAcliConfigFile('a47ac10b-58cc-4372-a567-0e02b2c3d470');
         $this->createDataStores();
         $this->mockApplicationRequest();
@@ -86,8 +85,6 @@ class TelemetryCommandTest extends CommandTestBase
      */
     public function testAmplitudeDisabled(): void
     {
-        $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => false];
-        $this->createMockConfigFiles();
         $this->executeCommand();
 
         $this->assertEquals(0, $this->getStatusCode());
@@ -95,8 +92,7 @@ class TelemetryCommandTest extends CommandTestBase
 
     public function testMigrateLegacyTelemetryPreference(): void
     {
-        $this->cloudConfig = [DataStoreContract::SEND_TELEMETRY => null];
-        $this->createMockConfigFiles();
+        $this->createMockCloudConfigFile([DataStoreContract::SEND_TELEMETRY => null]);
         $this->fs->remove($this->legacyAcliConfigFilepath);
         $legacyAcliConfig = ['send_telemetry' => false];
         $contents = json_encode($legacyAcliConfig);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -69,16 +69,6 @@ abstract class TestBase extends TestCase
 
     protected Client|ObjectProphecy $clientProphecy;
 
-    /**
-     * @var array<mixed>
-     */
-    protected array $acliConfig = [];
-
-    /**
-     * @var array<mixed>
-     */
-    protected array $cloudConfig = [];
-
     protected string $key = '17feaf34-5d04-402b-9a67-15d5161d24e1';
 
     protected string $secret = 'X1u\/PIQXtYaoeui.4RJSJpGZjwmWYmfl5AUQkAebYE=';
@@ -425,18 +415,13 @@ abstract class TestBase extends TestCase
     protected function createMockConfigFiles(): void
     {
         $this->createMockCloudConfigFile();
-
-        $defaultValues = [];
-        $acliConfig = array_merge($defaultValues, $this->acliConfig);
-        $contents = json_encode($acliConfig, JSON_THROW_ON_ERROR);
-        $filepath = $this->acliConfigFilepath;
-        $this->fs->dumpFile($filepath, $contents);
+        $this->createMockAcliConfigFile();
     }
 
-    protected function createMockCloudConfigFile(mixed $defaultValues = []): void
+    protected function createMockCloudConfigFile(mixed $cloudConfig = []): void
     {
-        if (!$defaultValues) {
-            $defaultValues = [
+        if (!$cloudConfig) {
+            $cloudConfig = [
                 'acli_key' => $this->key,
                 'keys' => [
                     (string) ($this->key) => [
@@ -448,15 +433,20 @@ abstract class TestBase extends TestCase
                 DataStoreContract::SEND_TELEMETRY => false,
             ];
         }
-        $cloudConfig = array_merge($defaultValues, $this->cloudConfig);
         $contents = json_encode($cloudConfig, JSON_THROW_ON_ERROR);
         $filepath = $this->cloudConfigFilepath;
         $this->fs->dumpFile($filepath, $contents);
     }
 
-    protected function createMockAcliConfigFile(string $cloudAppUuid): void
+    protected function createMockAcliConfigFile(mixed $cloudAppUuid = null): void
     {
-        $this->datastoreAcli->set('cloud_app_uuid', $cloudAppUuid);
+        $acliConfig = [];
+        if (is_string($cloudAppUuid)) {
+            $acliConfig['cloud_app_uuid'] = $cloudAppUuid;
+        } elseif (is_array($cloudAppUuid)) {
+            $acliConfig = $cloudAppUuid;
+        }
+        $this->fs->dumpFile($this->acliConfigFilepath, json_encode($acliConfig, JSON_THROW_ON_ERROR));
     }
 
     /**


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1389

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Improve tests to catch validation errors in datastores to prevent regressions like CLI-1389

Calling set() on a keystore doesn't trigger validation. Validation only occurs when the contents of the datastore file are loaded from disk. So test cases should never use set() for configuring a test fixture, but rather write the file and reload the command/datastore.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3.  Change destination_git_urls to destination-git-urls (i.e., revert #1789)
4. See that tests fail
