### PR TITLE
Add option for bootstrapping new site with Drupal CMS

### DIFF
--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -23,6 +23,7 @@ final class NewCommand extends CommandBase
      */
     private static array $distros = [
         'acquia_drupal_recommended' => 'acquia/drupal-recommended-project',
+        'acquia_drupal_cms' => 'acquia/drupal-cms-project',
         'acquia_next_acms' => 'acquia/next-acms',
     ];
     protected function configure(): void
@@ -39,6 +40,7 @@ final class NewCommand extends CommandBase
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output->writeln('Acquia recommends most customers use <options=bold>acquia/drupal-recommended-project</> to setup a Drupal project, which includes useful utilities such as Acquia Connector.');
+        $this->output->writeln('<options=bold>acquia/drupal-cms-project</> is Drupal CMS scaffolded to work with Acquia hosting.');
         $this->output->writeln('<options=bold>acquia/next-acms</> is a starter template for building a headless site powered by Acquia CMS and Next.js.');
 
         if ($input->hasOption('template') && $input->getOption('template')) {

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -22,8 +22,8 @@ final class NewCommand extends CommandBase
      * @var string[]
      */
     private static array $distros = [
-        'acquia_drupal_recommended' => 'acquia/drupal-recommended-project',
         'acquia_drupal_cms' => 'acquia/drupal-cms-project',
+        'acquia_drupal_recommended' => 'acquia/drupal-recommended-project',
         'acquia_next_acms' => 'acquia/next-acms',
     ];
     protected function configure(): void

--- a/tests/phpunit/src/Commands/App/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/App/NewCommandTest.php
@@ -91,6 +91,7 @@ class NewCommandTest extends CommandTestBase
 
         $output = $this->getDisplay();
         $this->assertStringContainsString('Acquia recommends most customers use acquia/drupal-recommended-project to setup a Drupal project', $output);
+        $this->assertStringContainsString('acquia/drupal-cms-project is Drupal CMS scaffolded to work with Acquia hosting.', $output);
         $this->assertStringContainsString('Choose a starting project', $output);
         $this->assertStringContainsString($project, $output);
         $this->assertTrue($mockFileSystem->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');


### PR DESCRIPTION
**Motivation**
Adds Drupal CMS to the list of scaffold projects.

**Proposed changes**
""

**Alternatives considered**
None

**Testing steps**
`acli app:new:local` should show three options including Drupal CMS.
