### PR TITLE
CLI-1410: self:info command

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -761,17 +761,19 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
         return null;
     }
 
-    protected function createTable(OutputInterface $output, string $title, array $headers, mixed $widths): Table
+    protected function createTable(OutputInterface $output, string $title, array $headers, ?array $widths = null): Table
     {
         $terminalWidth = (new Terminal())->getWidth();
         $terminalWidth *= .90;
         $table = new Table($output);
         $table->setHeaders($headers);
         $table->setHeaderTitle($title);
-        $setWidths = static function (mixed $width) use ($terminalWidth) {
-            return (int) ($terminalWidth * $width);
-        };
-        $table->setColumnWidths(array_map($setWidths, $widths));
+        if ($widths !== null) {
+            $setWidths = static function (float $width) use ($terminalWidth) {
+                return (int) ($terminalWidth * $width);
+            };
+            $table->setColumnWidths(array_map($setWidths, $widths));
+        }
         return $table;
     }
 

--- a/src/Command/Self/SelfInfoCommand.php
+++ b/src/Command/Self/SelfInfoCommand.php
@@ -11,9 +11,9 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'self:status')]
+#[AsCommand(name: 'self:info', description: 'Print information about the running version of Acquia CLI')]
 
-final class SelfStatusCommand extends CommandBase
+final class SelfInfoCommand extends CommandBase
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/src/Command/Self/SelfInfoCommand.php
+++ b/src/Command/Self/SelfInfoCommand.php
@@ -17,9 +17,7 @@ final class SelfInfoCommand extends CommandBase
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $table = new Table($output);
-        $table->setStyle('borderless');
-        $table->setHeaders(['Property', 'Value']);
+        $table = $this->createTable($output, 'Acquia CLI information', ['Property', 'Value']);
         $table->addRow(['Version', $this->getApplication()->getVersion()]);
         $table->addRow(['Cloud datastore', $this->datastoreCloud->filepath]);
         $table->addRow(['ACLI datastore', $this->datastoreAcli->filepath]);

--- a/src/Command/Self/SelfStatusCommand.php
+++ b/src/Command/Self/SelfStatusCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Cli\Command\Self;
+
+use Acquia\Cli\Command\CommandBase;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'self:status')]
+
+final class SelfStatusCommand extends CommandBase
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $table = new Table($output);
+        $table->setStyle('borderless');
+        $table->setHeaders(['Property', 'Value']);
+        $table->addRow(['Version', $this->getApplication()->getVersion()]);
+        $table->addRow(['Cloud datastore', $this->datastoreCloud->filepath]);
+        $table->addRow(['ACLI datastore', $this->datastoreAcli->filepath]);
+        $table->addRow(['Telemetry enabled', var_export($this->telemetryHelper->telemetryEnabled(), true)]);
+        $table->addRow(['User ID', $this->telemetryHelper->getUserId()]);
+        foreach ($this->telemetryHelper->getTelemetryUserData() as $key => $value) {
+            $table->addRow([$key, $value]);
+        }
+        $table->render();
+        return Command::SUCCESS;
+    }
+}

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -39,8 +39,7 @@ class TelemetryHelper
         if (empty($this->bugSnagKey)) {
             return;
         }
