### PR TITLE
CLI-822: Add --task-wait option to API commands

### DIFF
--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -100,6 +100,11 @@ class ApiCommandHelper
             $inputDefinition = array_merge($inputDefinition, $bodyInputDefinition);
         }
 
+        // Add --task-wait parameter for responses with notifications.
+        if (array_key_exists('responses', $schema) && array_key_exists(202, $schema['responses'])) {
+            $inputDefinition[] = new InputOption('task-wait', null, InputOption::VALUE_NONE, 'Wait for this task to complete');
+        }
+
         $command->setDefinition(new InputDefinition($inputDefinition));
         if ($usage) {
             $command->addUsage(rtrim($usage));


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-822

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Add a `--task-wait` option to API commands that return a notification which will cause the command to wait for the notification to complete.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. Clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check the help for a command that returns notifications, see it includes the `--task-wait` option: `wacli help api:environments:code-switch`
4. Run the command without the `--task-wait` option, see it behaves like before: `wacli api:environments:code-switch pipelinesvalidation2.dev master`
5. Run the command with `--task-wait`, see it waits for the task to complete: `wacli api:environments:code-switch pipelinesvalidation2.dev master --task-wait`
