### PR TITLE
CLI-1397: Exception on local non-RSA SSH keys

### DIFF
--- a/src/Command/Ssh/SshKeyCommandBase.php
+++ b/src/Command/Ssh/SshKeyCommandBase.php
@@ -420,9 +420,6 @@ EOT
 
     protected static function getFingerprint(mixed $sshPublicKey): string
     {
-        if (!str_starts_with($sshPublicKey, 'ssh-rsa ')) {
-            throw new AcquiaCliException('SSH keys must start with "ssh-rsa ".');
-        }
         $content = explode(' ', $sshPublicKey, 3);
         return base64_encode(hash('sha256', base64_decode($content[1]), true));
     }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1397

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Remove the check for RSA keys

It looks like this was added in #1501 because we simply copied the code from the upstream library: https://github.com/violuke/rsa-ssh-key-fingerprint/blob/master/src/violuke/RsaSshKeyFingerprint/FingerprintGenerator.php

But I can't see any reason to restrict that code to RSA keys. You can run sha256 on any key 🤷 

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
