### PR TITLE
CLI-1413: Set PHP compatibility level

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.xml.dist]
+indent_size = 2

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -24,8 +24,12 @@
 
   <rule ref="AcquiaPHPStrict">
     <exclude name="Generic.Files.LineLength"/>
+    <exclude name="PHPCompatibility"/>
   </rule>
-
+  <config name="testVersion" value="8.2-"/>
+  <rule ref="PHPCompatibility">
+    <exclude name="PHPCompatibility.Extensions.RemovedExtensions.famRemoved"/>
+  </rule>
     <rule ref="Generic.PHP.ForbiddenFunctions">
     <properties>
       <property name="forbiddenFunctions" type="array">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,7 +30,8 @@
   <rule ref="PHPCompatibility">
     <exclude name="PHPCompatibility.Extensions.RemovedExtensions.famRemoved"/>
   </rule>
-    <rule ref="Generic.PHP.ForbiddenFunctions">
+
+  <rule ref="Generic.PHP.ForbiddenFunctions">
     <properties>
       <property name="forbiddenFunctions" type="array">
         <element key="echo" value="$output->writeln"/>


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1413

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Set compatibility level according to https://github.com/acquia/coding-standards-php/pull/37

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
