### PR TITLE
GL-3695: Add MySQL version prompt for cs:wizard.

### DIFF
--- a/src/Command/CodeStudio/CodeStudioCiCdVariables.php
+++ b/src/Command/CodeStudio/CodeStudioCiCdVariables.php
@@ -76,7 +76,7 @@ class CodeStudioCiCdVariables
     /**
      * @return array<mixed>
      */
-    public static function getDefaultsForPhp(?string $cloudApplicationUuid = null, ?string $cloudKey = null, ?string $cloudSecret = null, ?string $projectAccessTokenName = null, ?string $projectAccessToken = null, ?string $phpVersion = null): array
+    public static function getDefaultsForPhp(?string $cloudApplicationUuid = null, ?string $cloudKey = null, ?string $cloudSecret = null, ?string $projectAccessTokenName = null, ?string $projectAccessToken = null, ?string $mysqlVersion = null, ?string $phpVersion = null): array
     {
         return [
             [
@@ -112,6 +112,13 @@ class CodeStudioCiCdVariables
                 'masked' => true,
                 'protected' => false,
                 'value' => $projectAccessToken,
+                'variable_type' => 'env_var',
+            ],
+            [
+                'key' => 'MYSQL_VERSION',
+                'masked' => false,
+                'protected' => false,
+                'value' => $mysqlVersion,
                 'variable_type' => 'env_var',
             ],
             [

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -57,7 +57,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase
                     'MYSQL_version_5.7' => "5.7",
                     'MYSQL_version_8.0' => "8.0",
                 ];
-                $project = $this->io->choice('Select a MySQL version', array_values($mysqlVersions), "5.7");
+                $project = $this->io->choice('Select a MySQL version', array_values($mysqlVersions), "8.0");
                 $project = array_search($project, $mysqlVersions, true);
                 $mysqlVersion = $mysqlVersions[$project];
                 $phpVersions = [

--- a/src/Command/CodeStudio/CodeStudioWizardCommand.php
+++ b/src/Command/CodeStudio/CodeStudioWizardCommand.php
@@ -44,6 +44,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase
         // But, we specifically need an API Token key-pair of Code Studio.
         // So we reauthenticate to be sure we're using the provided credentials.
         $this->reAuthenticate($cloudKey, $cloudSecret, $this->cloudCredentials->getBaseUri(), $this->cloudCredentials->getAccountsUri());
+        $mysqlVersion = null;
         $phpVersion = null;
         $nodeVersion = null;
         $nodeHostingType = null;
@@ -52,6 +53,13 @@ final class CodeStudioWizardCommand extends WizardCommandBase
 
         switch ($projectSelected) {
             case "Drupal_project":
+                $mysqlVersions = [
+                    'MYSQL_version_5.7' => "5.7",
+                    'MYSQL_version_8.0' => "8.0",
+                ];
+                $project = $this->io->choice('Select a MySQL version', array_values($mysqlVersions), "5.7");
+                $project = array_search($project, $mysqlVersions, true);
+                $mysqlVersion = $mysqlVersions[$project];
                 $phpVersions = [
                     'PHP_version_8.1' => "8.1",
                     'PHP_version_8.2' => "8.2",
@@ -127,7 +135,7 @@ final class CodeStudioWizardCommand extends WizardCommandBase
         $this->updateGitLabProject($project);
         switch ($projectSelected) {
             case "Drupal_project":
-                $this->setGitLabCiCdVariablesForPhpProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $phpVersion);
+                $this->setGitLabCiCdVariablesForPhpProject($project, $appUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $mysqlVersion, $phpVersion);
                 $this->createScheduledPipeline($project);
                 break;
             case "Node_project":
@@ -218,10 +226,10 @@ final class CodeStudioWizardCommand extends WizardCommandBase
         return $projectAccessToken['token'];
     }
 
-    private function setGitLabCiCdVariablesForPhpProject(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken, string $phpVersion): void
+    private function setGitLabCiCdVariablesForPhpProject(array $project, string $cloudApplicationUuid, string $cloudKey, string $cloudSecret, string $projectAccessTokenName, string $projectAccessToken, string $mysqlVersion, string $phpVersion): void
     {
         $this->io->writeln("Setting GitLab CI/CD variables for {$project['path_with_namespace']}..");
-        $gitlabCicdVariables = CodeStudioCiCdVariables::getDefaultsForPhp($cloudApplicationUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $phpVersion);
+        $gitlabCicdVariables = CodeStudioCiCdVariables::getDefaultsForPhp($cloudApplicationUuid, $cloudKey, $cloudSecret, $projectAccessTokenName, $projectAccessToken, $mysqlVersion, $phpVersion);
         $gitlabCicdExistingVariables = $this->gitLabClient->projects()
             ->variables($project['id']);
         $gitlabCicdExistingVariablesKeyed = [];

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioCiCdVariablesTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioCiCdVariablesTest.php
@@ -21,7 +21,7 @@ class CodeStudioCiCdVariablesTest extends TestBase
     protected function testBooleanValues(array $variables): void
     {
         foreach ($variables as $variable) {
-            if ($variable['key'] !== "PHP_VERSION" && $variable['key'] !== "NODE_VERSION" && $variable['key'] !== "NODE_HOSTING_TYPE" && $variable['key'] !== "MYSQL_VERSION") {
+            if ($variable['key'] !== "MYSQL_VERSION" && $variable['key'] !== "PHP_VERSION" && $variable['key'] !== "NODE_VERSION" && $variable['key'] !== "NODE_HOSTING_TYPE") {
                 $maskedValue = $variable['masked'];
                 $this->assertEquals(true, $maskedValue);
             } else {

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioCiCdVariablesTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioCiCdVariablesTest.php
@@ -21,7 +21,7 @@ class CodeStudioCiCdVariablesTest extends TestBase
     protected function testBooleanValues(array $variables): void
     {
         foreach ($variables as $variable) {
-            if ($variable['key'] !== "PHP_VERSION" && $variable['key'] !== "NODE_VERSION" && $variable['key'] !== "NODE_HOSTING_TYPE") {
+            if ($variable['key'] !== "PHP_VERSION" && $variable['key'] !== "NODE_VERSION" && $variable['key'] !== "NODE_HOSTING_TYPE" && $variable['key'] !== "MYSQL_VERSION") {
                 $maskedValue = $variable['masked'];
                 $this->assertEquals(true, $maskedValue);
             } else {

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioPipelinesMigrateCommandTest.php
@@ -136,6 +136,13 @@ class CodeStudioPipelinesMigrateCommandTest extends CommandTestBase
                 'variable_type' => 'env_var',
             ],
             [
+                'key' => 'MYSQL_VERSION',
+                'masked' => false,
+                'protected' => false,
+                'value' => null,
+                'variable_type' => 'env_var',
+            ],
+            [
                 'key' => 'PHP_VERSION',
                 'masked' => false,
                 'protected' => false,

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -131,6 +131,10 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [],
                 // Inputs.
                 [
+                    // Enter Cloud Key.
+                    self::$key,
+                    // Enter Cloud secret,.
+                    self::$secret,
                     // Select a project type Drupal_project.
                     '0',
                     // Select MySQL version 8.0.
@@ -143,10 +147,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                     'y',
                 ],
                 // Args.
-                [
-                    '--key' => self::$key,
-                    '--secret' => self::$secret,
-                ],
+                [],
             ],
             [
                 // No projects.

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -109,15 +109,19 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [],
                 // Inputs.
                 [
+                    // Select a project type [Drupal_project]:
                     0,
+                    // Select a MySQL version [5.7]:
                     0,
+                    // Select a PHP version [8.3]:
                     0,
+                    // Would you like to link the Cloud application Sample application 1 to this repository? (yes/no) [yes]:
                     0,
-                    // Do you want to continue?
-                    'y',
-                    // Select application from Cloud.
+                    // Would you like to create a new Code Studio project? If you select "no" you may choose from a full list of existing projects. (yes/no) [yes]:
                     0,
-                    // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
+                    // Choose a Code Studio project to configure for the Sample application.
+                    0,
+                    // Do you want to continue? (yes/no) [yes]:
                     'y',
                 ],
                 // Args.

--- a/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
+++ b/tests/phpunit/src/Commands/CodeStudio/CodeStudioWizardCommandTest.php
@@ -67,6 +67,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [
                     0,
                     0,
+                    0,
                     // Do you want to continue?
                     'y',
                     // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
@@ -86,6 +87,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 ],
                 // Inputs.
                 [
+                    0,
                     0,
                     0,
                     'n',
@@ -109,14 +111,12 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [
                     0,
                     0,
-                    // 'Would you like to create a new Code Studio project?
-                    'y',
-                    // Select a project type Drupal_project.
-                    '0',
-                    // Select PHP version 8.1.
-                    '0',
+                    0,
+                    0,
                     // Do you want to continue?
                     'y',
+                    // Select application from Cloud.
+                    0,
                     // Would you like to perform a one time push of code from Acquia Cloud to Code Studio now? (yes/no) [yes]:
                     'y',
                 ],
@@ -133,6 +133,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [
                     // Select a project type Drupal_project.
                     '0',
+                    // Select MySQL version 8.0.
+                    '1',
                     // Select PHP version 8.2.
                     '1',
                     // Do you want to continue?
@@ -152,6 +154,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 // Inputs.
                 [
                     // Select a project type Drupal_project.
+                    '0',
+                    // Select MySQL version 5.7.
                     '0',
                     // Select PHP version 8.3.
                     '2',
@@ -173,6 +177,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [
                     // Select a project type Drupal_project.
                     '0',
+                    // Select MySQL version 8.0.
+                    '1',
                     // Select PHP version 8.4.
                     '3',
                     // Do you want to continue?
@@ -259,6 +265,7 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                 [
                     0,
                     0,
+                    0,
                     'y',
                     'y',
                     // Choose project.
@@ -283,6 +290,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                     self::$secret,
                     // Select a project type Drupal_project.
                     '0',
+                    // Select MySQL version 5.7.
+                    '0',
                     // Select PHP version 8.1.
                     '0',
                     // Do you want to continue?
@@ -302,6 +311,8 @@ class CodeStudioWizardCommandTest extends WizardTestBase
                     self::$secret,
                     // Select a project type Drupal_project.
                     '0',
+                    // Select MySQL version 8.0.
+                    '1',
                     // Select PHP version 8.2.
                     '1',
                     // Do you want to continue?


### PR DESCRIPTION
**Please wait to merge & release until Code Studio team gives the ok.**

**Motivation**
Addresses [GL-3695](https://acquia.atlassian.net/browse/GL-3695)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Adds a prompt for MySQL version to Drupal projects.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
N/A. This will become a required variable for all Drupal projects, so we should set it upon project setup.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
- Locally, run `glab auth login --hostname=code.dev.cloudservices.acquia.io`
- Run `export GITLAB_HOST=code.dev.cloudservices.acquia.io`
- Run `./bin/acli cs:wizard`
- Answer prompts, ensuring to select an application type of Drupal, until you see the prompt for MySQL version.
![prompt](https://github.com/user-attachments/assets/74c84656-448b-40cd-89aa-6eacf70d96aa)
- Confirm the variable is added to the Code Studio project upon completion of `cs:wizard`.