### PR TITLE
GL-3584: Remove Node 18 as an option in cs:wizard.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -70,7 +70,6 @@ final class CodeStudioWizardCommand extends WizardCommandBase
                 $project = $this->io->choice('Select a NODE hosting type', array_values($nodeHostingTypes), "Basic Frontend Hosting");
                 $nodeHostingType = array_search($project, $nodeHostingTypes, true);
                 $nodeVersions = [
-                    'NODE_version_18' => "18",
                     'NODE_version_20' => "20",
                     'NODE_version_22' => "22",
                 ];

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -195,51 +195,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                     '1',
                     // Select NODE hosting type advanced.
                     '0',
-                    // Select NODE version 18.
-                    '0',
-                    // Do you want to continue?
-                    'y',
-                    // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
-                    'y',
-                ],
-                // Args.
-                [
-                    '--key' => self::$key,
-                    '--secret' => self::$secret,
-                ],
-            ],
-            [
-                // No projects.
-                [],
-                // Inputs.
-                [
-                    // Select a project type Node_project.
-                    '1',
-                    // Select NODE hosting type advanced.
-                    '0',
                     // Select NODE version 20.
-                    '1',
-                    // Do you want to continue?
-                    'y',
-                    // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
-                    'y',
-                ],
-                // Args.
-                [
-                    '--key' => self::$key,
-                    '--secret' => self::$secret,
-                ],
-            ],
-            [
-                // No projects.
-                [],
-                // Inputs.
-                [
-                    // Select a project type Node_project.
-                    '1',
-                    // Select NODE hosting type basic.
-                    '1',
-                    // Select NODE version 18.
                     '0',
                     // Do you want to continue?
                     'y',
@@ -262,7 +218,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                     // Select NODE hosting type basic.
                     '1',
                     // Select NODE version 20.
-                    '1',
+                    '0',
                     // Do you want to continue?
                     'y',
                     // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
@@ -284,7 +240,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                     // Select NODE hosting type basic.
                     '1',
                     // Select NODE version 22.
-                    '2',
+                    '1',
                     // Do you want to continue?
                     'y',
                     // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
@@ -344,27 +300,6 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                     self::$key,
                     // Enter Cloud secret,.
                     self::$secret,
-                    // Select a project type Node_project.
-                    '1',
-                    // Select NODE hosting type basic.
-                    '1',
-                    // Select NODE version 18.
-                    '0',
-                    // Do you want to continue?
-                    'y',
-                ],
-                // Args.
-                [],
-            ],
-            [
-                // No projects.
-                [],
-                // Inputs.
-                [
-                    // Enter Cloud Key.
-                    self::$key,
-                    // Enter Cloud secret,.
-                    self::$secret,
                     // Select a project type Drupal_project.
                     '0',
                     // Select PHP version 8.2.
@@ -389,7 +324,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                     // Select NODE hosting type basic.
                     '1',
                     // Select NODE version 20.
-                    '1',
+                    '0',
                     // Do you want to continue?
                     'y',
                 ],


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Resolves [GL-3584](https://acquia.atlassian.net/browse/GL-3584)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
In `cs:wizard`, removes version 18 as a node version option. This is due to Acquia removing Node 18 support on April 15, 2025.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
N/A

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
- Locally, run glab auth login --hostname=code.dev.cloudservices.acquia.io
- Run export GITLAB_HOST=code.dev.cloudservices.acquia.io
- Run ./bin/acli cs:wizard
- Answer prompts, ensuring to select an application type of node, until you see the prompt for node version. You should only see options for Node 20 and 22.
<img width="268" alt="Screenshot 2025-04-08 at 12 08 11 PM" src="https://github.com/user-attachments/assets/cc7a56d1-31a5-4489-bd74-433fae971e66" />
