### PR TITLE
GL-3133: Add prompt for NODE_HOSTING_TYPE.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -18,7 +18,7 @@ class CodeStudioCiCdVariables
     /**
      * @return array<mixed>
      */
-    public static function getDefaultsForNode(?string $cloudApplicationUuid = null, ?string $cloudKey = null, ?string $cloudSecret = null, ?string $projectAccessTokenName = null, ?string $projectAccessToken = null, ?string $nodeVersion = null, ?string $nodeHosting = null): array
+    public static function getDefaultsForNode(?string $cloudApplicationUuid = null, ?string $cloudKey = null, ?string $cloudSecret = null, ?string $projectAccessTokenName = null, ?string $projectAccessToken = null, ?string $nodeVersion = null, ?string $nodeHostingType = null): array
     {
         return [
             [
@@ -67,7 +67,7 @@ class CodeStudioCiCdVariables
                 'key' => 'NODE_HOSTING_TYPE',
                 'masked' => false,
                 'protected' => false,
-                'value' => $nodeHosting,
+                'value' => $nodeHostingType,
                 'variable_type' => 'env_var',
             ],
         ];

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -46,9 +46,9 @@ final class CodeStudioWizardCommand extends WizardCommandBase
         $this->reAuthenticate($cloudKey, $cloudSecret, $this->cloudCredentials->getBaseUri(), $this->cloudCredentials->getAccountsUri());
         $phpVersion = null;
         $nodeVersion = null;
+        $nodeHostingType = null;
         $projectType = $this->getListOfProjectType();
         $projectSelected = $this->io->choice('Select a project type', $projectType, "Drupal_project");
-        $nodeHosting = "basic";
 
         switch ($projectSelected) {
             case "Drupal_project":
@@ -62,6 +62,12 @@ final class CodeStudioWizardCommand extends WizardCommandBase
                 $phpVersion = $phpVersions[$project];
                 break;
             case "Node_project":
+                $nodeHostingTypes = [
+                    'advanced' => "Advanced Frontend Hosting",
+                    'basic' => "Basic Frontend Hosting",
+                ];
+                $project = $this->io->choice('Select a NODE hosting type', array_values($nodeHostingTypes), "Basic Frontend Hosting");
+                $nodeHostingType = array_search($project, $nodeHostingTypes, true);
                 $nodeVersions = [
                     'NODE_version_18' => "18",
                     'NODE_version_20' => "20",
@@ -129,7 +135,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase
                 ];
                 $client = $this->getGitLabClient();
                 $client->projects()->update($project['id'], $parameters);
-                $this->setGitLabCiCdVariablesForNodeProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion, $nodeHosting);
+                $this->setGitLabCiCdVariablesForNodeProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion, $nodeHostingType);
                 break;
         }
 
@@ -242,10 +248,10 @@ final class CodeStudioWizardCommand extends WizardCommandBase
         }
     }
 
-    private function setGitLabCiCdVariablesForNodeProject(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken, string $nodeVersion, string $nodeHosting): void
+    private function setGitLabCiCdVariablesForNodeProject(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken, string $nodeVersion, string $nodeHostingType): void
     {
         $this->io->writeln("Setting GitLab CI/CD variables for {$project['path_with_namespace']}..");
-        $gitlabCicdVariables = CodeStudioCiCdVariables::getDefaultsForNode($cloudApplicationUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion, $nodeHosting);
+        $gitlabCicdVariables = CodeStudioCiCdVariables::getDefaultsForNode($cloudApplicationUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $nodeVersion, $nodeHostingType);
         $gitlabCicdExistingVariables = $this->gitLabClient->projects()
             ->variables($project['id']);
         $gitlabCicdExistingVariablesKeyed = [];

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -153,6 +153,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [
                     // Select a project type Node_project.
                     '1',
+                    // Select NODE hosting type advanced.
+                    '0',
                     // Select NODE version 18.
                     '0',
                     // Do you want to continue?
@@ -172,6 +174,52 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 // Inputs.
                 [
                     // Select a project type Node_project.
+                    '1',
+                    // Select NODE hosting type advanced.
+                    '0',
+                    // Select NODE version 20.
+                    '1',
+                    // Do you want to continue?
+                    'y',
+                    // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
+                    'y',
+                ],
+                // Args.
+                [
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
+                ],
+            ],
+            [
+                // No projects.
+                [],
+                // Inputs.
+                [
+                    // Select a project type Node_project.
+                    '1',
+                    // Select NODE hosting type basic.
+                    '1',
+                    // Select NODE version 18.
+                    '0',
+                    // Do you want to continue?
+                    'y',
+                    // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
+                    'y',
+                ],
+                // Args.
+                [
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
+                ],
+            ],
+            [
+                // No projects.
+                [],
+                // Inputs.
+                [
+                    // Select a project type Node_project.
+                    '1',
+                    // Select NODE hosting type basic.
                     '1',
                     // Select NODE version 20.
                     '1',
@@ -235,6 +283,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                     // Enter Cloud secret,.
                     self::$secret,
                     // Select a project type Node_project.
+                    '1',
+                    // Select NODE hosting type basic.
                     '1',
                     // Select NODE version 18.
                     '0',


### PR DESCRIPTION
**DO NOT MERGE YET**
Cloud does not yet support Node V3. This PR should wait to be merged & released until Node V3 is launched [FR-2378](https://acquia.atlassian.net/browse/FR-2378).

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Addresses [GL-3133](https://acquia.atlassian.net/browse/GL-3133)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
If application type is selected as Node, adds a prompt to select the node hosting type in the `cs:wizard` command.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
N/A

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Locally, run glab auth login --hostname=code.dev.cloudservices.acquia.io
2. Run export GITLAB_HOST=code.dev.cloudservices.acquia.io
3. Run ./bin/acli cs:wizard
4. Answer prompts, ensuring to select an application type of node, until you see the prompt for node hosting type
![Screenshot 2025-02-07 at 12 17 23 PM](https://github.com/user-attachments/assets/4ebd4b20-a4aa-4bd9-915f-acaaf40e90ab)

