### PR TITLE
GL-3070: PHP 8.4 support for Code Studio.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -56,6 +56,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase
                     'PHP_version_8.1' => "8.1",
                     'PHP_version_8.2' => "8.2",
                     'PHP_version_8.3' => "8.3",
+                    'PHP_version_8.4' => "8.4",
                 ];
                 $project = $this->io->choice('Select a PHP version', array_values($phpVersions), "8.3");
                 $project = array_search($project, $phpVersions, true);

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -151,6 +151,46 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [],
                 // Inputs.
                 [
+                    // Select a project type Drupal_project.
+                    '0',
+                    // Select PHP version 8.3.
+                    '2',
+                    // Do you want to continue?
+                    'y',
+                    // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
+                    'y',
+                ],
+                // Args.
+                [
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
+                ],
+            ],
+            [
+                // No projects.
+                [],
+                // Inputs.
+                [
+                    // Select a project type Drupal_project.
+                    '0',
+                    // Select PHP version 8.4.
+                    '3',
+                    // Do you want to continue?
+                    'y',
+                    // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
+                    'y',
+                ],
+                // Args.
+                [
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
+                ],
+            ],
+            [
+                // No projects.
+                [],
+                // Inputs.
+                [
                     // Select a project type Node_project.
                     '1',
                     // Select NODE version 18.


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Addresses [GL-3070](https://acquia.atlassian.net/browse/GL-3070)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Adds PHP 8.4 as a prompt option during the `cs:wizard` command.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
1. Locally, run `glab auth login --hostname=code.dev.cloudservices.acquia.io`
2. Run `export GITLAB_HOST=code.dev.cloudservices.acquia.io`
3. Run `./bin/acli cs:wizard`
4. Answer prompts until you see the prompt for `Select a PHP version`. Note 8.4 is now an option.
5. Note: 8.3 is still the default selection per Out of Scope section in [FR-2809](https://acquia.atlassian.net/browse/FR-2809)
<img width="259" alt="408204703-f0c0c223-c46f-4d5d-a00a-3f1ce6269db6" src="https://github.com/user-attachments/assets/24c17c4d-4a1c-4796-a062-0e7aa69343f1" />

