### PR TITLE
CLI-1473: Pull default site if non-interactive.

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1411,7 +1411,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
         if ($process->isSuccessful() && $sites) {
             if ($key = array_search('default', $sites, true)) {
                 unset($sites[$key]);
-                $sites = array_merge([0 => 'default'], $sites);
+                array_unshift($sites, 'default');
             }
             return $sites;
         }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1409,6 +1409,10 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
         $process = $this->sshHelper->executeCommand($cloudEnvironment->sshUrl, $command, false);
         $sites = array_filter(explode("\n", trim($process->getOutput())));
         if ($process->isSuccessful() && $sites) {
+            if ($key = array_search('default', $sites, true)) {
+                unset($sites[$key]);
+                $sites = array_merge([0 => 'default'], $sites);
+            }
             return $sites;
         }
 

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -458,10 +458,6 @@ abstract class PullCommandBase extends CommandBase
             return $input->getArgument('site');
         }
 
-        if (!$this->input->isInteractive()) {
-            return 'default';
-        }
-
         $this->site = $this->promptChooseDrupalSite($environment);
 
         return $this->site;

--- a/src/Command/Pull/PullCommandBase.php
+++ b/src/Command/Pull/PullCommandBase.php
@@ -458,6 +458,10 @@ abstract class PullCommandBase extends CommandBase
             return $input->getArgument('site');
         }
 
+        if (!$this->input->isInteractive()) {
+            return 'default';
+        }
+
         $this->site = $this->promptChooseDrupalSite($environment);
 
         return $this->site;

--- a/tests/phpunit/src/Commands/Pull/PullCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTest.php
@@ -55,7 +55,7 @@ class PullCommandTest extends PullCommandTestBase
         $this->mockGetFilesystem($localMachineHelper);
         $parts = explode('.', $environment->ssh_url);
         $sitegroup = reset($parts);
-        $this->mockExecuteRsync($localMachineHelper, $environment, '/mnt/files/' . $sitegroup . '.' . $environment->name . '/sites/bar/files/', $this->projectDir . '/docroot/sites/bar/files');
+        $this->mockExecuteRsync($localMachineHelper, $environment, '/mnt/files/' . $sitegroup . '.' . $environment->name . '/sites/default/files/', $this->projectDir . '/docroot/sites/default/files');
         $this->command->sshHelper = $sshHelper->reveal();
 
         // Pull database.

--- a/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullFilesCommandTest.php
@@ -81,7 +81,7 @@ class PullFilesCommandTest extends PullCommandTestBase
         $this->mockGetFilesystem($localMachineHelper);
         $parts = explode('.', $selectedEnvironment->ssh_url);
         $sitegroup = reset($parts);
-        $this->mockExecuteRsync($localMachineHelper, $selectedEnvironment, '/mnt/files/' . $sitegroup . '.' . $selectedEnvironment->name . '/sites/bar/files/', $this->projectDir . '/docroot/sites/bar/files');
+        $this->mockExecuteRsync($localMachineHelper, $selectedEnvironment, '/mnt/files/' . $sitegroup . '.' . $selectedEnvironment->name . '/sites/default/files/', $this->projectDir . '/docroot/sites/default/files');
 
         $this->command->sshHelper = $sshHelper->reveal();
 

--- a/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushFilesCommandTest.php
@@ -145,8 +145,8 @@ class PushFilesCommandTest extends CommandTestBase
             'rsync',
             '-avPhze',
             'ssh -o StrictHostKeyChecking=no',
-            $this->projectDir . '/docroot/sites/bar/files/',
-            $environment->ssh_url . ':/mnt/files/' . $sitegroup . '.' . $environment->name . '/sites/bar/files',
+            $this->projectDir . '/docroot/sites/default/files/',
+            $environment->ssh_url . ':/mnt/files/' . $sitegroup . '.' . $environment->name . '/sites/default/files',
         ];
         $localMachineHelper->execute($command, Argument::type('callable'), null, true)
             ->willReturn($process->reveal())


### PR DESCRIPTION
If your site has multiple databases, acli pull:db --no-interaction will not pull the default database, which is the logical default.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->

Ran into this issue using `ddev pull acquia` on a site with multiple databases.

https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/acquia.yaml#L53

It wasn't pulling the default, which I would expect.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

Use the default site when non-interactive.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

Try `acli pull:db --no-interaction` on a site with multiple databases.

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: (add specific steps for this pr)
4. Check new functionality: (add specific steps for this pr)
