### PR TITLE
CLI-1485: Add SSH URL in alias list

### DIFF
--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -26,6 +26,9 @@ final class AliasListCommand extends CommandBase
         $this->acceptApplicationUuid();
     }
 
+    /**
+     * @throws \Acquia\Cli\Exception\AcquiaCliException
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $acquiaCloudClient = $this->cloudApiClientService->getClient();
@@ -35,29 +38,30 @@ final class AliasListCommand extends CommandBase
         $environmentsResource = new Environments($acquiaCloudClient);
 
         $table = new Table($this->output);
+        $table->setHeaderTitle('Environments for ' . $customerApplication->name);
         $table->setHeaders([
-            'Application',
-            'Environment Alias',
-            'Environment UUID',
+            'Alias',
+            'UUID',
+            'SSH URL',
         ]);
 
         $siteId = $customerApplication->hosting->id;
         $parts = explode(':', $siteId);
         $sitePrefix = $parts[1];
         $environments = $environmentsResource->getAll($customerApplication->uuid);
+        /** @var \AcquiaCloudApi\Response\EnvironmentResponse $environment */
         foreach ($environments as $environment) {
             $alias = $sitePrefix . '.' . $environment->name;
             $table->addRow([
-                $customerApplication->name,
                 $alias,
                 $environment->uuid,
+                $environment->sshUrl,
             ]);
         }
 
         $table->render();
 
-        $output->writeln('');
-        $output->writeln('<info>To get more information about a specific environment, run <options=bold>acli api:environments:find <alias></></info>');
+        $output->writeln('<info>Run <options=bold>acli api:environments:find <alias></> to get more information about a specific environment.</info>');
 
         return Command::SUCCESS;
     }

--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -39,7 +39,6 @@ final class AliasListCommand extends CommandBase
             'Application',
             'Environment Alias',
             'Environment UUID',
-            'SSH URL',
         ]);
 
         $siteId = $customerApplication->hosting->id;
@@ -52,11 +51,13 @@ final class AliasListCommand extends CommandBase
                 $customerApplication->name,
                 $alias,
                 $environment->uuid,
-                $environment->sshUrl,
             ]);
         }
 
         $table->render();
+
+        $output->writeln('');
+        $output->writeln('<info>To get more information about a specific environment, run <options=bold>acli api:environments:find <alias></></info>');
 
         return Command::SUCCESS;
     }

--- a/src/Command/Remote/AliasListCommand.php
+++ b/src/Command/Remote/AliasListCommand.php
@@ -39,6 +39,7 @@ final class AliasListCommand extends CommandBase
             'Application',
             'Environment Alias',
             'Environment UUID',
+            'SSH URL',
         ]);
 
         $siteId = $customerApplication->hosting->id;
@@ -51,6 +52,7 @@ final class AliasListCommand extends CommandBase
                 $customerApplication->name,
                 $alias,
                 $environment->uuid,
+                $environment->sshUrl,
             ]);
         }
 

--- a/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
@@ -41,6 +41,7 @@ class AliasesListCommandTest extends CommandTestBase
         $output = $this->getDisplay();
 
         $this->assertStringContainsString('Environments for Sample application 1', $output);
+        $this->assertStringContainsString('| Alias          | UUID                                    | SSH URL                                        |', $output);
         $this->assertStringContainsString('| devcloud2.dev  | 24-a47ac10b-58cc-4372-a567-0e02b2c3d470 | site.dev@sitedev.ssh.hosted.acquia-sites.com', $output);
         $this->assertStringContainsString('Run acli api:environments:find <alias> to get more information about a specific environment', $output);
     }

--- a/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
@@ -37,6 +37,8 @@ class AliasesListCommandTest extends CommandTestBase
         // Assert.
         $output = $this->getDisplay();
 
-        $this->assertStringContainsString('| Sample application 1 | devcloud2.dev     | 24-a47ac10b-58cc-4372-a567-0e02b2c3d470 |', $output);
+        $this->assertStringContainsString('| Application          | Environment Alias | Environment UUID                        | SSH URL', $output);
+
+        $this->assertStringContainsString('| Sample application 1 | devcloud2.dev     | 24-a47ac10b-58cc-4372-a567-0e02b2c3d470 | site.dev@sitedev.ssh.hosted.acquia-sites.com', $output);
     }
 }

--- a/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
@@ -37,8 +37,8 @@ class AliasesListCommandTest extends CommandTestBase
         // Assert.
         $output = $this->getDisplay();
 
-        $this->assertStringContainsString('| Application          | Environment Alias | Environment UUID                        | SSH URL', $output);
+        $this->assertStringContainsString('| Sample application 1 | devcloud2.dev     | 24-a47ac10b-58cc-4372-a567-0e02b2c3d470 |', $output);
 
-        $this->assertStringContainsString('| Sample application 1 | devcloud2.dev     | 24-a47ac10b-58cc-4372-a567-0e02b2c3d470 | site.dev@sitedev.ssh.hosted.acquia-sites.com', $output);
+        $this->assertStringContainsString('To get more information about a specific environment, run acli api:environments:find <alias>', $output);
     }
 }

--- a/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/AliasesListCommandTest.php
@@ -18,6 +18,9 @@ class AliasesListCommandTest extends CommandTestBase
         return $this->injectCommand(AliasListCommand::class);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testRemoteAliasesListCommand(): void
     {
         $applicationsResponse = $this->mockApplicationsRequest();
@@ -37,8 +40,8 @@ class AliasesListCommandTest extends CommandTestBase
         // Assert.
         $output = $this->getDisplay();
 
-        $this->assertStringContainsString('| Sample application 1 | devcloud2.dev     | 24-a47ac10b-58cc-4372-a567-0e02b2c3d470 |', $output);
-
-        $this->assertStringContainsString('To get more information about a specific environment, run acli api:environments:find <alias>', $output);
+        $this->assertStringContainsString('Environments for Sample application 1', $output);
+        $this->assertStringContainsString('| devcloud2.dev  | 24-a47ac10b-58cc-4372-a567-0e02b2c3d470 | site.dev@sitedev.ssh.hosted.acquia-sites.com', $output);
+        $this->assertStringContainsString('Run acli api:environments:find <alias> to get more information about a specific environment', $output);
     }
 }


### PR DESCRIPTION
Adding  **SSH URL** column for the drush alias list.

**Impacted command** - `acli remote:aliases:list`

**Context** - We can ssh on server using `acli remote:drush ssh`. I needed to download some file (basically `scp`) from the server to local but I didnt have the details of the ssh of server to do the scp as SCP.

So I think it will be helpfull if drush alias list also provide this details so that this can be used if required

**Output before** -
```
+-----------------------------------+-------------------+--------------------------------------------+
| Application                       | Environment Alias      |   Environment UUID                           |
+-----------------------------------+-------------------+--------------------------------------------+
| My Application                    |  myalias.dev           |   MYENVUUID |
+-----------------------------------+-------------------+--------------------------------------------+
```

**Output after** 
```
+-----------------------------------+-------------------+----------------------------------
| Application    | Environment Alias | Environment UUID | SSH URL                                             |
+-----------------------------------+-------------------+--------------------------------------------+--
| My Application | myalias.dev       | MYENVUUID        | myapp.dev@myappdev.ssh.prod.acquia-sites.com  |
```