### PR TITLE
CLI-1406: Command documentation markup

### DIFF
--- a/src/Command/Self/MakeDocsCommand.php
+++ b/src/Command/Self/MakeDocsCommand.php
@@ -7,6 +7,7 @@ namespace Acquia\Cli\Command\Self;
 use Acquia\Cli\Command\CommandBase;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,7 +20,7 @@ final class MakeDocsCommand extends CommandBase
     protected function configure(): void
     {
         $this->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'The format to describe the docs in.', 'rst');
-        $this->addOption('dump', 'd', InputOption::VALUE_OPTIONAL, 'Dump docs to directory');
+        $this->addOption('dump', 'd', InputOption::VALUE_OPTIONAL, 'Dump docs to directory (implies JSON format)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -46,6 +47,7 @@ final class MakeDocsCommand extends CommandBase
                 continue;
             }
             $filename = $command['name'] . '.json';
+            $command['help'] = (new OutputFormatter())->format($command['help']);
             $index[] = [
                 'command' => $command['name'],
                 'help' => $command['help'],

--- a/tests/phpunit/src/Commands/Self/MakeDocsCommandTest.php
+++ b/tests/phpunit/src/Commands/Self/MakeDocsCommandTest.php
@@ -7,6 +7,7 @@ namespace Acquia\Cli\Tests\Commands\Self;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Self\MakeDocsCommand;
 use Acquia\Cli\Tests\CommandTestBase;
+use org\bovigo\vfs\vfsStream;
 
 /**
  * @property \Acquia\Cli\Command\Self\MakeDocsCommand $command
@@ -25,5 +26,12 @@ class MakeDocsCommandTest extends CommandTestBase
         $this->assertStringContainsString('Console Tool', $output);
         $this->assertStringContainsString('============', $output);
         $this->assertStringContainsString('- `help`_', $output);
+    }
+
+    public function testMakeDocsCommandDump(): void
+    {
+        $vfs = vfsStream::setup('root');
+        $this->executeCommand(['--dump' => $vfs->url()]);
+        $this->assertStringContainsString('The completion command dumps', $vfs->getChild('completion.json')->getContent());
     }
 }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1406

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
Ideally we'd fix or extend the JsonDescriptor instead of handling this in post-processing. Unfortunately, all the JsonDescriptor methods are private and the Descriptor base class is marked as internal.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: (add specific steps for this pr)
4. Check new functionality: (add specific steps for this pr)
