### PR TITLE
[ssh-key:delete] Enable cloud-key-uuid & label options.

### DIFF
--- a/src/Command/Ssh/SshKeyDeleteCommand.php
+++ b/src/Command/Ssh/SshKeyDeleteCommand.php
@@ -25,6 +25,6 @@ final class SshKeyDeleteCommand extends SshKeyCommandBase
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        return $this->deleteSshKeyFromCloud($output);
+        return $this->deleteSshKeyFromCloud($output, $input->getOption('cloud-key-uuid'));
     }
 }

--- a/src/Helpers/SshCommandTrait.php
+++ b/src/Helpers/SshCommandTrait.php
@@ -15,11 +15,11 @@ trait SshCommandTrait
     private function deleteSshKeyFromCloud(mixed $output, mixed $cloudKey = null): int
     {
         $acquiaCloudClient = $this->cloudApiClientService->getClient();
-        if (!$cloudKey) {
-            $cloudKey = $this->determineCloudKey($acquiaCloudClient);
-        }
-
         $sshKeys = new SshKeys($acquiaCloudClient);
+
+        // If the user has provided a key, use it fetch key object. Otherwise, prompt to choose one.
+        $cloudKey = !empty($cloudKey) && is_string($cloudKey) ? $sshKeys->get($cloudKey) : $this->determineCloudKey($acquiaCloudClient);
+
         $sshKeys->delete($cloudKey->uuid);
         $output->writeln("<info>Successfully deleted SSH key <options=bold>$cloudKey->label</> from the Cloud Platform.</info>");
         $localKeys = $this->findLocalSshKeys();

--- a/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
+++ b/tests/phpunit/src/Commands/Ssh/SshKeyDeleteCommandTest.php
@@ -7,6 +7,10 @@ namespace Acquia\Cli\Tests\Commands\Ssh;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Ssh\SshKeyDeleteCommand;
 use Acquia\Cli\Tests\CommandTestBase;
+use AcquiaCloudApi\Endpoints\SshKeys;
+use AcquiaCloudApi\Response\OperationResponse;
+use AcquiaCloudApi\Response\SshKeyResponse;
+use PHPUnit\Framework\MockObject\Exception;
 
 /**
  * @property SshKeyDeleteCommand $command
@@ -18,7 +22,10 @@ class SshKeyDeleteCommandTest extends CommandTestBase
         return $this->injectCommand(SshKeyDeleteCommand::class);
     }
 
-    public function testDelete(): void
+    /**
+     * @throws \Exception
+     */
+    public function testDeleteWithoutUuid(): void
     {
         $sshKeyListResponse = $this->mockListSshKeysRequest();
         $this->mockRequest('deleteAccountSshKey', $sshKeyListResponse[self::$INPUT_DEFAULT_CHOICE]->uuid, null, 'Removed key');
@@ -35,5 +42,45 @@ class SshKeyDeleteCommandTest extends CommandTestBase
         $output = $this->getDisplay();
         $this->assertStringContainsString('Choose an SSH key to delete from the Cloud Platform', $output);
         $this->assertStringContainsString($sshKeyListResponse[self::$INPUT_DEFAULT_CHOICE]->label, $output);
+    }
+
+    /**
+     * @throws \Exception
+     * @throws Exception
+     */
+    public function testDeleteWithUuid(): void
+    {
+        $mockBody = self::getMockResponseFromSpec('/account/ssh-keys', 'get', '200');
+
+        // Mock the SshKeys->get method to return the predefined response.
+        $sshKeysMock = $this->createMock(SshKeys::class);
+        $sshKeysMock->method('get')
+            ->willReturn(new SshKeyResponse($mockBody->{'_embedded'}->items[0]));
+
+        // Mock the request method for the specific UUID.
+        $this->clientProphecy->request('get', '/account/ssh-keys/' . $mockBody->{'_embedded'}->items[0]->uuid)
+            ->willReturn($mockBody->{'_embedded'}->items[0])
+            ->shouldBeCalled();
+
+        // Mock the delete request to return a valid OperationResponse.
+        $operationResponse = $this->createMock(OperationResponse::class);
+        $operationResponse->message = 'Successfully deleted SSH key';
+        $this->clientProphecy->request('delete', '/account/ssh-keys/' . $mockBody->{'_embedded'}->items[0]->uuid)
+            ->willReturn($operationResponse)
+            ->shouldBeCalled();
+
+        $inputs = [
+            // Do you also want to delete the corresponding local key files?
+            'n',
+        ];
+
+        $this->executeCommand([
+            '--cloud-key-uuid' => $mockBody->{'_embedded'}->items[0]->uuid,
+        ], $inputs);
+
+        // Assert.
+        $output = $this->getDisplay();
+        $this->assertStringContainsString('Successfully deleted SSH key', $output);
+        $this->assertStringContainsString($mockBody->{'_embedded'}->items[0]->label, $output);
     }
 }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
The command should ideally execute when SSH key UUID and labels are specified, rather than prompting the user to select an SSH key from a list. This change would enable the use of command options `cloud-key-uuid` and `label`.

<img width="831" alt="image" src="https://github.com/user-attachments/assets/bfb25125-c768-4672-bb94-8c272b81a3c7" />

**Fixes**

- Enables the use of existing option `cloud-key-uuid`
- Adds new option `label`

**Proposed changes**

- If only the SSH key's UUID is provided, the command will prompt for a label. It will then search for the key using the given UUID and label and execute the delete operation.

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/5de05302-1447-4c41-8005-1a3ac1790566" />

- If both the label and UUID are provided, the delete operation will be executed (if found the key having same UUID & label).

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/9ac5f5b5-2e9a-4b12-a655-11980bc5f280" />

- If none of the options are given, it still works the same way.

<img width="986" alt="image" src="https://github.com/user-attachments/assets/95d60835-2253-44a1-a353-67a3ff2e1129" />

**Test case** is also altered the include the options during command execution.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: (add specific steps for this pr)
4. Check new functionality: (add specific steps for this pr)
