### PR TITLE
CLI-1423: PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "require-dev": {
         "acquia/coding-standards": "^3.0.1",
-        "brianium/paratest": "^6.6",
+        "brianium/paratest": "^7",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
         "dominikb/composer-license-checker": "^2.4",
         "infection/infection": "^0.27.7",
@@ -66,7 +66,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpunit/phpunit": "^9.1",
+        "phpunit/phpunit": "10.5.31",
         "slevomat/coding-standard": "^8.10",
         "squizlabs/php_codesniffer": "^3.5",
         "twig/twig": "^3.3"
@@ -140,7 +140,7 @@
             "@unit-serial",
             "@unit-parallel"
         ],
-        "unit-serial": "phpunit tests/phpunit -vvv --group serial",
+        "unit-serial": "phpunit tests/phpunit --group serial",
         "unit-parallel": "paratest --exclude-group serial",
         "coverage": "php -d pcov.enabled=1 vendor/bin/phpunit tests/phpunit --coverage-clover var/logs/clover.xml",
         "lint": "phplint",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "beac6fb88c2275980a5ce7b23a9d6173",
+    "content-hash": "a3c7bb3d8326557ccbc5348841a996e2",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -827,16 +827,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8"
+                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
-                "reference": "6ea8dd08867a2a42619d65c3deb2c0fcbf81c8f8",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
+                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
                 "shasum": ""
             },
             "require": {
@@ -890,7 +890,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.3"
+                "source": "https://github.com/guzzle/promises/tree/2.0.4"
             },
             "funding": [
                 {
@@ -906,7 +906,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-18T10:29:17+00:00"
+            "time": "2024-10-17T10:06:22+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -7428,16 +7428,16 @@
         },
         {
             "name": "brianium/paratest",
-            "version": "v6.11.1",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "78e297a969049ca7cc370e80ff5e102921ef39a3"
+                "reference": "551f46f52a93177d873f3be08a1649ae886b4a30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/78e297a969049ca7cc370e80ff5e102921ef39a3",
-                "reference": "78e297a969049ca7cc370e80ff5e102921ef39a3",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/551f46f52a93177d873f3be08a1649ae886b4a30",
+                "reference": "551f46f52a93177d873f3be08a1649ae886b4a30",
                 "shasum": ""
             },
             "require": {
@@ -7445,25 +7445,28 @@
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-simplexml": "*",
-                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
+                "fidry/cpu-core-counter": "^0.5.1 || ^1.0.0",
                 "jean85/pretty-package-versions": "^2.0.5",
-                "php": "^7.3 || ^8.0",
-                "phpunit/php-code-coverage": "^9.2.25",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-timer": "^5.0.3",
-                "phpunit/phpunit": "^9.6.4",
-                "sebastian/environment": "^5.1.5",
-                "symfony/console": "^5.4.28 || ^6.3.4 || ^7.0.0",
-                "symfony/process": "^5.4.28 || ^6.3.4 || ^7.0.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "phpunit/php-code-coverage": "^10.1.7",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-timer": "^6.0",
+                "phpunit/phpunit": "^10.4.2",
+                "sebastian/environment": "^6.0.1",
+                "symfony/console": "^6.3.4 || ^7.0.0",
+                "symfony/process": "^6.3.4 || ^7.0.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^12.0.0",
                 "ext-pcov": "*",
                 "ext-posix": "*",
                 "infection/infection": "^0.27.6",
+                "phpstan/phpstan": "^1.10.40",
+                "phpstan/phpstan-deprecation-rules": "^1.1.4",
+                "phpstan/phpstan-phpunit": "^1.3.15",
+                "phpstan/phpstan-strict-rules": "^1.5.2",
                 "squizlabs/php_codesniffer": "^3.7.2",
-                "symfony/filesystem": "^5.4.25 || ^6.3.1 || ^7.0.0",
-                "vimeo/psalm": "^5.7.7"
+                "symfony/filesystem": "^6.3.1 || ^7.0.0"
             },
             "bin": [
                 "bin/paratest",
@@ -7504,7 +7507,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v6.11.1"
+                "source": "https://github.com/paratestphp/paratest/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -7516,7 +7519,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2024-03-13T06:54:29+00:00"
+            "time": "2023-10-31T09:24:17+00:00"
         },
         {
             "name": "colinodell/json5",
@@ -10752,16 +10755,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
@@ -10769,18 +10772,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -10789,7 +10792,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -10818,7 +10821,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
             },
             "funding": [
                 {
@@ -10826,32 +10829,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -10878,7 +10881,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -10886,28 +10890,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -10915,7 +10919,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -10941,7 +10945,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -10949,32 +10953,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -11000,7 +11004,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -11008,32 +11013,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -11059,7 +11064,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -11067,24 +11072,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.21",
+            "version": "10.5.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
+                "reference": "43e7c3e6a484e538453f89dfa6a6f308c32792da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/43e7c3e6a484e538453f89dfa6a6f308c32792da",
+                "reference": "43e7c3e6a484e538453f89dfa6a6f308c32792da",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -11094,27 +11098,26 @@
                 "myclabs/deep-copy": "^1.12.0",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.2",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.2",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.0",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -11122,7 +11125,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -11154,7 +11157,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.31"
             },
             "funding": [
                 {
@@ -11170,7 +11173,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T10:50:18+00:00"
+            "time": "2024-09-03T11:57:55+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -11426,28 +11429,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -11470,7 +11473,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -11478,32 +11482,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:27:43+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -11526,7 +11530,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -11534,32 +11538,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -11581,7 +11585,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -11589,34 +11593,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -11655,7 +11661,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
             },
             "funding": [
                 {
@@ -11663,33 +11670,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2024-10-18T14:56:07+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -11712,7 +11719,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -11720,33 +11728,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -11778,7 +11786,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -11786,27 +11795,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -11814,7 +11823,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -11833,7 +11842,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -11841,7 +11850,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
             },
             "funding": [
                 {
@@ -11849,34 +11859,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -11918,7 +11928,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
             },
             "funding": [
                 {
@@ -11926,38 +11937,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2024-03-02T07:17:12+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -11976,13 +11984,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
@@ -11990,33 +11999,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -12039,7 +12048,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -12047,34 +12057,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -12096,7 +12106,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -12104,32 +12114,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -12151,7 +12161,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -12159,32 +12169,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -12214,7 +12224,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -12222,86 +12232,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -12324,7 +12280,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -12332,29 +12288,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -12377,7 +12333,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -12385,7 +12341,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -13244,14 +13200,14 @@
         }
     ],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.25"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,19 @@
 <?xml version="1.0"?>
 <!-- phpunit.xml.dist -->
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        cacheResultFile="var/.phpunit.result.cache"
-        failOnWarning="true"
-        failOnRisky="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        convertDeprecationsToExceptions="true"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" failOnWarning="true" failOnRisky="true" cacheDirectory="var">
   <php>
     <env name="AMPLITUDE_KEY" value=""/>
     <env name="BUGSNAG_KEY" value=""/>
   </php>
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </coverage>
   <testsuites>
     <testsuite name="Acquia CLI Test Suite">
       <directory>tests/phpunit</directory>
     </testsuite>
   </testsuites>
   <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
+++ b/tests/phpunit/src/AcsfApi/AcsfServiceTest.php
@@ -21,7 +21,7 @@ class AcsfServiceTest extends TestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestIsMachineAuthenticated(): array
+    public static function providerTestIsMachineAuthenticated(): array
     {
         return [
             [

--- a/tests/phpunit/src/AcsfApi/EnvVarAcsfAuthenticationTest.php
+++ b/tests/phpunit/src/AcsfApi/EnvVarAcsfAuthenticationTest.php
@@ -9,15 +9,15 @@ use Acquia\Cli\Tests\TestBase;
 
 class EnvVarAcsfAuthenticationTest extends TestBase
 {
-    private string $acsfCurrentFactoryUrl = 'https://www.test-something.com';
+    private static string $acsfCurrentFactoryUrl = 'https://www.test-something.com';
 
     public function setUp(mixed $output = null): void
     {
         parent::setUp();
         $this->cloudCredentials = new AcsfCredentials($this->datastoreCloud);
-        putenv('ACSF_USERNAME=' . $this->key);
-        putenv('ACSF_KEY=' . $this->secret);
-        putenv('ACSF_FACTORY_URI=' . $this->acsfCurrentFactoryUrl);
+        putenv('ACSF_USERNAME=' . self::$key);
+        putenv('ACSF_KEY=' . self::$secret);
+        putenv('ACSF_FACTORY_URI=' . self::$acsfCurrentFactoryUrl);
     }
 
     protected function tearDown(): void
@@ -30,8 +30,8 @@ class EnvVarAcsfAuthenticationTest extends TestBase
     public function testKeyAndSecret(): void
     {
         $this->removeMockCloudConfigFile();
-        self::assertEquals($this->key, $this->cloudCredentials->getCloudKey());
-        self::assertEquals($this->secret, $this->cloudCredentials->getCloudSecret());
-        self::assertEquals($this->acsfCurrentFactoryUrl, $this->cloudCredentials->getBaseUri());
+        self::assertEquals(self::$key, $this->cloudCredentials->getCloudKey());
+        self::assertEquals(self::$secret, $this->cloudCredentials->getCloudSecret());
+        self::assertEquals(self::$acsfCurrentFactoryUrl, $this->cloudCredentials->getBaseUri());
     }
 }

--- a/tests/phpunit/src/CloudApi/AcsfClientServiceTest.php
+++ b/tests/phpunit/src/CloudApi/AcsfClientServiceTest.php
@@ -14,14 +14,14 @@ use GuzzleHttp\Psr7\Response;
 
 class AcsfClientServiceTest extends TestBase
 {
-    protected string $apiSpecFixtureFilePath = __DIR__ . '/../../../../assets/acsf-spec.json';
+    protected static string $apiSpecFixtureFilePath = __DIR__ . '/../../../../assets/acsf-spec.json';
 
     protected string $apiCommandPrefix = 'acsf';
 
     /**
      * @return array<mixed>
      */
-    public function providerTestIsMachineAuthenticated(): array
+    public static function providerTestIsMachineAuthenticated(): array
     {
         return [
             [

--- a/tests/phpunit/src/CloudApi/ClientServiceTest.php
+++ b/tests/phpunit/src/CloudApi/ClientServiceTest.php
@@ -15,7 +15,7 @@ class ClientServiceTest extends TestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestIsMachineAuthenticated(): array
+    public static function providerTestIsMachineAuthenticated(): array
     {
         return [
             [

--- a/tests/phpunit/src/CloudApi/EnvVarAuthenticationTest.php
+++ b/tests/phpunit/src/CloudApi/EnvVarAuthenticationTest.php
@@ -13,8 +13,8 @@ class EnvVarAuthenticationTest extends TestBase
     public function setUp(mixed $output = null): void
     {
         parent::setUp();
-        putenv('ACLI_KEY=' . $this->key);
-        putenv('ACLI_SECRET=' . $this->secret);
+        putenv('ACLI_KEY=' . self::$key);
+        putenv('ACLI_SECRET=' . self::$secret);
         putenv('ACLI_CLOUD_API_BASE_URI=' . $this->cloudApiBaseUri);
     }
 
@@ -28,8 +28,8 @@ class EnvVarAuthenticationTest extends TestBase
     public function testKeyAndSecret(): void
     {
         $this->removeMockCloudConfigFile();
-        self::assertEquals($this->key, $this->cloudCredentials->getCloudKey());
-        self::assertEquals($this->secret, $this->cloudCredentials->getCloudSecret());
+        self::assertEquals(self::$key, $this->cloudCredentials->getCloudKey());
+        self::assertEquals(self::$secret, $this->cloudCredentials->getCloudSecret());
         self::assertEquals($this->cloudApiBaseUri, $this->cloudCredentials->getBaseUri());
     }
 }

--- a/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfApiCommandTest.php
@@ -29,15 +29,19 @@ class AcsfApiCommandTest extends AcsfCommandTestBase
 
     protected function createCommand(): CommandBase
     {
-        $this->createMockCloudConfigFile($this->getAcsfCredentialsFileContents());
+        $this->createMockCloudConfigFile(AcsfCommandTestBase::getAcsfCredentialsFileContents());
         $this->cloudCredentials = new AcsfCredentials($this->datastoreCloud);
         $this->setClientProphecies();
         return $this->injectCommand(ApiBaseCommand::class);
     }
 
+    /**
+     * @throws \JsonException
+     * @throws \Exception
+     */
     public function testAcsfCommandExecutionForHttpPostWithMultipleDataTypes(): void
     {
-        $mockBody = $this->getMockResponseFromSpec('/api/v1/groups/{group_id}/members', 'post', '200');
+        $mockBody = self::getMockResponseFromSpec('/api/v1/groups/{group_id}/members', 'post', '200', true);
         $this->clientProphecy->request('post', '/api/v1/groups/1/members')
             ->willReturn($mockBody)
             ->shouldBeCalled();
@@ -50,14 +54,11 @@ class AcsfApiCommandTest extends AcsfCommandTestBase
             // group_id.
             '1',
         ]);
-
-        // Assert.
-        $output = $this->getDisplay();
     }
 
     public function testAcsfCommandExecutionBool(): void
     {
-        $mockBody = $this->getMockResponseFromSpec('/api/v1/update/pause', 'post', '200');
+        $mockBody = self::getMockResponseFromSpec('/api/v1/update/pause', 'post', '200', true);
         $this->clientProphecy->request('post', '/api/v1/update/pause')
             ->willReturn($mockBody)
             ->shouldBeCalled();
@@ -68,13 +69,11 @@ class AcsfApiCommandTest extends AcsfCommandTestBase
             // Pause.
             '1',
         ]);
-
-        // Assert.
     }
 
     public function testAcsfCommandExecutionForHttpGet(): void
     {
-        $mockBody = $this->getMockResponseFromSpec('/api/v1/audit', 'get', '200');
+        $mockBody = self::getMockResponseFromSpec('/api/v1/audit', 'get', '200', true);
         $this->clientProphecy->addQuery('limit', '1')->shouldBeCalled();
         $this->clientProphecy->request('get', '/api/v1/audit')
             ->willReturn($mockBody)
@@ -95,7 +94,7 @@ class AcsfApiCommandTest extends AcsfCommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestAcsfCommandExecutionForHttpGetMultiple(): array
+    public static function providerTestAcsfCommandExecutionForHttpGetMultiple(): array
     {
         return [
             [
@@ -170,7 +169,7 @@ class AcsfApiCommandTest extends AcsfCommandTestBase
      */
     public function testAcsfCommandExecutionForHttpGetMultiple(string $method, string $specPath, string $path, string $command, array $arguments = [], array $jsonArguments = []): void
     {
-        $mockBody = $this->getMockResponseFromSpec($specPath, $method, '200');
+        $mockBody = self::getMockResponseFromSpec($specPath, $method, '200', true);
         $this->clientProphecy->request($method, $path)
             ->willReturn($mockBody)
             ->shouldBeCalled();

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLoginCommandTest.php
@@ -24,7 +24,7 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestAuthLoginCommand(): array
+    public static function providerTestAuthLoginCommand(): array
     {
         return [
             // Data set 0.
@@ -36,11 +36,11 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase
                     // Would you like to share anonymous performance usage and data? (yes/no) [yes].
                     'yes',
                     // Enter the full URL of the factory.
-                    $this->acsfCurrentFactoryUrl,
+                    self::$acsfCurrentFactoryUrl,
                     // Enter a value for username.
-                    $this->acsfUsername,
+                    self::$acsfUsername,
                     // Enter a value for key.
-                    $this->acsfKey,
+                    self::$acsfKey,
                 ],
                 // No arguments, all interactive.
                 [],
@@ -56,16 +56,16 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase
                 // Arguments.
                 [
                     // Enter the full URL of the factory.
-                    '--factory-url' => $this->acsfCurrentFactoryUrl,
+                    '--factory-url' => self::$acsfCurrentFactoryUrl,
                     // Enter a value for key.
-                    '--key' => $this->acsfKey,
+                    '--key' => self::$acsfKey,
                     // Enter a value for username.
-                    '--username' => $this->acsfUsername,
+                    '--username' => self::$acsfUsername,
                 ],
                 // Output to assert.
                 'Saved credentials',
                 // $config.
-                $this->getAcsfCredentialsFileContents(),
+                AcsfCommandTestBase::getAcsfCredentialsFileContents(),
             ],
             // Data set 2.
             [
@@ -74,16 +74,16 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase
                 // $inputs
                 [
                     // Choose a factory to log in to.
-                    $this->acsfCurrentFactoryUrl,
+                    self::$acsfCurrentFactoryUrl,
                     // Choose which user to log in as.
-                    $this->acsfUsername,
+                    self::$acsfUsername,
                 ],
                 // Arguments.
                 [],
                 // Output to assert.
-                "Acquia CLI is now logged in to $this->acsfCurrentFactoryUrl as $this->acsfUsername",
+                'Acquia CLI is now logged in to ' . self::$acsfCurrentFactoryUrl . ' as ' . self::$acsfUsername,
                 // $config.
-                $this->getAcsfCredentialsFileContents(),
+                AcsfCommandTestBase::getAcsfCredentialsFileContents(),
             ],
         ];
     }
@@ -112,9 +112,9 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase
             $this->assertStringContainsString('Enter your Site Factory key (option -k, --key) (input will be hidden):', $output);
         }
         $this->assertKeySavedCorrectly();
-        $this->assertEquals($this->acsfActiveUser, $this->cloudCredentials->getCloudKey());
-        $this->assertEquals($this->acsfKey, $this->cloudCredentials->getCloudSecret());
-        $this->assertEquals($this->acsfCurrentFactoryUrl, $this->cloudCredentials->getBaseUri());
+        $this->assertEquals(self::$acsfActiveUser, $this->cloudCredentials->getCloudKey());
+        $this->assertEquals(self::$acsfKey, $this->cloudCredentials->getCloudSecret());
+        $this->assertEquals(self::$acsfCurrentFactoryUrl, $this->cloudCredentials->getBaseUri());
     }
 
     protected function assertKeySavedCorrectly(): void
@@ -130,13 +130,13 @@ class AcsfAuthLoginCommandTest extends AcsfCommandTestBase
         $factory = $factories[$factoryUrl];
         $this->assertArrayHasKey('users', $factory);
         $this->assertArrayHasKey('active_user', $factory);
-        $this->assertEquals($this->acsfUsername, $factory['active_user']);
+        $this->assertEquals(self::$acsfUsername, $factory['active_user']);
         $users = $factory['users'];
         $this->assertArrayHasKey($factory['active_user'], $users);
         $user = $users[$factory['active_user']];
         $this->assertArrayHasKey('username', $user);
         $this->assertArrayHasKey('key', $user);
-        $this->assertEquals($this->acsfUsername, $user['username']);
-        $this->assertEquals($this->acsfKey, $user['key']);
+        $this->assertEquals(self::$acsfUsername, $user['username']);
+        $this->assertEquals(self::$acsfKey, $user['key']);
     }
 }

--- a/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfAuthLogoutCommandTest.php
@@ -24,7 +24,7 @@ class AcsfAuthLogoutCommandTest extends AcsfCommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestAuthLogoutCommand(): array
+    public static function providerTestAuthLogoutCommand(): array
     {
         return [
             // Data set 0.
@@ -44,7 +44,7 @@ class AcsfAuthLogoutCommandTest extends AcsfCommandTestBase
                     0,
                 ],
                 // $config.
-                $this->getAcsfCredentialsFileContents(),
+                AcsfCommandTestBase::getAcsfCredentialsFileContents(),
             ],
         ];
     }

--- a/tests/phpunit/src/Commands/Acsf/AcsfCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfCommandTestBase.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Acquia\Cli\Tests\Commands\Acsf;
 
+use Acquia\Cli\Command\Api\ApiCommandHelper;
 use Acquia\Cli\Helpers\DataStoreContract;
 use Acquia\Cli\Tests\CommandTestBase;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
 /**
  * @property \Acquia\Cli\Command\Api\ApiBaseCommand $command
@@ -13,33 +16,43 @@ use Acquia\Cli\Tests\CommandTestBase;
 abstract class AcsfCommandTestBase extends CommandTestBase
 {
     // Test URLs with hyphens to ensure they don't get normalized to underscores.
-    protected string $acsfCurrentFactoryUrl = 'https://www.test-something.com';
+    protected static string $acsfCurrentFactoryUrl = 'https://www.test-something.com';
 
-    protected string $acsfActiveUser = 'tester';
+    protected static string $acsfActiveUser = 'tester';
 
-    protected string $acsfUsername = 'tester';
+    protected static string $acsfUsername = 'tester';
 
-    protected string $acsfKey = 'h@x0r';
+    protected static string $acsfKey = 'h@x0r';
 
     protected string $apiCommandPrefix = 'acsf';
 
-    protected string $apiSpecFixtureFilePath = __DIR__ . '/../../../../../assets/acsf-spec.json';
+    protected static string $apiSpecFixtureFilePath = __DIR__ . '/../../../../../assets/acsf-spec.json';
 
     /**
      * @return array<mixed>
      */
-    protected function getAcsfCredentialsFileContents(): array
+    protected function getApiCommands(): array
+    {
+        $apiCommandHelper = new ApiCommandHelper($this->logger);
+        $commandFactory = $this->getCommandFactory();
+        return $apiCommandHelper->getApiCommands(self::$apiSpecFixtureFilePath, $this->apiCommandPrefix, $commandFactory);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    protected static function getAcsfCredentialsFileContents(): array
     {
         return [
-            'acsf_active_factory' => $this->acsfCurrentFactoryUrl,
+            'acsf_active_factory' => self::$acsfCurrentFactoryUrl,
             'acsf_factories' => [
-                $this->acsfCurrentFactoryUrl => [
-                    'active_user' => $this->acsfActiveUser,
-                    'url' => $this->acsfCurrentFactoryUrl,
+                self::$acsfCurrentFactoryUrl => [
+                    'active_user' => self::$acsfActiveUser,
+                    'url' => self::$acsfCurrentFactoryUrl,
                     'users' => [
-                        $this->acsfUsername => [
-                            'key' => $this->acsfKey,
-                            'username' => $this->acsfUsername,
+                        self::$acsfUsername => [
+                            'key' => self::$acsfKey,
+                            'username' => self::$acsfUsername,
                         ],
                     ],
                 ],

--- a/tests/phpunit/src/Commands/Acsf/AcsfListCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfListCommandTest.php
@@ -25,6 +25,9 @@ class AcsfListCommandTest extends AcsfCommandTestBase
         return $this->injectCommand(AcsfListCommand::class);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testAcsfListCommand(): void
     {
         $this->executeCommand();
@@ -34,6 +37,9 @@ class AcsfListCommandTest extends AcsfCommandTestBase
         $this->assertStringContainsString('acsf:info:audit-events-find', $output);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testApiNamespaceListCommand(): void
     {
         $this->command = $this->injectCommand(AcsfListCommandBase::class);
@@ -46,6 +52,9 @@ class AcsfListCommandTest extends AcsfCommandTestBase
         $this->assertStringNotContainsString('acsf:groups', $output);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testListCommand(): void
     {
         $this->command = $this->injectCommand(ListCommand::class);

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -85,7 +85,7 @@ class ApiCommandTest extends CommandTestBase
         $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
             ->shouldBeCalled();
         $this->command = $this->getApiCommandByName('api:applications:find');
-        $mockBody = $this->getMockResponseFromSpec($this->command->getPath(), $this->command->getMethod(), '404');
+        $mockBody = self::getMockResponseFromSpec($this->command->getPath(), $this->command->getMethod(), '404');
         $this->clientProphecy->request('get', '/applications/' . $invalidUuid)
             ->willThrow(new ApiErrorException($mockBody))
             ->shouldBeCalled();
@@ -114,7 +114,7 @@ class ApiCommandTest extends CommandTestBase
     {
         $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
             ->shouldBeCalled();
-        $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
+        $mockBody = self::getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
         $this->clientProphecy->addQuery('limit', '1')->shouldBeCalled();
         $this->clientProphecy->request('get', '/account/ssh-keys')
             ->willReturn($mockBody->{'_embedded'}->items)
@@ -174,7 +174,7 @@ class ApiCommandTest extends CommandTestBase
     /**
      * @return bool[][]
      */
-    public function providerTestConvertApplicationAliasToUuidArgument(): array
+    public static function providerTestConvertApplicationAliasToUuidArgument(): array
     {
         return [
             [false],
@@ -330,8 +330,8 @@ class ApiCommandTest extends CommandTestBase
     {
         $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
             ->shouldBeCalled();
-        $mockRequestArgs = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
-        $mockResponseBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'post', '202');
+        $mockRequestArgs = self::getMockRequestBodyFromSpec('/account/ssh-keys');
+        $mockResponseBody = self::getMockResponseFromSpec('/account/ssh-keys', 'post', '202');
         foreach ($mockRequestArgs as $name => $value) {
             $this->clientProphecy->addOption('json', [$name => $value])
                 ->shouldBeCalled();
@@ -353,7 +353,7 @@ class ApiCommandTest extends CommandTestBase
     {
         $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
             ->shouldBeCalled();
-        $mockRequestOptions = $this->getMockRequestBodyFromSpec('/environments/{environmentId}', 'put');
+        $mockRequestOptions = self::getMockRequestBodyFromSpec('/environments/{environmentId}', 'put');
         $mockRequestOptions['max_input_vars'] = 1001;
         $mockResponseBody = $this->getMockEnvironmentResponse('put', '202');
 
@@ -385,7 +385,7 @@ class ApiCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestApiCommandDefinitionParameters(): array
+    public static function providerTestApiCommandDefinitionParameters(): array
     {
         $apiAccountsSshKeysListUsage = '--from="-7d" --to="-1d" --sort="field1,-field2" --limit="10" --offset="10"';
         return [
@@ -431,7 +431,7 @@ class ApiCommandTest extends CommandTestBase
         putenv('ACQUIA_CLI_USE_CLOUD_API_SPEC_CACHE=' . $useSpecCache);
 
         $this->command = $this->getApiCommandByName($commandName);
-        $resource = $this->getResourceFromSpec($this->command->getPath(), $method);
+        $resource = self::getResourceFromSpec($this->command->getPath(), $method);
         $this->assertEquals($resource['summary'], $this->command->getDescription());
 
         $expectedCommandName = 'api:' . $resource['x-cli-name'];
@@ -439,7 +439,7 @@ class ApiCommandTest extends CommandTestBase
 
         foreach ($resource['parameters'] as $parameter) {
             $paramKey = str_replace('#/components/parameters/', '', $parameter['$ref']);
-            $param = $this->getCloudApiSpec()['components']['parameters'][$paramKey];
+            $param = self::getCloudApiSpec()['components']['parameters'][$paramKey];
             $this->assertTrue(
                 $this->command->getDefinition()->hasOption($param['name']) ||
                 $this->command->getDefinition()->hasArgument($param['name']),
@@ -467,7 +467,7 @@ class ApiCommandTest extends CommandTestBase
     /**
      * @return string[][]
      */
-    public function providerTestApiCommandDefinitionRequestBody(): array
+    public static function providerTestApiCommandDefinitionRequestBody(): array
     {
         return [
             [
@@ -492,7 +492,7 @@ class ApiCommandTest extends CommandTestBase
     public function testApiCommandDefinitionRequestBody(string $commandName, string $method, string $usage): void
     {
         $this->command = $this->getApiCommandByName($commandName);
-        $resource = $this->getResourceFromSpec($this->command->getPath(), $method);
+        $resource = self::getResourceFromSpec($this->command->getPath(), $method);
         foreach ($resource['requestBody']['content']['application/hal+json']['example'] as $propKey => $value) {
             $this->assertTrue(
                 $this->command->getDefinition()
@@ -508,7 +508,7 @@ class ApiCommandTest extends CommandTestBase
     {
         $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
             ->shouldBeCalled();
-        $mockBody = $this->getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
+        $mockBody = self::getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
         $this->clientProphecy->request('get', '/applications/' . $mockBody->uuid)
             ->willReturn($mockBody)
             ->shouldBeCalled();
@@ -553,7 +553,7 @@ class ApiCommandTest extends CommandTestBase
     {
         $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
             ->shouldBeCalled();
-        $membersResponse = $this->getMockResponseFromSpec('/organizations/{organizationUuid}/members', 'get', 200);
+        $membersResponse = self::getMockResponseFromSpec('/organizations/{organizationUuid}/members', 'get', 200);
         $orgId = 'bfafd31a-83a6-4257-b0ec-afdeff83117a';
         $memberMail = $membersResponse->_embedded->items[0]->mail;
         $memberUuid = $membersResponse->_embedded->items[0]->uuid;
@@ -583,7 +583,7 @@ class ApiCommandTest extends CommandTestBase
      */
     public function testOrganizationMemberDeleteInvalidEmail(): void
     {
-        $membersResponse = $this->getMockResponseFromSpec('/organizations/{organizationUuid}/members', 'get', 200);
+        $membersResponse = self::getMockResponseFromSpec('/organizations/{organizationUuid}/members', 'get', 200);
         $orgId = 'bfafd31a-83a6-4257-b0ec-afdeff83117a';
         $memberUuid = $membersResponse->_embedded->items[0]->mail . 'INVALID';
         $this->clientProphecy->request('get', '/organizations/' . $orgId . '/members')
@@ -610,7 +610,7 @@ class ApiCommandTest extends CommandTestBase
      */
     public function testOrganizationMemberDeleteNoMembers(): void
     {
-        $membersResponse = $this->getMockResponseFromSpec('/organizations/{organizationUuid}/members', 'get', 200);
+        $membersResponse = self::getMockResponseFromSpec('/organizations/{organizationUuid}/members', 'get', 200);
         $orgId = 'bfafd31a-83a6-4257-b0ec-afdeff83117a';
         $memberUuid = $membersResponse->_embedded->items[0]->mail;
         $this->clientProphecy->request('get', '/organizations/' . $orgId . '/members')

--- a/tests/phpunit/src/Commands/App/From/ConfigurationTest.php
+++ b/tests/phpunit/src/Commands/App/From/ConfigurationTest.php
@@ -34,7 +34,7 @@ class ConfigurationTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function getTestConfigurations(): array
+    public static function getTestConfigurations(): array
     {
         return [
             'bad JSON in configuration file' => [

--- a/tests/phpunit/src/Commands/App/From/DefinedRecommendationTest.php
+++ b/tests/phpunit/src/Commands/App/From/DefinedRecommendationTest.php
@@ -47,7 +47,7 @@ class DefinedRecommendationTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function getTestConfigurations(): array
+    public static function getTestConfigurations(): array
     {
         // phpcs:disable SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys
         return [

--- a/tests/phpunit/src/Commands/App/From/ProjectBuilderTest.php
+++ b/tests/phpunit/src/Commands/App/From/ProjectBuilderTest.php
@@ -31,7 +31,7 @@ final class ProjectBuilderTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function getTestResources(): array
+    public static function getTestResources(): array
     {
         // phpcs:disable SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys
         $test_cases = [

--- a/tests/phpunit/src/Commands/App/From/RecommendationsTest.php
+++ b/tests/phpunit/src/Commands/App/From/RecommendationsTest.php
@@ -49,7 +49,7 @@ class RecommendationsTest extends TestCase
     /**
      * @return array<mixed>
      */
-    public function getTestConfigurations(): array
+    public static function getTestConfigurations(): array
     {
         // phpcs:disable SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys
         return [

--- a/tests/phpunit/src/Commands/App/LogTailCommandTest.php
+++ b/tests/phpunit/src/Commands/App/LogTailCommandTest.php
@@ -22,7 +22,7 @@ class LogTailCommandTest extends CommandTestBase
     /**
      * @return int[]
      */
-    public function providerLogTailCommand(): array
+    public static function providerLogTailCommand(): array
     {
         return [
             [0],
@@ -131,7 +131,7 @@ class LogTailCommandTest extends CommandTestBase
 
     private function mockLogStreamRequest(): void
     {
-        $response = $this->getMockResponseFromSpec(
+        $response = self::getMockResponseFromSpec(
             '/environments/{environmentId}/logstream',
             'get',
             '200'

--- a/tests/phpunit/src/Commands/App/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/App/NewCommandTest.php
@@ -32,7 +32,7 @@ class NewCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function provideTestNewDrupalCommand(): array
+    public static function provideTestNewDrupalCommand(): array
     {
         return [
             [['acquia_drupal_recommended' => 'acquia/drupal-recommended-project']],
@@ -48,7 +48,7 @@ class NewCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function provideTestNewNextJsAppCommand(): array
+    public static function provideTestNewNextJsAppCommand(): array
     {
         return [
             [['acquia_next_acms' => 'acquia/next-acms']],

--- a/tests/phpunit/src/Commands/App/NewFromDrupal7CommandTest.php
+++ b/tests/phpunit/src/Commands/App/NewFromDrupal7CommandTest.php
@@ -31,7 +31,7 @@ class NewFromDrupal7CommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function provideTestNewFromDrupal7Command(): array
+    public static function provideTestNewFromDrupal7Command(): array
     {
         $repo_root = dirname(dirname(dirname(dirname(dirname(dirname(__FILE__))))));
         // Windows accepts paths with either slash (/) or backslash (\), but will

--- a/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
+++ b/tests/phpunit/src/Commands/App/TaskWaitCommandTest.php
@@ -65,7 +65,7 @@ class TaskWaitCommandTest extends CommandTestBase
      *
      * @return (string|int)[][]
      */
-    public function providerTestTaskWaitCommand(): array
+    public static function providerTestTaskWaitCommand(): array
     {
         return [
             [
@@ -127,7 +127,7 @@ EOT,
     /**
      * @return string[]
      */
-    public function providerTestTaskWaitCommandWithInvalidJson(): array
+    public static function providerTestTaskWaitCommandWithInvalidJson(): array
     {
         return [
             [

--- a/tests/phpunit/src/Commands/App/UnlinkCommandTest.php
+++ b/tests/phpunit/src/Commands/App/UnlinkCommandTest.php
@@ -21,7 +21,7 @@ class UnlinkCommandTest extends CommandTestBase
 
     public function testUnlinkCommand(): void
     {
-        $applicationsResponse = $this->getMockResponseFromSpec(
+        $applicationsResponse = self::getMockResponseFromSpec(
             '/applications',
             'get',
             '200'

--- a/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
+++ b/tests/phpunit/src/Commands/Auth/AuthLoginCommandTest.php
@@ -37,8 +37,8 @@ class AuthLoginCommandTest extends CommandTestBase
         $this->command = $this->createCommand();
 
         $this->executeCommand([
-            '--key' => $this->key,
-            '--secret' => $this->secret,
+            '--key' => self::$key,
+            '--secret' => self::$secret,
         ]);
         $output = $this->getDisplay();
 
@@ -59,8 +59,8 @@ class AuthLoginCommandTest extends CommandTestBase
         $this->command = $this->createCommand();
 
         $this->executeCommand([
-            '--key' => $this->key,
-            '--secret' => $this->secret,
+            '--key' => self::$key,
+            '--secret' => self::$secret,
         ]);
         $output = $this->getDisplay();
 
@@ -68,22 +68,22 @@ class AuthLoginCommandTest extends CommandTestBase
         $this->assertKeySavedCorrectly();
     }
 
-    public function providerTestAuthLoginInvalidInputCommand(): Generator
+    public static function providerTestAuthLoginInvalidInputCommand(): Generator
     {
         yield
         [
             [],
-            ['--key' => 'no spaces are allowed', '--secret' => $this->secret],
+            ['--key' => 'no spaces are allowed', '--secret' => self::$secret],
         ];
         yield
         [
             [],
-            ['--key' => 'shorty', '--secret' => $this->secret],
+            ['--key' => 'shorty', '--secret' => self::$secret],
         ];
         yield
         [
             [],
-            ['--key' => ' ', '--secret' => $this->secret],
+            ['--key' => ' ', '--secret' => self::$secret],
         ];
     }
 
@@ -137,12 +137,12 @@ class AuthLoginCommandTest extends CommandTestBase
         $this->assertFileExists($credsFile);
         $config = new CloudDataStore($this->localMachineHelper, new CloudDataConfig(), $credsFile);
         $this->assertTrue($config->exists('acli_key'));
-        $this->assertEquals($this->key, $config->get('acli_key'));
+        $this->assertEquals(self::$key, $config->get('acli_key'));
         $this->assertTrue($config->exists('keys'));
         $keys = $config->get('keys');
-        $this->assertArrayHasKey($this->key, $keys);
-        $this->assertArrayHasKey('label', $keys[$this->key]);
-        $this->assertArrayHasKey('secret', $keys[$this->key]);
-        $this->assertEquals($this->secret, $keys[$this->key]['secret']);
+        $this->assertArrayHasKey(self::$key, $keys);
+        $this->assertArrayHasKey('label', $keys[self::$key]);
+        $this->assertArrayHasKey('secret', $keys[self::$key]);
+        $this->assertEquals(self::$secret, $keys[self::$key]['secret']);
     }
 }

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPhpVersionCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPhpVersionCommandTest.php
@@ -21,7 +21,7 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase
 
     private string $gitLabToken = 'gitlabtoken';
 
-    private int $gitLabProjectId = 33;
+    private static int $gitLabProjectId = 33;
 
     public static string $applicationUuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
 
@@ -33,7 +33,7 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestPhpVersionFailure(): array
+    public static function providerTestPhpVersionFailure(): array
     {
         return [
             ['', ValidatorException::class],
@@ -67,8 +67,8 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase
         $this->mockGitLabUsersMe($gitlabClient);
         $projects = $this->mockGetGitLabProjects(
             self::$applicationUuid,
-            $this->gitLabProjectId,
-            [$this->getMockedGitLabProject($this->gitLabProjectId)],
+            self::$gitLabProjectId,
+            [self::getMockedGitLabProject(self::$gitLabProjectId)],
         );
 
         $gitlabClient->projects()->willReturn($projects);
@@ -93,17 +93,17 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase
         $this->mockApplicationRequest();
         $gitlabClient = $this->prophet->prophesize(Client::class);
         $this->mockGitLabUsersMe($gitlabClient);
-        $mockedProject = $this->getMockedGitLabProject($this->gitLabProjectId);
+        $mockedProject = self::getMockedGitLabProject(self::$gitLabProjectId);
         $mockedProject['jobs_enabled'] = true;
         $projects = $this->mockGetGitLabProjects(
             self::$applicationUuid,
-            $this->gitLabProjectId,
+            self::$gitLabProjectId,
             [$mockedProject],
         );
 
-        $projects->variables($this->gitLabProjectId)
+        $projects->variables(self::$gitLabProjectId)
             ->willReturn($this->getMockGitLabVariables());
-        $projects->addVariable($this->gitLabProjectId, Argument::type('string'), Argument::type('string'))
+        $projects->addVariable(self::$gitLabProjectId, Argument::type('string'), Argument::type('string'))
             ->willThrow(RuntimeException::class);
 
         $gitlabClient->projects()->willReturn($projects);
@@ -127,17 +127,17 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase
         $this->mockApplicationRequest();
         $gitlabClient = $this->prophet->prophesize(Client::class);
         $this->mockGitLabUsersMe($gitlabClient);
-        $mockedProject = $this->getMockedGitLabProject($this->gitLabProjectId);
+        $mockedProject = self::getMockedGitLabProject(self::$gitLabProjectId);
         $mockedProject['jobs_enabled'] = true;
         $projects = $this->mockGetGitLabProjects(
             self::$applicationUuid,
-            $this->gitLabProjectId,
+            self::$gitLabProjectId,
             [$mockedProject],
         );
 
-        $projects->variables($this->gitLabProjectId)
+        $projects->variables(self::$gitLabProjectId)
             ->willReturn($this->getMockGitLabVariables());
-        $projects->addVariable($this->gitLabProjectId, Argument::type('string'), Argument::type('string'));
+        $projects->addVariable(self::$gitLabProjectId, Argument::type('string'), Argument::type('string'));
 
         $gitlabClient->projects()->willReturn($projects);
 
@@ -161,11 +161,11 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase
         $this->mockApplicationRequest();
         $gitlabClient = $this->prophet->prophesize(Client::class);
         $this->mockGitLabUsersMe($gitlabClient);
-        $mockedProject = $this->getMockedGitLabProject($this->gitLabProjectId);
+        $mockedProject = self::getMockedGitLabProject(self::$gitLabProjectId);
         $mockedProject['jobs_enabled'] = true;
         $projects = $this->mockGetGitLabProjects(
             self::$applicationUuid,
-            $this->gitLabProjectId,
+            self::$gitLabProjectId,
             [$mockedProject],
         );
 
@@ -178,8 +178,8 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase
             'value' => '8.1',
             'variable_type' => 'env_var',
         ];
-        $projects->variables($this->gitLabProjectId)->willReturn($variables);
-        $projects->updateVariable($this->gitLabProjectId, Argument::type('string'), Argument::type('string'))
+        $projects->variables(self::$gitLabProjectId)->willReturn($variables);
+        $projects->updateVariable(self::$gitLabProjectId, Argument::type('string'), Argument::type('string'))
             ->willThrow(RuntimeException::class);
 
         $gitlabClient->projects()->willReturn($projects);
@@ -203,11 +203,11 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase
         $this->mockApplicationRequest();
         $gitlabClient = $this->prophet->prophesize(Client::class);
         $this->mockGitLabUsersMe($gitlabClient);
-        $mockedProject = $this->getMockedGitLabProject($this->gitLabProjectId);
+        $mockedProject = self::getMockedGitLabProject(self::$gitLabProjectId);
         $mockedProject['jobs_enabled'] = true;
         $projects = $this->mockGetGitLabProjects(
             self::$applicationUuid,
-            $this->gitLabProjectId,
+            self::$gitLabProjectId,
             [$mockedProject],
         );
 
@@ -220,8 +220,8 @@ class CodeStudioPhpVersionCommandTest extends CommandTestBase
             'value' => '8.1',
             'variable_type' => 'env_var',
         ];
-        $projects->variables($this->gitLabProjectId)->willReturn($variables);
-        $projects->updateVariable($this->gitLabProjectId, Argument::type('string'), Argument::type('string'));
+        $projects->variables(self::$gitLabProjectId)->willReturn($variables);
+        $projects->updateVariable(self::$gitLabProjectId, Argument::type('string'), Argument::type('string'));
 
         $gitlabClient->projects()->willReturn($projects);
 

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -28,9 +28,7 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase
 
     private string $gitLabToken = 'gitlabtoken';
 
-    private int $gitLabProjectId = 33;
-
-    private int $gitLabTokenId = 118;
+    private static int $gitLabProjectId = 33;
 
     public static string $applicationUuid = 'a47ac10b-58cc-4372-a567-0e02b2c3d470';
 
@@ -38,13 +36,13 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase
     {
         parent::setUp();
         $this->mockApplicationRequest();
-        TestBase::setEnvVars(['GITLAB_HOST' => 'code.cloudservices.acquia.io']);
+        self::setEnvVars(['GITLAB_HOST' => 'code.cloudservices.acquia.io']);
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        TestBase::unsetEnvVars(['GITLAB_HOST' => 'code.cloudservices.acquia.io']);
+        self::unsetEnvVars(['GITLAB_HOST' => 'code.cloudservices.acquia.io']);
     }
 
     protected function createCommand(): CommandBase
@@ -55,12 +53,12 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestCommand(): array
+    public static function providerTestCommand(): array
     {
         return [
             [
                 // One project.
-                [$this->getMockedGitLabProject($this->gitLabProjectId)],
+                [self::getMockedGitLabProject(self::$gitLabProjectId)],
                 // Inputs.
                 [
                     // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
@@ -72,8 +70,8 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase
                 ],
                 // Args.
                 [
-                    '--key' => $this->key,
-                    '--secret' => $this->secret,
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
                 ],
             ],
         ];
@@ -100,7 +98,7 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase
         $this->mockGitLabUsersMe($gitlabClient);
         $this->mockRequest('getAccount');
         $this->mockGitLabPermissionsRequest($this::$applicationUuid);
-        $projects = $this->mockGetGitLabProjects($this::$applicationUuid, $this->gitLabProjectId, $mockedGitlabProjects);
+        $projects = $this->mockGetGitLabProjects($this::$applicationUuid, self::$gitLabProjectId, $mockedGitlabProjects);
         $gitlabCicdVariables = [
             [
                 'key' => 'ACQUIA_APPLICATION_UUID',
@@ -145,9 +143,9 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase
                 'variable_type' => 'env_var',
             ],
         ];
-        $projects->variables($this->gitLabProjectId)
+        $projects->variables(self::$gitLabProjectId)
             ->willReturn($gitlabCicdVariables);
-        $projects->update($this->gitLabProjectId, Argument::type('array'));
+        $projects->update(self::$gitLabProjectId, Argument::type('array'));
         $gitlabClient->projects()->willReturn($projects);
         $localMachineHelper->getFilesystem()
             ->willReturn(new Filesystem())

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -32,7 +32,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
 
     private string $gitLabToken = 'gitlabtoken';
 
-    private int $gitLabProjectId = 33;
+    private static int $gitLabProjectId = 33;
 
     private int $gitLabTokenId = 118;
 
@@ -40,13 +40,13 @@ class CodeStudioWizardCommandTest extends WizardTestBase
     {
         parent::setUp();
         $this->mockApplicationRequest();
-        TestBase::setEnvVars(['GITLAB_HOST' => 'code.cloudservices.acquia.io']);
+        self::setEnvVars(['GITLAB_HOST' => 'code.cloudservices.acquia.io']);
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        TestBase::unsetEnvVars(['GITLAB_HOST' => 'code.cloudservices.acquia.io']);
+        self::unsetEnvVars(['GITLAB_HOST' => 'code.cloudservices.acquia.io']);
     }
 
     protected function createCommand(): CommandBase
@@ -57,12 +57,12 @@ class CodeStudioWizardCommandTest extends WizardTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestCommand(): array
+    public static function providerTestCommand(): array
     {
         return [
             [
                 // One project.
-                [$this->getMockedGitLabProject($this->gitLabProjectId)],
+                [self::getMockedGitLabProject(self::$gitLabProjectId)],
                 // Inputs.
                 [
                     0,
@@ -74,15 +74,15 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 ],
                 // Args.
                 [
-                    '--key' => $this->key,
-                    '--secret' => $this->secret,
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
                 ],
             ],
             // Two projects.
             [
                 [
-                    $this->getMockedGitLabProject($this->gitLabProjectId),
-                    $this->getMockedGitLabProject($this->gitLabProjectId),
+                    self::getMockedGitLabProject(self::$gitLabProjectId),
+                    self::getMockedGitLabProject(self::$gitLabProjectId),
                 ],
                 // Inputs.
                 [
@@ -98,8 +98,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 ],
                 // Args.
                 [
-                    '--key' => $this->key,
-                    '--secret' => $this->secret,
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
                 ],
             ],
             [
@@ -122,8 +122,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 ],
                 // Args.
                 [
-                    '--key' => $this->key,
-                    '--secret' => $this->secret,
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
                 ],
             ],
             [
@@ -142,8 +142,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 ],
                 // Args.
                 [
-                    '--key' => $this->key,
-                    '--secret' => $this->secret,
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
                 ],
             ],
             [
@@ -162,8 +162,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 ],
                 // Args.
                 [
-                    '--key' => $this->key,
-                    '--secret' => $this->secret,
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
                 ],
             ],
             [
@@ -182,8 +182,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 ],
                 // Args.
                 [
-                    '--key' => $this->key,
-                    '--secret' => $this->secret,
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
                 ],
             ],
             [
@@ -202,8 +202,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 ],
                 // Args.
                 [
-                    '--key' => $this->key,
-                    '--secret' => $this->secret,
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
                 ],
             ],
             [
@@ -212,9 +212,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 // Inputs.
                 [
                     // Enter Cloud Key.
-                    $this->key,
+                    self::$key,
                     // Enter Cloud secret,.
-                    $this->secret,
+                    self::$secret,
                     // Select a project type Drupal_project.
                     '0',
                     // Select PHP version 8.1.
@@ -231,9 +231,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 // Inputs.
                 [
                     // Enter Cloud Key.
-                    $this->key,
+                    self::$key,
                     // Enter Cloud secret,.
-                    $this->secret,
+                    self::$secret,
                     // Select a project type Node_project.
                     '1',
                     // Select NODE version 18.
@@ -250,9 +250,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 // Inputs.
                 [
                     // Enter Cloud Key.
-                    $this->key,
+                    self::$key,
                     // Enter Cloud secret,.
-                    $this->secret,
+                    self::$secret,
                     // Select a project type Drupal_project.
                     '0',
                     // Select PHP version 8.2.
@@ -269,9 +269,9 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 // Inputs.
                 [
                     // Enter Cloud Key.
-                    $this->key,
+                    self::$key,
                     // Enter Cloud secret,.
-                    $this->secret,
+                    self::$secret,
                     // Select a project type Node_project.
                     '1',
                     // Select NODE version 20.
@@ -300,7 +300,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
         $this->mockGitLabGroups($gitlabClient);
         $this->mockGitLabNamespaces($gitlabClient);
 
-        $projects = $this->mockGetGitLabProjects($this::$applicationUuid, $this->gitLabProjectId, $mockedGitlabProjects);
+        $projects = $this->mockGetGitLabProjects($this::$applicationUuid, self::$gitLabProjectId, $mockedGitlabProjects);
         $parameters = [
             'container_registry_access_level' => 'disabled',
             'default_branch' => 'main',
@@ -310,7 +310,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
             'topics' => 'Acquia Cloud Application',
         ];
         $projects->create('Sample-application-1', $parameters)
-            ->willReturn($this->getMockedGitLabProject($this->gitLabProjectId));
+            ->willReturn(self::getMockedGitLabProject(self::$gitLabProjectId));
         $this->mockGitLabProjectsTokens($projects);
         $parameters = [
             'container_registry_access_level' => 'disabled',
@@ -319,23 +319,23 @@ class CodeStudioWizardCommandTest extends WizardTestBase
             'initialize_with_readme' => true,
             'topics' => 'Acquia Cloud Application',
         ];
-        $projects->update($this->gitLabProjectId, $parameters)
+        $projects->update(self::$gitLabProjectId, $parameters)
             ->shouldBeCalled();
         $projects->uploadAvatar(
             33,
             Argument::type('string'),
         )->shouldBeCalled();
-        $this->mockGitLabVariables($this->gitLabProjectId, $projects);
+        $this->mockGitLabVariables(self::$gitLabProjectId, $projects);
 
         if (($inputs[0] === '1' || (array_key_exists(2, $inputs) && $inputs[2] === '1'))) {
             $parameters = [
                 'ci_config_path' => 'gitlab-ci/Auto-DevOps.acquia.gitlab-ci.yml@acquia/node-template',
             ];
-            $projects->update($this->gitLabProjectId, $parameters)
+            $projects->update(self::$gitLabProjectId, $parameters)
                 ->shouldBeCalled();
         } else {
             $schedules = $this->prophet->prophesize(Schedules::class);
-            $schedules->showAll($this->gitLabProjectId)->willReturn([]);
+            $schedules->showAll(self::$gitLabProjectId)->willReturn([]);
             $pipeline = ['id' => 1];
             $parameters = [
                 // Every Thursday at midnight.
@@ -343,13 +343,13 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 'description' => 'Code Studio Automatic Updates',
                 'ref' => 'master',
             ];
-            $schedules->create($this->gitLabProjectId, $parameters)
+            $schedules->create(self::$gitLabProjectId, $parameters)
                 ->willReturn($pipeline);
-            $schedules->addVariable($this->gitLabProjectId, $pipeline['id'], [
+            $schedules->addVariable(self::$gitLabProjectId, $pipeline['id'], [
                 'key' => 'ACQUIA_JOBS_DEPRECATED_UPDATE',
                 'value' => 'true',
             ])->shouldBeCalled();
-            $schedules->addVariable($this->gitLabProjectId, $pipeline['id'], [
+            $schedules->addVariable(self::$gitLabProjectId, $pipeline['id'], [
                 'key' => 'ACQUIA_JOBS_COMPOSER_UPDATE',
                 'value' => 'true',
             ])->shouldBeCalled();
@@ -401,8 +401,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
         $this->expectException(AcquiaCliException::class);
         $this->expectExceptionMessage('Unable to authenticate with Code Studio');
         $this->executeCommand([
-            '--key' => $this->key,
-            '--secret' => $this->secret,
+            '--key' => self::$key,
+            '--secret' => self::$secret,
         ]);
     }
 
@@ -419,8 +419,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
         $this->expectException(AcquiaCliException::class);
         $this->expectExceptionMessage('Could not determine GitLab token');
         $this->executeCommand([
-            '--key' => $this->key,
-            '--secret' => $this->secret,
+            '--key' => self::$key,
+            '--secret' => self::$secret,
         ]);
     }
 
@@ -442,14 +442,14 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 'user_id' => 154,
             ],
         ];
-        $projects->projectAccessTokens($this->gitLabProjectId)
+        $projects->projectAccessTokens(self::$gitLabProjectId)
             ->willReturn($tokens)
             ->shouldBeCalled();
-        $projects->deleteProjectAccessToken($this->gitLabProjectId, $this->gitLabTokenId)
+        $projects->deleteProjectAccessToken(self::$gitLabProjectId, $this->gitLabTokenId)
             ->shouldBeCalled();
         $token = $tokens[0];
         $token['token'] = 'token';
-        $projects->createProjectAccessToken($this->gitLabProjectId, Argument::type('array'))
+        $projects->createProjectAccessToken(self::$gitLabProjectId, Argument::type('array'))
             ->willReturn($token);
     }
 
@@ -560,7 +560,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
             ])->shouldBeCalled();
         }
         foreach ($variables as $variable) {
-            $projects->updateVariable($this->gitLabProjectId, $variable['key'], $variable['value'], false, null, [
+            $projects->updateVariable(self::$gitLabProjectId, $variable['key'], $variable['value'], false, null, [
                 'masked' => true,
                 'variable_type' => 'env_var',
             ])->shouldBeCalled();

--- a/tests/phpunit/src/Commands/CommandBaseTest.php
+++ b/tests/phpunit/src/Commands/CommandBaseTest.php
@@ -51,7 +51,7 @@ class CommandBaseTest extends CommandTestBase
     /**
      * @return string[][]
      */
-    public function providerTestCloudAppUuidArg(): array
+    public static function providerTestCloudAppUuidArg(): array
     {
         return [
             ['a47ac10b-58cc-4372-a567-0e02b2c3d470'],
@@ -72,7 +72,7 @@ class CommandBaseTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestInvalidCloudAppUuidArg(): array
+    public static function providerTestInvalidCloudAppUuidArg(): array
     {
         return [
             [
@@ -99,7 +99,7 @@ class CommandBaseTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestInvalidCloudEnvironmentAlias(): array
+    public static function providerTestInvalidCloudEnvironmentAlias(): array
     {
         return [
             [

--- a/tests/phpunit/src/Commands/DocsCommandTest.php
+++ b/tests/phpunit/src/Commands/DocsCommandTest.php
@@ -36,7 +36,7 @@ class DocsCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestDocsCommand(): array
+    public static function providerTestDocsCommand(): array
     {
         return [
             [

--- a/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/ConfigurePlatformEmailCommandTest.php
@@ -87,7 +87,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestConfigurePlatformEmail(): array
+    public static function providerTestConfigurePlatformEmail(): array
     {
 
         return [
@@ -189,7 +189,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestConfigurePlatformEmailEnableEnv(): array
+    public static function providerTestConfigurePlatformEmailEnableEnv(): array
     {
         return [
             [
@@ -249,23 +249,23 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
         $localMachineHelper = $this->mockLocalMachineHelper();
         $mockFileSystem = $this->mockGetFilesystem($localMachineHelper);
 
-        $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+        $subscriptionsResponse = self::getMockResponseFromSpec('/subscriptions', 'get', '200');
         $this->clientProphecy->request('get', '/subscriptions')
         ->willReturn($subscriptionsResponse->{'_embedded'}->items)
         ->shouldBeCalledTimes(1);
 
-        $postDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
+        $postDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
         $this->clientProphecy->request('post', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains", [
             'form_params' => [
                 'domain' => $baseDomain,
             ],
         ])->willReturn($postDomainsResponse);
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $getDomainsResponse->_embedded->items[0]->domain_name = 'test.com';
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
-        $domainsRegistrationResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
+        $domainsRegistrationResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
         $domainsRegistrationResponse->health->code = $responseCode;
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains/{$getDomainsResponse->_embedded->items[0]->uuid}")
         ->willReturn($domainsRegistrationResponse);
@@ -277,7 +277,7 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
         $mockFileSystem->dumpFile('dns-records.' . $fileDumpFormat, $fileDump)->shouldBeCalled();
 
         if ($responseCode == '404') {
-            $reverifyResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}/actions/verify', 'post', '200');
+            $reverifyResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}/actions/verify', 'post', '200');
             $this->clientProphecy->request('post', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains/{$getDomainsResponse->_embedded->items[0]->uuid}/actions/verify")
             ->willReturn($reverifyResponse);
         } elseif ($responseCode == '200') {
@@ -285,10 +285,10 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
             // We need the application to belong to the subscription.
             $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
 
-            $associateResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains/{domainRegistrationUuid}/actions/associate', 'post', '200');
+            $associateResponse = self::getMockResponseFromSpec('/applications/{applicationUuid}/email/domains/{domainRegistrationUuid}/actions/associate', 'post', '200');
             $this->clientProphecy->request('post', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains/{$getDomainsResponse->_embedded->items[0]->uuid}/actions/associate")->willReturn($associateResponse);
             $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
-            $enableResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/email/actions/enable', 'post', '200');
+            $enableResponse = self::getMockResponseFromSpec('/environments/{environmentId}/email/actions/enable', 'post', '200');
             $this->clientProphecy->request('post', "/environments/{$environmentsResponse->_embedded->items[0]->id}/email/actions/enable")->willReturn($enableResponse);
         }
 
@@ -322,23 +322,23 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
         $localMachineHelper = $this->mockLocalMachineHelper();
         $mockFileSystem = $this->mockGetFilesystem($localMachineHelper);
 
-        $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+        $subscriptionsResponse = self::getMockResponseFromSpec('/subscriptions', 'get', '200');
         $this->clientProphecy->request('get', '/subscriptions')
         ->willReturn($subscriptionsResponse->{'_embedded'}->items)
         ->shouldBeCalledTimes(1);
 
-        $postDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
+        $postDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
         $this->clientProphecy->request('post', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains", [
             'form_params' => [
                 'domain' => 'test.com',
             ],
         ])->willReturn($postDomainsResponse);
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $getDomainsResponse->_embedded->items[0]->domain_name = 'test.com';
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
-        $domainsRegistrationResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
+        $domainsRegistrationResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
         $domainsRegistrationResponse200 = $domainsRegistrationResponse;
         $domainsRegistrationResponse200->health->code = '200';
         // Passing in two responses will return the first response the first time
@@ -356,17 +356,17 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
         $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
         $applicationsResponse->_embedded->items[1]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
 
-        $associateResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains/{domainRegistrationUuid}/actions/associate', 'post', '200');
+        $associateResponse = self::getMockResponseFromSpec('/applications/{applicationUuid}/email/domains/{domainRegistrationUuid}/actions/associate', 'post', '200');
         $this->clientProphecy->request('post', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains/{$getDomainsResponse->_embedded->items[0]->uuid}/actions/associate")->willReturn($associateResponse);
         $this->clientProphecy->request('post', "/applications/{$applicationsResponse->_embedded->items[1]->uuid}/email/domains/{$getDomainsResponse->_embedded->items[1]->uuid}/actions/associate")->willReturn($associateResponse);
 
-        $environmentResponseApp1 = $this->getMockEnvironmentsResponse();
+        $environmentResponseApp1 = self::getMockEnvironmentsResponse();
         $environmentResponseApp2 = $environmentResponseApp1;
 
         $this->clientProphecy->request('get', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/environments")->willReturn($environmentResponseApp1->_embedded->items);
         $this->clientProphecy->request('get', "/applications/{$applicationsResponse->_embedded->items[1]->uuid}/environments")->willReturn($environmentResponseApp2->_embedded->items);
 
-        $enableResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/email/actions/enable', 'post', '200');
+        $enableResponse = self::getMockResponseFromSpec('/environments/{environmentId}/email/actions/enable', 'post', '200');
         $this->clientProphecy->request('post', "/environments/{$environmentResponseApp1->_embedded->items[0]->id}/email/actions/enable")->willReturn($enableResponse);
         $this->clientProphecy->request('post', "/environments/{$environmentResponseApp1->_embedded->items[1]->id}/email/actions/enable")->willReturn($enableResponse);
 
@@ -396,23 +396,23 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
             'y',
         ];
 
-        $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+        $subscriptionsResponse = self::getMockResponseFromSpec('/subscriptions', 'get', '200');
         $this->clientProphecy->request('get', '/subscriptions')
         ->willReturn($subscriptionsResponse->{'_embedded'}->items)
         ->shouldBeCalledTimes(1);
 
-        $postDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
+        $postDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
         $this->clientProphecy->request('post', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains", [
             'form_params' => [
                 'domain' => $baseDomain,
             ],
         ])->willReturn($postDomainsResponse);
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $getDomainsResponse->_embedded->items[0]->domain_name = 'test.com';
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
-        $domainsRegistrationResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
+        $domainsRegistrationResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
         $domainsRegistrationResponse200 = $domainsRegistrationResponse;
         $domainsRegistrationResponse200->health->code = '200';
 
@@ -448,19 +448,19 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
             'y',
         ];
 
-        $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+        $subscriptionsResponse = self::getMockResponseFromSpec('/subscriptions', 'get', '200');
         $this->clientProphecy->request('get', '/subscriptions')
         ->willReturn($subscriptionsResponse->{'_embedded'}->items)
         ->shouldBeCalledTimes(1);
 
-        $postDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
+        $postDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
         $this->clientProphecy->request('post', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains", [
             'form_params' => [
                 'domain' => $baseDomain,
             ],
         ])->willReturn($postDomainsResponse);
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $getDomainsResponse->_embedded->items[0]->domain_name = 'mismatch-test.com';
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
@@ -483,23 +483,23 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
             'y',
         ];
 
-        $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+        $subscriptionsResponse = self::getMockResponseFromSpec('/subscriptions', 'get', '200');
         $this->clientProphecy->request('get', '/subscriptions')
         ->willReturn($subscriptionsResponse->{'_embedded'}->items)
         ->shouldBeCalledTimes(1);
 
-        $postDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
+        $postDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
         $this->clientProphecy->request('post', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains", [
             'form_params' => [
                 'domain' => $baseDomain,
             ],
         ])->willReturn($postDomainsResponse);
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $getDomainsResponse->_embedded->items[0]->domain_name = 'test.com';
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
-        $domainsRegistrationResponse404 = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '404');
+        $domainsRegistrationResponse404 = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '404');
 
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains/{$getDomainsResponse->_embedded->items[0]->uuid}")->willReturn($domainsRegistrationResponse404);
         $this->expectException(AcquiaCliException::class);
@@ -527,22 +527,22 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
         // What are the environments you'd like to enable email for? You may enter multiple separated by a comma.
             '0',
         ];
-        $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+        $subscriptionsResponse = self::getMockResponseFromSpec('/subscriptions', 'get', '200');
         $this->clientProphecy->request('get', '/subscriptions')
         ->willReturn($subscriptionsResponse->{'_embedded'}->items);
 
-        $postDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
+        $postDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
         $this->clientProphecy->request('post', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains", [
             'form_params' => [
                 'domain' => 'test.com',
             ],
         ])->willReturn($postDomainsResponse);
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $getDomainsResponse->_embedded->items[0]->domain_name = 'test.com';
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
-        $domainsRegistrationResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
+        $domainsRegistrationResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
         $domainsRegistrationResponse200 = $domainsRegistrationResponse;
         $domainsRegistrationResponse200->health->code = '200';
 
@@ -553,17 +553,17 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
         $mockFileSystem->dumpFile('dns-records.json', self::JSON_TEST_OUTPUT)->shouldBeCalled();
         $applicationsResponse = $this->mockApplicationsRequest();
 
-        $appDomainsResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
+        $appDomainsResponse = self::getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
         $appDomainsResponse->_embedded->items[0]->domain_name = 'test.com';
         $this->clientProphecy->request('get', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains")->willReturn($appDomainsResponse->_embedded->items);
         // We need the application to belong to the subscription.
         $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
 
-        $associateResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains/{domainRegistrationUuid}/actions/associate', 'post', '200');
+        $associateResponse = self::getMockResponseFromSpec('/applications/{applicationUuid}/email/domains/{domainRegistrationUuid}/actions/associate', 'post', '200');
         $this->clientProphecy->request('post', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains/{$getDomainsResponse->_embedded->items[0]->uuid}/actions/associate")->willReturn($associateResponse);
 
         $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
-        $enableResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/email/actions/enable', 'post', '200');
+        $enableResponse = self::getMockResponseFromSpec('/environments/{environmentId}/email/actions/enable', 'post', '200');
         $this->clientProphecy->request('post', "/environments/{$environmentsResponse->_embedded->items[0]->id}/email/actions/enable")->willReturn($enableResponse);
 
         $this->executeCommand([], $inputs);
@@ -578,23 +578,23 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
      */
     public function testConfigurePlatformEmailWithAlreadyEnabledEnvs(mixed $baseDomain, mixed $inputs, mixed $expectedExitCode, mixed $responseCode, mixed $specKey, mixed $expectedText): void
     {
-        $subscriptionsResponse = $this->getMockResponseFromSpec('/subscriptions', 'get', '200');
+        $subscriptionsResponse = self::getMockResponseFromSpec('/subscriptions', 'get', '200');
         $this->clientProphecy->request('get', '/subscriptions')
         ->willReturn($subscriptionsResponse->{'_embedded'}->items)
         ->shouldBeCalledTimes(1);
 
-        $postDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
+        $postDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'post', '200');
         $this->clientProphecy->request('post', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains", [
             'form_params' => [
                 'domain' => $baseDomain,
             ],
         ])->willReturn($postDomainsResponse);
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $getDomainsResponse->_embedded->items[0]->domain_name = 'example.com';
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptionsResponse->_embedded->items[0]->uuid}/domains")->willReturn($getDomainsResponse->_embedded->items);
 
-        $domainsRegistrationResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
+        $domainsRegistrationResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains/{domainRegistrationUuid}', 'get', '200');
         $domainsRegistrationResponse200 = $domainsRegistrationResponse;
         $domainsRegistrationResponse200->health->code = '200';
 
@@ -602,19 +602,19 @@ class ConfigurePlatformEmailCommandTest extends CommandTestBase
 
         $applicationsResponse = $this->mockApplicationsRequest();
 
-        $appDomainsResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
+        $appDomainsResponse = self::getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
         $appDomainsResponse->_embedded->items[0]->domain_name = 'example.com';
         $this->clientProphecy->request('get', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains")->willReturn($appDomainsResponse->_embedded->items);
         // We need the application to belong to the subscription.
         $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptionsResponse->_embedded->items[0]->uuid;
 
-        $associateResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains/{domainRegistrationUuid}/actions/associate', 'post', '409');
+        $associateResponse = self::getMockResponseFromSpec('/applications/{applicationUuid}/email/domains/{domainRegistrationUuid}/actions/associate', 'post', '409');
 
         $this->clientProphecy->request('post', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains/{$getDomainsResponse->_embedded->items[0]->uuid}/actions/associate")
         ->willThrow(new ApiErrorException($associateResponse->{'Already associated'}->value));
 
         $environmentsResponse = $this->mockEnvironmentsRequest($applicationsResponse);
-        $enableResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/email/actions/enable', 'post', $responseCode);
+        $enableResponse = self::getMockResponseFromSpec('/environments/{environmentId}/email/actions/enable', 'post', $responseCode);
         $this->clientProphecy->request('post', "/environments/{$environmentsResponse->_embedded->items[0]->id}/email/actions/enable")
         ->willThrow(new ApiErrorException($enableResponse->{$specKey}->value));
 

--- a/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
+++ b/tests/phpunit/src/Commands/Email/EmailInfoForSubscriptionCommandTest.php
@@ -34,9 +34,9 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase
         ];
         $subscriptions = $this->mockRequest('getSubscriptions');
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         // Duplicating the request to ensure there is at least one domain with a successful, pending, and failed health code.
-        $getDomainsResponse2 = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse2 = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $totalDomainsList = array_merge($getDomainsResponse->_embedded->items, $getDomainsResponse2->_embedded->items);
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptions[0]->uuid}/domains")
             ->willReturn($totalDomainsList);
@@ -51,9 +51,9 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase
 
         $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptions[0]->uuid;
 
-        $getAppDomainsResponse = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
+        $getAppDomainsResponse = self::getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
         // Duplicating the request to ensure added domains are included in association list.
-        $getAppDomainsResponse2 = $this->getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
+        $getAppDomainsResponse2 = self::getMockResponseFromSpec('/applications/{applicationUuid}/email/domains', 'get', '200');
         $totalAppDomainsList = array_merge($getAppDomainsResponse->_embedded->items, $getAppDomainsResponse2->_embedded->items);
         $this->clientProphecy->request('get', "/applications/{$applicationsResponse->_embedded->items[0]->uuid}/email/domains")
             ->willReturn($totalAppDomainsList);
@@ -88,7 +88,7 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase
         ];
         $subscriptions = $this->mockRequest('getSubscriptions');
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptions[0]->uuid}/domains")
             ->willReturn($getDomainsResponse->_embedded->items);
 
@@ -109,15 +109,15 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase
         ];
         $subscriptions = $this->mockRequest('getSubscriptions');
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptions[0]->uuid}/domains")
             ->willReturn($getDomainsResponse->_embedded->items);
 
-        $applicationsResponse = $this->getMockResponseFromSpec('/applications', 'get', '200');
+        $applicationsResponse = self::getMockResponseFromSpec('/applications', 'get', '200');
         $applicationsResponse->_embedded->items[0]->subscription->uuid = $subscriptions[0]->uuid;
         $applicationsResponse->_embedded->items[1]->subscription->uuid = $subscriptions[0]->uuid;
 
-        $app = $this->getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
+        $app = self::getMockResponseFromSpec('/applications/{applicationUuid}', 'get', '200');
         for ($i = 2; $i < 101; $i++) {
             $applicationsResponse->_embedded->items[$i] = $app;
             $applicationsResponse->_embedded->items[$i]->subscription->uuid = $subscriptions[0]->uuid;
@@ -160,7 +160,7 @@ class EmailInfoForSubscriptionCommandTest extends CommandTestBase
         ];
         $subscriptions = $this->mockRequest('getSubscriptions');
 
-        $getDomainsResponse = $this->getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
+        $getDomainsResponse = self::getMockResponseFromSpec('/subscriptions/{subscriptionUuid}/domains', 'get', '200');
         $this->clientProphecy->request('get', "/subscriptions/{$subscriptions[0]->uuid}/domains")
             ->willReturn($getDomainsResponse->_embedded->items);
 

--- a/tests/phpunit/src/Commands/Env/EnvCertCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvCertCreateCommandTest.php
@@ -35,7 +35,7 @@ class EnvCertCreateCommandTest extends CommandTestBase
             ->willReturn($keyContents)
             ->shouldBeCalled();
 
-        $sslResponse = $this->getMockResponseFromSpec(
+        $sslResponse = self::getMockResponseFromSpec(
             '/environments/{environmentId}/ssl/certificates',
             'post',
             '202'
@@ -94,7 +94,7 @@ class EnvCertCreateCommandTest extends CommandTestBase
             ->willReturn($keyContents)
             ->shouldBeCalled();
 
-        $sslResponse = $this->getMockResponseFromSpec(
+        $sslResponse = self::getMockResponseFromSpec(
             '/environments/{environmentId}/ssl/certificates',
             'post',
             '202'
@@ -160,7 +160,7 @@ class EnvCertCreateCommandTest extends CommandTestBase
             ->willReturn($keyContents)
             ->shouldBeCalled();
 
-        $sslResponse = $this->getMockResponseFromSpec(
+        $sslResponse = self::getMockResponseFromSpec(
             '/environments/{environmentId}/ssl/certificates',
             'post',
             '202'

--- a/tests/phpunit/src/Commands/Env/EnvCopyCronCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvCopyCronCommandTest.php
@@ -22,8 +22,8 @@ class EnvCopyCronCommandTest extends CommandTestBase
 
     public function testCopyCronTasksCommandTest(): void
     {
-        $environmentsResponse = $this->getMockEnvironmentsResponse();
-        $sourceCronsListResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'get', '200');
+        $environmentsResponse = self::getMockEnvironmentsResponse();
+        $sourceCronsListResponse = self::getMockResponseFromSpec('/environments/{environmentId}/crons', 'get', '200');
         $this->clientProphecy->request(
             'get',
             '/environments/' . $environmentsResponse->{'_embedded'}->items[0]->id . '/crons'
@@ -31,7 +31,7 @@ class EnvCopyCronCommandTest extends CommandTestBase
             ->willReturn($sourceCronsListResponse->{'_embedded'}->items)
             ->shouldBeCalled();
 
-        $createCronResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'post', '202');
+        $createCronResponse = self::getMockResponseFromSpec('/environments/{environmentId}/crons', 'post', '202');
         $this->clientProphecy->request(
             'post',
             '/environments/' . $environmentsResponse->{'_embedded'}->items[2]->id . '/crons',
@@ -75,7 +75,7 @@ class EnvCopyCronCommandTest extends CommandTestBase
      */
     public function testNoCronJobOnSource(): void
     {
-        $environmentsResponse = $this->getMockEnvironmentsResponse();
+        $environmentsResponse = self::getMockEnvironmentsResponse();
         $this->clientProphecy->request(
             'get',
             '/environments/' . $environmentsResponse->{'_embedded'}->items[0]->id . '/crons'
@@ -104,8 +104,8 @@ class EnvCopyCronCommandTest extends CommandTestBase
      */
     public function testExceptionOnCronJobCopy(): void
     {
-        $environmentsResponse = $this->getMockEnvironmentsResponse();
-        $sourceCronsListResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'get', '200');
+        $environmentsResponse = self::getMockEnvironmentsResponse();
+        $sourceCronsListResponse = self::getMockResponseFromSpec('/environments/{environmentId}/crons', 'get', '200');
         $this->clientProphecy->request(
             'get',
             '/environments/' . $environmentsResponse->{'_embedded'}->items[0]->id . '/crons'
@@ -113,7 +113,7 @@ class EnvCopyCronCommandTest extends CommandTestBase
             ->willReturn($sourceCronsListResponse->{'_embedded'}->items)
             ->shouldBeCalled();
 
-        $this->getMockResponseFromSpec('/environments/{environmentId}/crons', 'post', '202');
+        self::getMockResponseFromSpec('/environments/{environmentId}/crons', 'post', '202');
         $this->clientProphecy->request(
             'post',
             '/environments/' . $environmentsResponse->{'_embedded'}->items[2]->id . '/crons',

--- a/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvCreateCommandTest.php
@@ -23,8 +23,8 @@ class EnvCreateCommandTest extends CommandTestBase
         $applicationResponse = $this->mockApplicationRequest();
         $this->mockEnvironmentsRequest($applicationsResponse);
 
-        $response1 = $this->getMockEnvironmentsResponse();
-        $response2 = $this->getMockEnvironmentsResponse();
+        $response1 = self::getMockEnvironmentsResponse();
+        $response2 = self::getMockEnvironmentsResponse();
         $cde = $response2->_embedded->items[0];
         $cde->label = $label;
         $response2->_embedded->items[3] = $cde;
@@ -35,7 +35,7 @@ class EnvCreateCommandTest extends CommandTestBase
             ->willReturn($response1->_embedded->items, $response2->_embedded->items)
             ->shouldBeCalled();
 
-        $codeResponse = $this->getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
+        $codeResponse = self::getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
         $this->clientProphecy->request(
             'get',
             "/applications/$applicationResponse->uuid/code"
@@ -43,7 +43,7 @@ class EnvCreateCommandTest extends CommandTestBase
             ->willReturn($codeResponse->_embedded->items)
             ->shouldBeCalled();
 
-        $databasesResponse = $this->getMockResponseFromSpec("/applications/{applicationUuid}/databases", 'get', '200');
+        $databasesResponse = self::getMockResponseFromSpec("/applications/{applicationUuid}/databases", 'get', '200');
         $this->clientProphecy->request(
             'get',
             "/applications/$applicationResponse->uuid/databases"
@@ -51,7 +51,7 @@ class EnvCreateCommandTest extends CommandTestBase
             ->willReturn($databasesResponse->_embedded->items)
             ->shouldBeCalled();
 
-        $environmentsResponse = $this->getMockResponseFromSpec(
+        $environmentsResponse = self::getMockResponseFromSpec(
             '/applications/{applicationUuid}/environments',
             'post',
             202
@@ -64,15 +64,15 @@ class EnvCreateCommandTest extends CommandTestBase
         return $response2->_embedded->items[3]->domains[0];
     }
 
-    private function getBranch(): string
+    private static function getBranch(): string
     {
-        $codeResponse = $this->getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
+        $codeResponse = self::getMockResponseFromSpec("/applications/{applicationUuid}/code", 'get', '200');
         return $codeResponse->_embedded->items[0]->name;
     }
 
-    private function getApplication(): string
+    private static function getApplication(): string
     {
-        $applicationsResponse = $this->getMockResponseFromSpec(
+        $applicationsResponse = self::getMockResponseFromSpec(
             '/applications',
             'get',
             '200'
@@ -88,10 +88,10 @@ class EnvCreateCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestCreateCde(): array
+    public static function providerTestCreateCde(): array
     {
-        $application = $this->getApplication();
-        $branch = $this->getBranch();
+        $application = self::getApplication();
+        $branch = self::getBranch();
         return [
             // No args, only interactive input.
             [[null, null], ['n', 0, 0]],
@@ -136,8 +136,8 @@ class EnvCreateCommandTest extends CommandTestBase
         $this->expectExceptionMessage('An environment named Dev already exists.');
         $this->executeCommand(
             [
-                'applicationUuid' => $this->getApplication(),
-                'branch' => $this->getBranch(),
+                'applicationUuid' => EnvCreateCommandTest::getApplication(),
+                'branch' => EnvCreateCommandTest::getBranch(),
                 'label' => $label,
             ]
         );
@@ -154,7 +154,7 @@ class EnvCreateCommandTest extends CommandTestBase
         $this->expectExceptionMessage('There is no branch or tag with the name bogus on the remote VCS.');
         $this->executeCommand(
             [
-                'applicationUuid' => $this->getApplication(),
+                'applicationUuid' => EnvCreateCommandTest::getApplication(),
                 'branch' => 'bogus',
                 'label' => self::$validLabel,
             ]
@@ -173,8 +173,8 @@ class EnvCreateCommandTest extends CommandTestBase
 
         $this->executeCommand(
             [
-                'applicationUuid' => $this->getApplication(),
-                'branch' => $this->getBranch(),
+                'applicationUuid' => EnvCreateCommandTest::getApplication(),
+                'branch' => EnvCreateCommandTest::getBranch(),
                 'label' => self::$validLabel,
             ]
         );

--- a/tests/phpunit/src/Commands/Env/EnvDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvDeleteCommandTest.php
@@ -22,9 +22,9 @@ class EnvDeleteCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestDeleteCde(): array
+    public static function providerTestDeleteCde(): array
     {
-        $environmentResponse = $this->getMockEnvironmentsResponse();
+        $environmentResponse = self::getMockEnvironmentsResponse();
         $environment = $environmentResponse->_embedded->items[0];
         return [
             [$environment->id],
@@ -42,8 +42,8 @@ class EnvDeleteCommandTest extends CommandTestBase
         $this->mockApplicationRequest();
         $this->mockEnvironmentsRequest($applicationsResponse);
 
-        $this->getMockEnvironmentsResponse();
-        $response2 = $this->getMockEnvironmentsResponse();
+        self::getMockEnvironmentsResponse();
+        $response2 = self::getMockEnvironmentsResponse();
         $cde = $response2->_embedded->items[0];
         $cde->flags->cde = true;
         $label = "New CDE";
@@ -56,7 +56,7 @@ class EnvDeleteCommandTest extends CommandTestBase
             ->willReturn($response2->_embedded->items)
             ->shouldBeCalled();
 
-        $environmentsResponse = $this->getMockResponseFromSpec(
+        $environmentsResponse = self::getMockResponseFromSpec(
             '/environments/{environmentId}',
             'delete',
             202
@@ -65,7 +65,7 @@ class EnvDeleteCommandTest extends CommandTestBase
             ->willReturn($environmentsResponse)
             ->shouldBeCalled();
 
-        $this->getMockResponseFromSpec(
+        self::getMockResponseFromSpec(
             '/environments/{environmentId}',
             'get',
             200
@@ -132,7 +132,7 @@ class EnvDeleteCommandTest extends CommandTestBase
             ->shouldBeCalled();
 
         $cde = $environments[0];
-        $environmentsResponse = $this->getMockResponseFromSpec(
+        $environmentsResponse = self::getMockResponseFromSpec(
             '/environments/{environmentId}',
             'delete',
             202

--- a/tests/phpunit/src/Commands/Env/EnvMirrorCommandTest.php
+++ b/tests/phpunit/src/Commands/Env/EnvMirrorCommandTest.php
@@ -23,7 +23,7 @@ class EnvMirrorCommandTest extends CommandTestBase
     public function testEnvironmentMirror(): void
     {
         $environmentResponse = $this->mockGetEnvironments();
-        $codeSwitchResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
+        $codeSwitchResponse = self::getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
         $response = $codeSwitchResponse->{'Switching code'}->value;
         $this->mockNotificationResponseFromObject($response);
         $response->links = $response->{'_links'};
@@ -39,7 +39,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $databasesResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
+        $databasesResponse = self::getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
         $this->clientProphecy->request(
             'get',
             "/environments/$environmentResponse->id/databases"
@@ -47,7 +47,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($databasesResponse->_embedded->items)
             ->shouldBeCalled();
 
-        $dbCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
+        $dbCopyResponse = self::getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
         $response = $dbCopyResponse->{'Database being copied'}->value;
         $this->mockNotificationResponseFromObject($response);
         $response->links = $response->{'_links'};
@@ -60,7 +60,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $filesCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
+        $filesCopyResponse = self::getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
         $response = $filesCopyResponse->{'Files queued for copying'}->value;
         $this->mockNotificationResponseFromObject($response);
         $response->links = $response->{'_links'};
@@ -72,7 +72,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $environmentUpdateResponse = $this->getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
+        $environmentUpdateResponse = self::getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
         $this->clientProphecy->request('put', "/environments/$environmentResponse->id", Argument::type('array'))
             ->willReturn($environmentUpdateResponse)
             ->shouldBeCalled();
@@ -101,7 +101,7 @@ class EnvMirrorCommandTest extends CommandTestBase
     public function testEnvironmentMirrorDbCopyFail(): void
     {
         $environmentResponse = $this->mockGetEnvironments();
-        $codeSwitchResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
+        $codeSwitchResponse = self::getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
         $response = $codeSwitchResponse->{'Switching code'}->value;
         $this->mockNotificationResponseFromObject($response);
         $response->links = $response->{'_links'};
@@ -117,7 +117,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $databasesResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
+        $databasesResponse = self::getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
         $this->clientProphecy->request(
             'get',
             "/environments/$environmentResponse->id/databases"
@@ -125,7 +125,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($databasesResponse->_embedded->items)
             ->shouldBeCalled();
 
-        $dbCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
+        $dbCopyResponse = self::getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
         $response = $dbCopyResponse->{'Database being copied'}->value;
         $this->mockNotificationResponseFromObject($response, false);
         $response->links = $response->{'_links'};
@@ -138,7 +138,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $filesCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
+        $filesCopyResponse = self::getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
         $response = $filesCopyResponse->{'Files queued for copying'}->value;
         $response->links = $response->{'_links'};
         $this->clientProphecy->request('post', "/environments/$environmentResponse->id/files", [
@@ -149,7 +149,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $environmentUpdateResponse = $this->getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
+        $environmentUpdateResponse = self::getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
         $this->clientProphecy->request('put', "/environments/$environmentResponse->id", Argument::type('array'))
             ->willReturn($environmentUpdateResponse)
             ->shouldBeCalled();
@@ -171,7 +171,7 @@ class EnvMirrorCommandTest extends CommandTestBase
     public function testEnvironmentMirrorFileCopyFail(): void
     {
         $environmentResponse = $this->mockGetEnvironments();
-        $codeSwitchResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
+        $codeSwitchResponse = self::getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
         $response = $codeSwitchResponse->{'Switching code'}->value;
         $this->mockNotificationResponseFromObject($response);
         $response->links = $response->{'_links'};
@@ -187,7 +187,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $databasesResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
+        $databasesResponse = self::getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
         $this->clientProphecy->request(
             'get',
             "/environments/$environmentResponse->id/databases"
@@ -195,7 +195,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($databasesResponse->_embedded->items)
             ->shouldBeCalled();
 
-        $dbCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
+        $dbCopyResponse = self::getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
         $response = $dbCopyResponse->{'Database being copied'}->value;
         $this->mockNotificationResponseFromObject($response);
         $response->links = $response->{'_links'};
@@ -208,7 +208,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $filesCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
+        $filesCopyResponse = self::getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
         $response = $filesCopyResponse->{'Files queued for copying'}->value;
         $this->mockNotificationResponseFromObject($response, false);
         $response->links = $response->{'_links'};
@@ -220,7 +220,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $environmentUpdateResponse = $this->getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
+        $environmentUpdateResponse = self::getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
         $this->clientProphecy->request('put', "/environments/$environmentResponse->id", Argument::type('array'))
             ->willReturn($environmentUpdateResponse)
             ->shouldBeCalled();
@@ -242,7 +242,7 @@ class EnvMirrorCommandTest extends CommandTestBase
     public function testEnvironmentMirrorFiCopyFail(): void
     {
         $environmentResponse = $this->mockGetEnvironments();
-        $codeSwitchResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
+        $codeSwitchResponse = self::getMockResponseFromSpec("/environments/{environmentId}/code/actions/switch", 'post', '202');
         $response = $codeSwitchResponse->{'Switching code'}->value;
         $this->mockNotificationResponseFromObject($response);
         $response->links = $response->{'_links'};
@@ -258,7 +258,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $databasesResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
+        $databasesResponse = self::getMockResponseFromSpec("/environments/{environmentId}/databases", 'get', '200');
         $this->clientProphecy->request(
             'get',
             "/environments/$environmentResponse->id/databases"
@@ -266,7 +266,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($databasesResponse->_embedded->items)
             ->shouldBeCalled();
 
-        $dbCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
+        $dbCopyResponse = self::getMockResponseFromSpec("/environments/{environmentId}/databases", 'post', '202');
         $response = $dbCopyResponse->{'Database being copied'}->value;
         $this->mockNotificationResponseFromObject($response);
         $response->links = $response->{'_links'};
@@ -279,7 +279,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $filesCopyResponse = $this->getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
+        $filesCopyResponse = self::getMockResponseFromSpec("/environments/{environmentId}/files", 'post', '202');
         $response = $filesCopyResponse->{'Files queued for copying'}->value;
         $this->mockNotificationResponseFromObject($response);
         $response->links = $response->{'_links'};
@@ -291,7 +291,7 @@ class EnvMirrorCommandTest extends CommandTestBase
             ->willReturn($response)
             ->shouldBeCalled();
 
-        $environmentUpdateResponse = $this->getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
+        $environmentUpdateResponse = self::getMockResponseFromSpec("/environments/{environmentId}", 'put', '202');
         $this->clientProphecy->request('put', "/environments/$environmentResponse->id", Argument::type('array'))
             ->willReturn($environmentUpdateResponse)
             ->shouldBeCalled();

--- a/tests/phpunit/src/Commands/Ide/IdeListCommandMineTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeListCommandMineTest.php
@@ -20,7 +20,7 @@ class IdeListCommandMineTest extends CommandTestBase
 
     public function testIdeListMineCommand(): void
     {
-        $applicationsResponse = $this->getMockResponseFromSpec('/applications', 'get', '200');
+        $applicationsResponse = self::getMockResponseFromSpec('/applications', 'get', '200');
         $idesResponse = $this->mockAccountIdeListRequest();
         foreach ($idesResponse->{'_embedded'}->items as $key => $ide) {
             $applicationResponse = $applicationsResponse->{'_embedded'}->items[$key];
@@ -61,7 +61,7 @@ class IdeListCommandMineTest extends CommandTestBase
 
     protected function mockAccountIdeListRequest(): object
     {
-        $response = $this->getMockResponseFromSpec(
+        $response = self::getMockResponseFromSpec(
             '/account/ides',
             'get',
             '200'

--- a/tests/phpunit/src/Commands/Ide/IdePhpVersionCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdePhpVersionCommandTest.php
@@ -29,7 +29,7 @@ class IdePhpVersionCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestIdePhpVersionCommand(): array
+    public static function providerTestIdePhpVersionCommand(): array
     {
         return [
             ['7.4'],
@@ -63,7 +63,7 @@ class IdePhpVersionCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestIdePhpVersionCommandFailure(): array
+    public static function providerTestIdePhpVersionCommandFailure(): array
     {
         return [
             ['6.3', AcquiaCliException::class],

--- a/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
+++ b/tests/phpunit/src/Commands/Ide/IdeXdebugToggleCommandTest.php
@@ -46,7 +46,7 @@ class IdeXdebugToggleCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestXdebugCommandEnable(): array
+    public static function providerTestXdebugCommandEnable(): array
     {
         return [
             ['7.4'],

--- a/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCodeCommandTest.php
@@ -224,7 +224,7 @@ class PullCodeCommandTest extends PullCommandTestBase
     /**
      * @return string[][]
      */
-    public function providerTestMatchPhpVersion(): array
+    public static function providerTestMatchPhpVersion(): array
     {
         return [
             ['7.1'],

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -381,7 +381,7 @@ abstract class PullCommandTestBase extends CommandTestBase
             $this->httpClientProphecy->request('GET', 'https://other.example.com/download-backup', Argument::type('array'))
                 ->willReturn($response->reveal())
                 ->shouldBeCalled();
-            $domainsResponse = $this->getMockResponseFromSpec('/environments/{environmentId}/domains', 'get', 200);
+            $domainsResponse = self::getMockResponseFromSpec('/environments/{environmentId}/domains', 'get', 200);
             $this->clientProphecy->request('get', "/environments/$environment->id/domains")
                 ->willReturn($domainsResponse->_embedded->items);
             $this->command->setBackupDownloadUrl(new Uri('https://www.example.com/download-backup'));

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -23,7 +23,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase
     /**
      * @return int[][]
      */
-    public function providerTestPullDatabaseWithInvalidSslCertificate(): array
+    public static function providerTestPullDatabaseWithInvalidSslCertificate(): array
     {
         return [[51], [60]];
     }

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -36,14 +36,14 @@ To run additional build or sanitization steps (e.g. <options=bold>npm install</>
 
 This command is designed for a specific scenario in which there are two branches or repositories involved: a source branch without vendor files committed, and an artifact branch with them. If both your source and destination branches are the same, you should simply use git push instead.
 EOF;
-        self::assertStringContainsStringIgnoringLineEndings($expectedHelp, $help);
+        self::assertStringEqualsStringIgnoringLineEndings($expectedHelp, $help);
         $this->assertStringNotContainsString('This command requires authentication', $help);
     }
 
     /**
      * @return mixed[]
      */
-    public function providerTestPushArtifact(): array
+    public static function providerTestPushArtifact(): array
     {
         return [
             [OutputInterface::VERBOSITY_NORMAL, false],

--- a/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushDatabaseCommandTest.php
@@ -24,7 +24,7 @@ class PushDatabaseCommandTest extends CommandTestBase
     /**
      * @return mixed[]
      */
-    public function providerTestPushDatabase(): array
+    public static function providerTestPushDatabase(): array
     {
         return [
             [OutputInterface::VERBOSITY_NORMAL, false, false],

--- a/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesDownloadCommandTest.php
@@ -35,7 +35,7 @@ class AliasesDownloadCommandTest extends CommandTestBase
      *
      * @return array<array<mixed>>
      */
-    public function providerTestRemoteAliasesDownloadCommand(): array
+    public static function providerTestRemoteAliasesDownloadCommand(): array
     {
         return [
             [['9'], []],
@@ -73,7 +73,7 @@ class AliasesDownloadCommandTest extends CommandTestBase
             $destinationDir = Path::join($homeDir, '.drush');
         }
         if ($aliasVersion === '9' && !$all) {
-            $applicationsResponse = $this->getMockResponseFromSpec('/applications', 'get', '200');
+            $applicationsResponse = self::getMockResponseFromSpec('/applications', 'get', '200');
             $cloudApplication = $applicationsResponse->{'_embedded'}->items[0];
             $cloudApplicationUuid = $cloudApplication->uuid;
             $this->createMockAcliConfigFile($cloudApplicationUuid);

--- a/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/DrushCommandTest.php
@@ -22,7 +22,7 @@ class DrushCommandTest extends SshCommandTestBase
     /**
      * @return array<array<array<string>>>
      */
-    public function providerTestRemoteDrushCommand(): array
+    public static function providerTestRemoteDrushCommand(): array
     {
         return [
             [

--- a/tests/phpunit/src/Commands/Self/ClearCacheCommandTest.php
+++ b/tests/phpunit/src/Commands/Self/ClearCacheCommandTest.php
@@ -28,7 +28,7 @@ class ClearCacheCommandTest extends CommandTestBase
         $this->command = $this->injectCommand(IdeListCommand::class);
 
         // Request for applications.
-        $applicationsResponse = $this->getMockResponseFromSpec(
+        $applicationsResponse = self::getMockResponseFromSpec(
             '/applications',
             'get',
             '200'

--- a/tests/phpunit/src/Commands/Self/TelemetryCommandTest.php
+++ b/tests/phpunit/src/Commands/Self/TelemetryCommandTest.php
@@ -49,7 +49,7 @@ class TelemetryCommandTest extends CommandTestBase
     /**
      * @return string[][]
      */
-    public function providerTestTelemetryPrompt(): array
+    public static function providerTestTelemetryPrompt(): array
     {
         return [
             [

--- a/tests/phpunit/src/Commands/Ssh/SshKeyCreateCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyCreateCommandTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Filesystem\Path;
  */
 class SshKeyCreateCommandTest extends CommandTestBase
 {
-    protected string $filename = 'id_rsa_acli_test';
+    protected static string $filename = 'id_rsa_acli_test';
 
     protected function createCommand(): CommandBase
     {
@@ -25,14 +25,14 @@ class SshKeyCreateCommandTest extends CommandTestBase
     /**
      * @return array<mixed>
      */
-    public function providerTestCreate(): array
+    public static function providerTestCreate(): array
     {
         return [
             [
                 true,
                 // Args.
                 [
-                    '--filename' => $this->filename,
+                    '--filename' => self::$filename,
                     '--password' => 'acli123',
                 ],
                 // Inputs.
@@ -45,7 +45,7 @@ class SshKeyCreateCommandTest extends CommandTestBase
                 // Inputs.
                 [
                     // Enter a filename for your new local SSH key:
-                    $this->filename,
+                    self::$filename,
                     // Enter a password for your SSH key:
                     'acli123',
                 ],
@@ -57,7 +57,7 @@ class SshKeyCreateCommandTest extends CommandTestBase
                 // Inputs.
                 [
                     // Enter a filename for your new local SSH key:
-                    $this->filename,
+                    self::$filename,
                     // Enter a password for your SSH key:
                     'acli123',
                 ],
@@ -71,7 +71,7 @@ class SshKeyCreateCommandTest extends CommandTestBase
      */
     public function testCreate(mixed $sshAddSuccess, mixed $args, mixed $inputs): void
     {
-        $sshKeyFilepath = Path::join($this->sshDir, '/' . $this->filename);
+        $sshKeyFilepath = Path::join($this->sshDir, '/' . self::$filename);
         $this->fs->remove($sshKeyFilepath);
         $localMachineHelper = $this->mockLocalMachineHelper();
         $localMachineHelper->getLocalFilepath('~/.passphrase')

--- a/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyCreateUploadCommandTest.php
@@ -34,7 +34,7 @@ class SshKeyCreateUploadCommandTest extends CommandTestBase
 
     public function testCreateUpload(): void
     {
-        $mockRequestArgs = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+        $mockRequestArgs = self::getMockRequestBodyFromSpec('/account/ssh-keys');
 
         $sshKeyFilename = 'id_rsa';
         $localMachineHelper = $this->mockLocalMachineHelper();

--- a/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyListCommandTest.php
@@ -28,11 +28,11 @@ class SshKeyListCommandTest extends CommandTestBase
     public function testList(): void
     {
 
-        $mockBody = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
+        $mockBody = self::getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
         $this->clientProphecy->request('get', '/account/ssh-keys')
             ->willReturn($mockBody->{'_embedded'}->items)
             ->shouldBeCalled();
-        $mockRequestArgs = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+        $mockRequestArgs = self::getMockRequestBodyFromSpec('/account/ssh-keys');
         $tempFileName = $this->createLocalSshKey($mockRequestArgs['public_key']);
         $baseFilename = basename($tempFileName);
         $this->executeCommand();

--- a/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyUploadCommandTest.php
@@ -21,10 +21,11 @@ class SshKeyUploadCommandTest extends CommandTestBase
 
     /**
      * @return array<mixed>
+     * @throws \Psr\Cache\InvalidArgumentException
      */
-    public function providerTestUpload(): array
+    public static function providerTestUpload(): array
     {
-        $sshKeysRequestBody = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+        $sshKeysRequestBody = self::getMockRequestBodyFromSpec('/account/ssh-keys');
         return [
             [
                 // Args.
@@ -67,7 +68,7 @@ class SshKeyUploadCommandTest extends CommandTestBase
      */
     public function testUpload(array $args, array $inputs, bool $perms): void
     {
-        $sshKeysRequestBody = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+        $sshKeysRequestBody = self::getMockRequestBodyFromSpec('/account/ssh-keys');
         $body = [
             'json' => [
                 'label' => $sshKeysRequestBody['label'],
@@ -111,7 +112,7 @@ class SshKeyUploadCommandTest extends CommandTestBase
     // Ensure permission checks aren't against a Node environment.
     public function testUploadNode(): void
     {
-        $sshKeysRequestBody = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+        $sshKeysRequestBody = self::getMockRequestBodyFromSpec('/account/ssh-keys');
         $body = [
             'json' => [
                 'label' => $sshKeysRequestBody['label'],

--- a/tests/phpunit/src/Commands/WizardTestBase.php
+++ b/tests/phpunit/src/Commands/WizardTestBase.php
@@ -25,7 +25,7 @@ abstract class WizardTestBase extends CommandTestBase
      */
     public function setUp(): void
     {
-        TestBase::setEnvVars(self::getEnvVars());
+        self::setEnvVars(self::getEnvVars());
         parent::setUp();
         $this->getCommandTester();
         $this->application->addCommands([
@@ -38,7 +38,7 @@ abstract class WizardTestBase extends CommandTestBase
     protected function tearDown(): void
     {
         parent::tearDown();
-        TestBase::unsetEnvVars(self::getEnvVars());
+        self::unsetEnvVars(self::getEnvVars());
     }
 
     /**
@@ -53,11 +53,11 @@ abstract class WizardTestBase extends CommandTestBase
 
     protected function runTestCreate(): void
     {
-        $environmentsResponse = $this->getMockEnvironmentsResponse();
+        $environmentsResponse = self::getMockEnvironmentsResponse();
         $this->clientProphecy->request('get', "/applications/" . $this::$applicationUuid . "/environments")
             ->willReturn($environmentsResponse->_embedded->items)
             ->shouldBeCalled();
-        $request = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
+        $request = self::getMockRequestBodyFromSpec('/account/ssh-keys');
 
         $body = [
             'json' => [
@@ -108,8 +108,8 @@ abstract class WizardTestBase extends CommandTestBase
 
     protected function runTestSshKeyAlreadyUploaded(): void
     {
-        $mockRequestArgs = $this->getMockRequestBodyFromSpec('/account/ssh-keys');
-        $sshKeysResponse = $this->getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
+        $mockRequestArgs = self::getMockRequestBodyFromSpec('/account/ssh-keys');
+        $sshKeysResponse = self::getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
         // Make the uploaded key match the created one.
         $sshKeysResponse->_embedded->items[0]->public_key = $mockRequestArgs['public_key'];
         $this->clientProphecy->request('get', '/account/ssh-keys')
@@ -126,7 +126,7 @@ abstract class WizardTestBase extends CommandTestBase
             ->willReturn($deleteResponse->reveal())
             ->shouldBeCalled();
 
-        $environmentsResponse = $this->getMockEnvironmentsResponse();
+        $environmentsResponse = self::getMockEnvironmentsResponse();
         $this->clientProphecy->request('get', "/applications/" . $this::$applicationUuid . "/environments")
             ->willReturn($environmentsResponse->_embedded->items)
             ->shouldBeCalled();

--- a/tests/phpunit/src/Misc/EnvDbCredsTest.php
+++ b/tests/phpunit/src/Misc/EnvDbCredsTest.php
@@ -25,14 +25,14 @@ class EnvDbCredsTest extends CommandTestBase
         $this->dbPassword = 'mypasswordisgreat';
         $this->dbName = 'mynameisgrand';
         $this->dbHost = 'myhostismeh';
-        TestBase::setEnvVars($this->getEnvVars());
+        self::setEnvVars($this->getEnvVars());
         parent::setUp();
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        TestBase::unsetEnvVars($this->getEnvVars());
+        self::unsetEnvVars($this->getEnvVars());
     }
 
     /**

--- a/tests/phpunit/src/Misc/ExceptionListenerTest.php
+++ b/tests/phpunit/src/Misc/ExceptionListenerTest.php
@@ -51,7 +51,7 @@ class ExceptionListenerTest extends TestBase
     /**
      * @return string[][]
      */
-    public function providerTestHelp(): array
+    public static function providerTestHelp(): array
     {
         return [
             [

--- a/tests/phpunit/src/Misc/LocalMachineHelperTest.php
+++ b/tests/phpunit/src/Misc/LocalMachineHelperTest.php
@@ -23,7 +23,7 @@ class LocalMachineHelperTest extends TestBase
     /**
      * @return bool[][]
      */
-    public function providerTestExecuteFromCmd(): array
+    public static function providerTestExecuteFromCmd(): array
     {
         return [
             [false, null, null],

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -19,7 +19,7 @@ class TelemetryHelperTest extends TestBase
             $envVars = array_merge($envVars, $args[1]);
         }
 
-        self::unsetEnvVars($envVars);
+        TestBase::unsetEnvVars($envVars);
     }
 
     public function unsetGitHubEnvVars(): void
@@ -31,7 +31,7 @@ class TelemetryHelperTest extends TestBase
         foreach ($providers['github'] as $var) {
             $github_env_vars[$var] = self::ENV_VAR_DEFAULT_VALUE;
         }
-        self::unsetEnvVars($github_env_vars);
+        TestBase::unsetEnvVars($github_env_vars);
     }
 
     /**
@@ -58,7 +58,7 @@ class TelemetryHelperTest extends TestBase
     public function testEnvironmentProvider(string $provider, array $envVars): void
     {
         $this->unsetGitHubEnvVars();
-        self::setEnvVars($envVars);
+        TestBase::setEnvVars($envVars);
         $this->assertEquals($provider, TelemetryHelper::getEnvironmentProvider());
     }
 

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -15,7 +15,7 @@ class TelemetryHelperTest extends TestBase
     {
         parent::tearDown();
         $envVars = [];
-        foreach ($this->providerTestEnvironmentProvider() as $args) {
+        foreach (self::providerTestEnvironmentProvider() as $args) {
             $envVars = array_merge($envVars, $args[1]);
         }
 

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -53,6 +53,7 @@ class TelemetryHelperTest extends TestBase
     }
 
     /**
+     * @group serial
      * @dataProvider providerTestEnvironmentProvider()
      */
     public function testEnvironmentProvider(string $provider, array $envVars): void
@@ -65,6 +66,8 @@ class TelemetryHelperTest extends TestBase
     /**
      * Test the getEnvironmentProvider method when no environment provider is
      * detected.
+     *
+     * @group serial
      */
     public function testGetEnvironmentProviderWithoutAnyEnvSet(): void
     {
@@ -98,6 +101,7 @@ class TelemetryHelperTest extends TestBase
      *   The Acquia hosting environment.
      * @param string $expected
      *   The expected normalized environment.
+     * @group serial
      */
     public function testAhEnvNormalization(string $ah_env, string $expected): void
     {

--- a/tests/phpunit/src/Misc/TelemetryHelperTest.php
+++ b/tests/phpunit/src/Misc/TelemetryHelperTest.php
@@ -19,7 +19,7 @@ class TelemetryHelperTest extends TestBase
             $envVars = array_merge($envVars, $args[1]);
         }
 
-        TestBase::unsetEnvVars($envVars);
+        self::unsetEnvVars($envVars);
     }
 
     public function unsetGitHubEnvVars(): void
@@ -31,13 +31,13 @@ class TelemetryHelperTest extends TestBase
         foreach ($providers['github'] as $var) {
             $github_env_vars[$var] = self::ENV_VAR_DEFAULT_VALUE;
         }
-        TestBase::unsetEnvVars($github_env_vars);
+        self::unsetEnvVars($github_env_vars);
     }
 
     /**
      * @return array<mixed>
      */
-    public function providerTestEnvironmentProvider(): array
+    public static function providerTestEnvironmentProvider(): array
     {
         $providersList = TelemetryHelper::getProviders();
         $providersArray = [];
@@ -58,7 +58,7 @@ class TelemetryHelperTest extends TestBase
     public function testEnvironmentProvider(string $provider, array $envVars): void
     {
         $this->unsetGitHubEnvVars();
-        TestBase::setEnvVars($envVars);
+        self::setEnvVars($envVars);
         $this->assertEquals($provider, TelemetryHelper::getEnvironmentProvider());
     }
 
@@ -78,7 +78,7 @@ class TelemetryHelperTest extends TestBase
      * @return mixed[]
      *   The data provider.
      */
-    public function providerTestAhEnvNormalization(): array
+    public static function providerTestAhEnvNormalization(): array
     {
         return [
             ['prod', 'prod'],


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1423

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

Paratest dropped support for PHP 8.1 so we can't upgrade past 7.3.1. Unfortunately 7.3.1 is incompatible with newer versions of PHPUnit so we have to pin it until PHP 8.1 is EOL 😢 

https://github.com/paratestphp/paratest/issues/890

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
