### PR TITLE
CLI-1429: Allow production environments for log:tail and drush commands

### DIFF
--- a/src/Command/App/LogTailCommand.php
+++ b/src/Command/App/LogTailCommand.php
@@ -54,7 +54,7 @@ final class LogTailCommand extends CommandBase
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $environment = $this->determineEnvironment($input, $output);
+        $environment = $this->determineEnvironment($input, $output, true);
         $acquiaCloudClient = $this->cloudApiClientService->getClient();
         $logs = $this->promptChooseLogs();
         $logTypes = array_map(static function (mixed $log) {

--- a/src/Command/Remote/DrushCommand.php
+++ b/src/Command/Remote/DrushCommand.php
@@ -33,7 +33,7 @@ final class DrushCommand extends SshBaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
-        $environment = $this->determineEnvironment($input, $output);
+        $environment = $this->determineEnvironment($input, $output, true);
         $alias = self::getEnvironmentAlias($environment);
         $acliArguments = $input->getArguments();
         $drushArguments = (array) $acliArguments['drush_command'];


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. (add specific steps for this pr)
