### PR TITLE
CLI-1462: Remove league/oauth2-client dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,6 @@
     ],
     "repositories": [
         {
-            "type": "vcs", "url": "https://github.com/ruudk/oauth2-client"
-        },
-        {
             "type": "vcs", "url": "https://github.com/valzargaming/Pawl"
         },
         {
@@ -38,7 +35,6 @@
         "http-interop/http-factory-guzzle": "^1.0",
         "laminas/laminas-validator": "^2.20.0",
         "league/csv": "^9.8",
-        "league/oauth2-client": "dev-patch-1 as 2.7.0",
         "loophp/phposinfo": "^1.7.2",
         "ltd-beget/dns-zone-configurator": "^1.4.0",
         "m4tthumphrey/php-gitlab-api": "dev-fix/84",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3489031dc0fd26461aeb979bc4be5081",
+    "content-hash": "5631535a0e8a225e27cd5212d63e8a3f",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -1488,29 +1488,28 @@
         },
         {
             "name": "league/oauth2-client",
-            "version": "dev-patch-1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ruudk/oauth2-client.git",
-                "reference": "268c0ead17655d9ebdbffaf429853be8be7d32a5"
+                "url": "https://github.com/thephpleague/oauth2-client.git",
+                "reference": "3d5cf8d0543731dfb725ab30e4d7289891991e13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ruudk/oauth2-client/zipball/268c0ead17655d9ebdbffaf429853be8be7d32a5",
-                "reference": "268c0ead17655d9ebdbffaf429853be8be7d32a5",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/3d5cf8d0543731dfb725ab30e4d7289891991e13",
+                "reference": "3d5cf8d0543731dfb725ab30e4d7289891991e13",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/guzzle": "^6.0 || ^7.0",
-                "paragonie/random_compat": "^1 || ^2 || ^9.99",
-                "php": "^5.6 || ^7.0 || ^8.0"
+                "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
+                "php": "^7.1 || >=8.0.0 <8.5.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3.5",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpunit/phpunit": "^5.7 || ^6.0 || ^9.5",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0"
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.11"
             },
             "type": "library",
             "autoload": {
@@ -1518,11 +1517,7 @@
                     "League\\OAuth2\\Client\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "League\\OAuth2\\Client\\Test\\": "test/src/"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -1541,19 +1536,20 @@
             ],
             "description": "OAuth 2.0 Client Library",
             "keywords": [
-                "authentication",
+                "Authentication",
+                "SSO",
                 "authorization",
                 "identity",
                 "idp",
                 "oauth",
                 "oauth2",
-                "single sign on",
-                "sso"
+                "single sign on"
             ],
             "support": {
-                "source": "https://github.com/ruudk/oauth2-client/tree/patch-1"
+                "issues": "https://github.com/thephpleague/oauth2-client/issues",
+                "source": "https://github.com/thephpleague/oauth2-client/tree/2.8.0"
             },
-            "time": "2024-12-10T04:40:44+00:00"
+            "time": "2024-12-11T05:05:52+00:00"
         },
         {
             "name": "loophp/phposinfo",
@@ -1968,56 +1964,6 @@
                 "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.1"
             },
             "time": "2024-11-28T04:54:44+00:00"
-        },
-        {
-            "name": "paragonie/random_compat",
-            "version": "v9.99.100",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
-                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">= 7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*",
-                "vimeo/psalm": "^1"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "polyfill",
-                "pseudorandom",
-                "random"
-            ],
-            "support": {
-                "email": "info@paragonie.com",
-                "issues": "https://github.com/paragonie/random_compat/issues",
-                "source": "https://github.com/paragonie/random_compat"
-            },
-            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "php-http/cache-plugin",
@@ -13199,12 +13145,6 @@
     ],
     "aliases": [
         {
-            "package": "league/oauth2-client",
-            "version": "dev-patch-1",
-            "alias": "2.7.0",
-            "alias_normalized": "2.7.0.0"
-        },
-        {
             "package": "ratchet/pawl",
             "version": "dev-patch-1",
             "alias": "0.4.1",
@@ -13219,7 +13159,6 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "league/oauth2-client": 20,
         "m4tthumphrey/php-gitlab-api": 20,
         "overtrue/phplint": 20,
         "ratchet/pawl": 20,


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1462

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: (add specific steps for this pr)
4. Check new functionality: (add specific steps for this pr)
