### PR TITLE
GL-3083: updated default php version to 8.3 for cs-wizard command

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -56,7 +56,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase
                     'PHP_version_8.2' => "8.2",
                     'PHP_version_8.3' => "8.3",
                 ];
-                $project = $this->io->choice('Select a PHP version', array_values($phpVersions), "8.1");
+                $project = $this->io->choice('Select a PHP version', array_values($phpVersions), "8.3");
                 $project = array_search($project, $phpVersions, true);
                 $phpVersion = $phpVersions[$project];
                 break;

--- a/src/Helpers/TelemetryHelper.php
+++ b/src/Helpers/TelemetryHelper.php
@@ -56,6 +56,8 @@ class TelemetryHelper
                 case str_starts_with($report->getMessage(), 'Allowed memory size'):
                     // Exclude i/o errors.
                 case str_starts_with($report->getMessage(), 'fgets'):
+                    // Exclude exhausted disk space.
+                case str_starts_with($report->getMessage(), 'fwrite'):
                     return false;
             }
             // Set user info.


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
[GL-3083](https://acquia.atlassian.net/browse/GL-3083)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
The default version on PHP while running the cs-wizard command is now updated to 8.3 


**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Following steps can be taken to verify the changes:
- Run the following command `acli cs:wizard`.
- Please enter Cloud Key and Secret to login
- Select the type of project as Drupal
- In the PHP version select step the default value will be 8.3