-        $sendTelemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
-        if ($sendTelemetry === false) {
+        if (!$this->telemetryEnabled()) {
             return;
         }
         // It's safe-ish to make this key public.
@@ -89,11 +88,10 @@ class TelemetryHelper
         if (empty($this->amplitudeKey)) {
             return;
         }
-        $sendTelemetry = $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
         $amplitude = Amplitude::getInstance();
-        $amplitude->setOptOut($sendTelemetry === false);
+        $amplitude->setOptOut($this->telemetryEnabled());
 
-        if ($sendTelemetry === false) {
+        if (!$this->telemetryEnabled()) {
             return;
         }
         try {
@@ -107,6 +105,11 @@ class TelemetryHelper
         } catch (IdentityProviderException $e) {
             // If something is wrong with the Cloud API client, don't bother users.
         }
+    }
+
+    public function telemetryEnabled(): bool
+    {
+        return (bool) $this->datastoreCloud->get(DataStoreContract::SEND_TELEMETRY);
     }
 
     /**
@@ -140,7 +143,7 @@ class TelemetryHelper
      *
      * @return array<mixed> Telemetry user data.
      */
-    private function getTelemetryUserData(): array
+    public function getTelemetryUserData(): array
     {
         $data = [
             'ah_app_uuid' => getenv('AH_APPLICATION_UUID'),
@@ -179,7 +182,7 @@ class TelemetryHelper
         return null;
     }
 
-    private function getUserId(): ?string
+    public function getUserId(): ?string
     {
         $user = $this->getUserData();
         if ($user && isset($user['uuid'])) {

--- a/tests/phpunit/src/Application/KernelTest.php
+++ b/tests/phpunit/src/Application/KernelTest.php
@@ -105,6 +105,7 @@ EOD;
   remote:ssh               [ssh] Use SSH to open a shell or run a command in a Cloud Platform environment
  self
   self:clear-caches        [cc|cr] Clears local Acquia CLI caches
+  self:info                Print information about the running version of Acquia CLI
   self:telemetry:disable   [telemetry:disable] Disable anonymous sharing of usage and performance data
   self:telemetry:enable    [telemetry:enable] Enable anonymous sharing of usage and performance data
   self:telemetry:toggle    [telemetry] Toggle anonymous sharing of usage and performance data

--- a/tests/phpunit/src/Commands/Self/ClearCacheCommandTest.php
+++ b/tests/phpunit/src/Commands/Self/ClearCacheCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Acquia\Cli\Tests\Commands;
+namespace Acquia\Cli\Tests\Commands\Self;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ide\IdeListCommand;

--- a/tests/phpunit/src/Commands/Self/SelfInfoCommandTest.php
+++ b/tests/phpunit/src/Commands/Self/SelfInfoCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Cli\Tests\Commands\Self;
+
+use Acquia\Cli\Command\CommandBase;
+use Acquia\Cli\Command\Self\SelfInfoCommand;
+use Acquia\Cli\Tests\CommandTestBase;
+
+/**
+ * @property \Acquia\Cli\Command\Self\SelfInfoCommand $command
+ */
+class SelfInfoCommandTest extends CommandTestBase
+{
+    protected function createCommand(): CommandBase
+    {
+        return $this->injectCommand(SelfInfoCommand::class);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testSelfInfoCommand(): void
+    {
+        $this->mockRequest('getAccount');
+        $this->executeCommand();
+        $output = $this->getDisplay();
+        $this->assertStringContainsString('Property', $output);
+        $this->assertStringContainsString('--------', $output);
+        $this->assertStringContainsString('Version', $output);
+        $this->assertStringContainsString('Cloud datastore', $output);
+        $this->assertStringContainsString('ACLI datastore', $output);
+        $this->assertStringContainsString('Telemetry enabled', $output);
+        $this->assertStringContainsString('User ID', $output);
+    }
+}

--- a/tests/phpunit/src/Commands/Self/SelfInfoCommandTest.php
+++ b/tests/phpunit/src/Commands/Self/SelfInfoCommandTest.php
@@ -33,5 +33,6 @@ class SelfInfoCommandTest extends CommandTestBase
         $this->assertStringContainsString('ACLI datastore', $output);
         $this->assertStringContainsString('Telemetry enabled', $output);
         $this->assertStringContainsString('User ID', $output);
+        $this->assertStringContainsString('is_acquian', $output);
     }
 }

--- a/tests/phpunit/src/Commands/Self/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/Self/TelemetryCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Acquia\Cli\Tests\Commands;
+namespace Acquia\Cli\Tests\Commands\Self;
 
 use Acquia\Cli\Command\App\LinkCommand;
 use Acquia\Cli\Command\CommandBase;

--- a/tests/phpunit/src/Commands/Self/TelemetryDisableCommandTest.php
+++ b/tests/phpunit/src/Commands/Self/TelemetryDisableCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Acquia\Cli\Tests\Commands;
+namespace Acquia\Cli\Tests\Commands\Self;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Self\TelemetryDisableCommand;

--- a/tests/phpunit/src/Commands/Self/TelemetryEnableCommandTest.php
+++ b/tests/phpunit/src/Commands/Self/TelemetryEnableCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Acquia\Cli\Tests\Commands;
+namespace Acquia\Cli\Tests\Commands\Self;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Self\TelemetryEnableCommand;


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1410

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Add a `self:info` command to provide debugging information for support tickets

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Provide debugging info inline with individual commands when running with `-vvv`. This could be unnecessarily verbose or expose mildly sensitive information, but would save customers an extra step. Most modern applications have a standalone command for generating debug logs and reports though.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
