### PR TITLE
GL-3134: Add new Gitlab variable for Node projects.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -18,7 +18,7 @@ class CodeStudioCiCdVariables
     /**
      * @return array<mixed>
      */
-    public static function getDefaultsForNode(?string $cloudApplicationUuid = null, ?string $cloudKey = null, ?string $cloudSecret = null, ?string $projectAccessTokenName = null, ?string $projectAccessToken = null, ?string $nodeVersion = null): array
+    public static function getDefaultsForNode(?string $cloudApplicationUuid = null, ?string $cloudKey = null, ?string $cloudSecret = null, ?string $projectAccessTokenName = null, ?string $projectAccessToken = null, ?string $nodeVersion = null, ?string $nodeHosting = null): array
     {
         return [
             [
@@ -61,6 +61,13 @@ class CodeStudioCiCdVariables
                 'masked' => false,
                 'protected' => false,
                 'value' => $nodeVersion,
+                'variable_type' => 'env_var',
+            ],
+            [
+                'key' => 'NODE_HOSTING_TYPE',
+                'masked' => false,
+                'protected' => false,
+                'value' => $nodeHosting,
                 'variable_type' => 'env_var',
             ],
         ];

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -48,6 +48,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase
         $nodeVersion = null;
         $projectType = $this->getListOfProjectType();
         $projectSelected = $this->io->choice('Select a project type', $projectType, "Drupal_project");
+        $nodeHosting = "basic";
 
         switch ($projectSelected) {
             case "Drupal_project":
@@ -128,7 +129,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase
                 ];
                 $client = $this->getGitLabClient();
                 $client->projects()->update($project['id'], $parameters);
-                $this->setGitLabCiCdVariablesForNodeProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion);
+                $this->setGitLabCiCdVariablesForNodeProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion, $nodeHosting);
                 break;
         }
 
@@ -241,10 +242,10 @@ final class CodeStudioWizardCommand extends WizardCommandBase
         }
     }
 
-    private function setGitLabCiCdVariablesForNodeProject(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken, string $nodeVersion): void
+    private function setGitLabCiCdVariablesForNodeProject(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken, string $nodeVersion, string $nodeHosting): void
     {
         $this->io->writeln("Setting GitLab CI/CD variables for {$project['path_with_namespace']}..");
-        $gitlabCicdVariables = CodeStudioCiCdVariables::getDefaultsForNode($cloudApplicationUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion);
+        $gitlabCicdVariables = CodeStudioCiCdVariables::getDefaultsForNode($cloudApplicationUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion, $nodeHosting);
         $gitlabCicdExistingVariables = $this->gitLabClient->projects()
             ->variables($project['id']);
         $gitlabCicdExistingVariablesKeyed = [];

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioCiCdVariablesTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioCiCdVariablesTest.php
@@ -21,7 +21,7 @@ class CodeStudioCiCdVariablesTest extends TestBase
     protected function testBooleanValues(array $variables): void
     {
         foreach ($variables as $variable) {
-            if ($variable['key'] !== "PHP_VERSION" && $variable['key'] !== "NODE_VERSION") {
+            if ($variable['key'] !== "PHP_VERSION" && $variable['key'] !== "NODE_VERSION" && $variable['key'] !== "NODE_HOSTING_TYPE") {
                 $maskedValue = $variable['masked'];
                 $this->assertEquals(true, $maskedValue);
             } else {


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes [GL-3134](https://acquia.atlassian.net/browse/GL-3134)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
New Node.js projects created in Code Studio pass a new variable of `NODE_HOSTING_TYPE` with a default value of `basic`. When Node V3 launches, we will update the user prompts to ask for a Node hosting type.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
N/A

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Run `acli cs:wizard --gitlab-host-name=code.dev.cloudservices.acquia.io` (or other env as needed)
4. Select prompts for a Node.js application
5. Confirm you do not see a prompt for Node hosting type
6. When the project is created in Gitlab, an environment variable should exist for `NODE_HOSTING_TYPE` with a value of `basic`. Variable should not be protected or masked.
