### PR TITLE
CLI-1412: [auth:login] PHP warning

### DIFF
--- a/src/Config/CloudDataConfig.php
+++ b/src/Config/CloudDataConfig.php
@@ -67,7 +67,7 @@ class CloudDataConfig implements ConfigurationInterface
             ->end()
             ->validate()
             ->ifTrue(function ($config) {
-                return is_array($config['keys']) && !empty($config['keys']) && !array_key_exists($config['acli_key'], $config['keys']);
+                return !empty($config['acli_key']) && (!is_array($config['keys']) || empty($config['keys']) || !array_key_exists($config['acli_key'], $config['keys']));
             })
             ->thenInvalid('acli_key must exist in keys');
         return $treeBuilder;


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1412

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
I suspect the root cause is keys being an empty array while there’s an active key, which passes the schema validation but obviously isn’t valid.

In troubleshooting this I found a related bug, which is that running auth:logout creates an invalid schema.

The fix in both cases is to adjust the schema validation logic.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
