### PR TITLE
GL-3465: Node 22 support for Code Studio.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -65,6 +65,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase
                 $nodeVersions = [
                     'NODE_version_18' => "18",
                     'NODE_version_20' => "20",
+                    'NODE_version_22' => "22",
                 ];
                 $project = $this->io->choice('Select a NODE version', array_values($nodeVersions), "20");
                 $project = array_search($project, $nodeVersions, true);

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -191,6 +191,26 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [],
                 // Inputs.
                 [
+                    // Select a project type Node_project.
+                    '1',
+                    // Select NODE version 22.
+                    '2',
+                    // Do you want to continue?
+                    'y',
+                    // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
+                    'y',
+                ],
+                // Args.
+                [
+                    '--key' => self::$key,
+                    '--secret' => self::$secret,
+                ],
+            ],
+            [
+                // No projects.
+                [],
+                // Inputs.
+                [
                     0,
                     0,
                     'y',


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Addresses [GL-3465](https://acquia.atlassian.net/browse/GL-3465)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Adds Node 22 as a prompt option during the cs:wizard command.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
N/A

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
1. Locally, run `glab auth login --hostname=code.dev.cloudservices.acquia.io`
2. Run `export GITLAB_HOST=code.dev.cloudservices.acquia.io`
3. Run `./bin/acli cs:wizard`
4. Answer prompts until you see the prompt for `Select a NODE version`. Note 22 is now an option.
<img width="296" alt="Screenshot 2025-03-05 at 18 37 53" src="https://github.com/user-attachments/assets/91e49b3f-f665-4f8a-9736-ac3f922ab5da" />

