### PR TITLE
CLI-1405: LocalMachineHelperTest::testExecuteFromCmd failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-22.04']
         php: ['8.1', '8.2', '8.3']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: ['ubuntu-22.04']
         php: ['8.1', '8.2', '8.3']

--- a/tests/phpunit/src/Misc/ChecklistTest.php
+++ b/tests/phpunit/src/Misc/ChecklistTest.php
@@ -23,6 +23,9 @@ class ChecklistTest extends TestBase
         $this->output = new ConsoleOutput();
     }
 
+    /**
+     * @group serial
+     */
     public function testSpinner(): void
     {
         putenv('PHPUNIT_RUNNING=1');

--- a/tests/phpunit/src/Misc/LocalMachineHelperTest.php
+++ b/tests/phpunit/src/Misc/LocalMachineHelperTest.php
@@ -21,16 +21,34 @@ class LocalMachineHelperTest extends TestBase
     }
 
     /**
-     * @group serial
+     * @return bool[][]
      */
-    public function testExecuteFromCmd(): void
+    public function providerTestExecuteFromCmd(): array
+    {
+        return [
+            [false, null, null],
+            [false, false, false],
+            [true, false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider providerTestExecuteFromCmd()
+     */
+    public function testExecuteFromCmd(bool $interactive, bool|null $isTty, bool|null $printOutput): void
     {
         $localMachineHelper = $this->localMachineHelper;
-        $process = $localMachineHelper->executeFromCmd('echo "hello world"');
+        $localMachineHelper->setIsTty($isTty);
+        $this->input->setInteractive($interactive);
+        $process = $localMachineHelper->executeFromCmd('echo "hello world"', null, null, $printOutput);
         $this->assertTrue($process->isSuccessful());
         assert(is_a($this->output, BufferedOutput::class));
         $buffer = $this->output->fetch();
-        $this->assertStringContainsString("hello world", $buffer);
+        if ($printOutput === false) {
+            $this->assertEmpty($buffer);
+        } else {
+            $this->assertStringContainsString("hello world", $buffer);
+        }
     }
 
     public function testExecuteWithCwd(): void

--- a/tests/phpunit/src/Misc/LocalMachineHelperTest.php
+++ b/tests/phpunit/src/Misc/LocalMachineHelperTest.php
@@ -20,6 +20,9 @@ class LocalMachineHelperTest extends TestBase
         putenv('DISPLAY');
     }
 
+    /**
+     * @group serial
+     */
     public function testExecuteFromCmd(): void
     {
         $localMachineHelper = $this->localMachineHelper;

--- a/tests/phpunit/src/Misc/LocalMachineHelperTest.php
+++ b/tests/phpunit/src/Misc/LocalMachineHelperTest.php
@@ -20,35 +20,14 @@ class LocalMachineHelperTest extends TestBase
         putenv('DISPLAY');
     }
 
-    /**
-     * @return bool[][]
-     */
-    public function providerTestExecuteFromCmd(): array
-    {
-        return [
-            [false, null, null],
-            [false, false, false],
-            [true, false, false],
-        ];
-    }
-
-    /**
-     * @dataProvider providerTestExecuteFromCmd()
-     */
-    public function testExecuteFromCmd(bool $interactive, bool|null $isTty, bool|null $printOutput): void
+    public function testExecuteFromCmd(): void
     {
         $localMachineHelper = $this->localMachineHelper;
-        $localMachineHelper->setIsTty($isTty);
-        $this->input->setInteractive($interactive);
-        $process = $localMachineHelper->executeFromCmd('echo "hello world"', null, null, $printOutput);
+        $process = $localMachineHelper->executeFromCmd('echo "hello world"');
         $this->assertTrue($process->isSuccessful());
         assert(is_a($this->output, BufferedOutput::class));
         $buffer = $this->output->fetch();
-        if ($printOutput === false) {
-            $this->assertEmpty($buffer);
-        } else {
-            $this->assertStringContainsString("hello world", $buffer);
-        }
+        $this->assertStringContainsString("hello world", $buffer);
     }
 
     public function testExecuteWithCwd(): void

--- a/tests/phpunit/src/Misc/LocalMachineHelperTest.php
+++ b/tests/phpunit/src/Misc/LocalMachineHelperTest.php
@@ -34,6 +34,7 @@ class LocalMachineHelperTest extends TestBase
 
     /**
      * @dataProvider providerTestExecuteFromCmd()
+     * @group serial
      */
     public function testExecuteFromCmd(bool $interactive, bool|null $isTty, bool|null $printOutput): void
     {


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
These tests fail frequently in CI, and only in PHP 8.3. No idea why... possibly a race condition, or i/o issues, or an issue caused by paratest.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Run these tests in serial.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
