### PR TITLE
CLI-1540: Pull codebase compatibility via vcs_url.

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -74,7 +74,6 @@ use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
-use Twig\Environment;
 use Zumba\Amplitude\Amplitude;
 
 abstract class CommandBase extends Command implements LoggerAwareInterface
@@ -225,7 +224,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
         $this->formatter = $this->getHelper('formatter');
 
         $this->output->writeln('Acquia CLI version: ' . $this->getApplication()
-            ->getVersion(), OutputInterface::VERBOSITY_DEBUG);
+        ->getVersion(), OutputInterface::VERBOSITY_DEBUG);
         if (getenv('ACLI_NO_TELEMETRY') !== 'true') {
             $this->checkAndPromptTelemetryPreference();
             $this->telemetryHelper->initialize();
@@ -725,8 +724,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
     {
         $this->localMachineHelper->checkRequiredBinariesExist(['git']);
         $process = $this->localMachineHelper->executeFromCmd(
-            // Problem with this is that it stages changes for the user. They may
-            // not want that.
+        // Problem with this is that it stages changes for the user. They may
+        // not want that.
             'git add . && git diff-index --cached --quiet HEAD',
             null,
             $this->dir,
@@ -1331,8 +1330,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
     {
         if (
             $input->hasArgument('applicationUuid') && !$input->getArgument('applicationUuid') && $this->getDefinition()
-            ->getArgument('applicationUuid')
-            ->isRequired()
+                ->getArgument('applicationUuid')
+                ->isRequired()
         ) {
             $output->writeln('Inferring Cloud Application UUID for this command since none was provided...', OutputInterface::VERBOSITY_VERBOSE);
             if ($applicationUuid = $this->determineCloudApplication()) {

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -680,44 +680,6 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
     }
 
     /**
-     * Get the environment associated with a codebase UUID.
-     *
-     * @throws \Acquia\Cli\Exception\AcquiaCliException
-     */
-    protected function getCloudEnvironmentByCodebase(string $codebaseUuid): EnvironmentResponse
-    {
-        $acquiaCloudClient = $this->cloudApiClientService->getClient();
-        $codebasesResource = new Codebases($acquiaCloudClient);
-        $codebase = $codebasesResource->get($codebaseUuid);
-        // Prepare environment response from codebase.
-        $environment = new stdClass();
-        $environment->id = $codebase->id;
-        $environment->name = $codebase->label;
-        $environment->label = $codebase->label;
-        $environment->application = new stdClass();
-        $environment->domains = [];
-        $environment->active_domain = "";
-        $environment->default_domain = "";
-        $environment->ips = [];
-        $environment->balancer = "";
-        $environment->platform = "";
-        $environment->status = "";
-        $environment->type = "";
-        $environment->flags = new stdClass();
-        $environment->_links = $codebase->links;
-        $environment->region = $codebase->region;
-        $environment->configuration =  new stdClass();
-        $environment->artifact  =  new stdClass();
-        $environment->image_url = "";
-        $environment->vcs = new stdClass();
-        $environment->vcs->path = $codebase->vcs_url;
-        $environment->vcs->url = $codebase->vcs_url;
-        $environmentResponse = new EnvironmentResponse($environment);
-        $environmentResponse->uuid = $codebase->id;
-        return $environmentResponse;
-    }
-
-    /**
      * @throws \Acquia\Cli\Exception\AcquiaCliException
      */
     protected function isLocalGitRepoDirty(): bool
@@ -1140,6 +1102,57 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
 
         return $environmentResource->get($environmentId);
     }
+
+
+    /**
+     * Get the environment associated with a codebase UUID.
+     *
+     * @throws \Acquia\Cli\Exception\AcquiaCliException
+     */
+    protected function getCloudEnvironmentByCodebase(string $codebaseUuid): EnvironmentResponse
+    {
+        $acquiaCloudClient = $this->cloudApiClientService->getClient();
+        $codebasesResource = new Codebases($acquiaCloudClient);
+
+        try {
+            $codebase = $codebasesResource->get($codebaseUuid);
+
+            // Prepare environment response from codebase.
+            $environment = new stdClass();
+            $environment->id = $codebase->id;
+            $environment->name = $codebase->label;
+            $environment->label = $codebase->label;
+            $environment->application = new stdClass();
+            $environment->domains = [];
+            $environment->active_domain = '';
+            $environment->default_domain = '';
+            $environment->ips = [];
+            $environment->balancer = '';
+            $environment->platform = '';
+            $environment->status = '';
+            $environment->type = '';
+            $environment->flags = new stdClass();
+            $environment->_links = $codebase->links ?? new stdClass();
+            $environment->region = $codebase->region ?? '';
+            $environment->configuration = new stdClass();
+            $environment->artifact = new stdClass();
+            $environment->image_url = '';
+            $environment->vcs = new stdClass();
+            $environment->vcs->path = $codebase->vcs_url ?? '';
+            $environment->vcs->url = $codebase->vcs_url ?? '';
+
+            $environmentResponse = new EnvironmentResponse($environment);
+            $environmentResponse->uuid = $codebase->id;
+
+            return $environmentResponse;
+        } catch (Exception $e) {
+            throw new AcquiaCliException(
+                "No codebases match the uuid '{$codebaseUuid}'",
+                ['codebaseUuid' => $codebaseUuid]
+            );
+        }
+    }
+
 
     public static function validateEnvironmentAlias(string $alias): string
     {

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -26,6 +26,7 @@ use AcquiaCloudApi\Connector\Client;
 use AcquiaCloudApi\Connector\Connector;
 use AcquiaCloudApi\Endpoints\Account;
 use AcquiaCloudApi\Endpoints\Applications;
+use AcquiaCloudApi\Endpoints\Codebases;
 use AcquiaCloudApi\Endpoints\Databases;
 use AcquiaCloudApi\Endpoints\Environments;
 use AcquiaCloudApi\Endpoints\Notifications;
@@ -33,6 +34,7 @@ use AcquiaCloudApi\Endpoints\Organizations;
 use AcquiaCloudApi\Endpoints\Subscriptions;
 use AcquiaCloudApi\Response\AccountResponse;
 use AcquiaCloudApi\Response\ApplicationResponse;
+use AcquiaCloudApi\Response\CodebaseResponse;
 use AcquiaCloudApi\Response\DatabaseResponse;
 use AcquiaCloudApi\Response\DatabasesResponse;
 use AcquiaCloudApi\Response\EnvironmentResponse;
@@ -72,6 +74,7 @@ use Symfony\Component\Validator\Constraints\Url;
 use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
+use Twig\Environment;
 use Zumba\Amplitude\Amplitude;
 
 abstract class CommandBase extends Command implements LoggerAwareInterface
@@ -222,7 +225,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
         $this->formatter = $this->getHelper('formatter');
 
         $this->output->writeln('Acquia CLI version: ' . $this->getApplication()
-                ->getVersion(), OutputInterface::VERBOSITY_DEBUG);
+            ->getVersion(), OutputInterface::VERBOSITY_DEBUG);
         if (getenv('ACLI_NO_TELEMETRY') !== 'true') {
             $this->checkAndPromptTelemetryPreference();
             $this->telemetryHelper->initialize();
@@ -632,6 +635,9 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
         if ($input->getArgument('environmentId')) {
             $environmentId = $input->getArgument('environmentId');
             $chosenEnvironment = $this->getCloudEnvironment($environmentId);
+        } elseif ($input->getOption('codebase-uuid')) {
+            $codebaseUuid = $input->getOption('codebase-uuid');
+            $chosenEnvironment = $this->getCloudEnvironmentByCodebase($codebaseUuid);
         } else {
             $cloudApplicationUuid = $this->determineCloudApplication();
             $cloudApplication = $this->getCloudApplication($cloudApplicationUuid);
@@ -675,14 +681,52 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
     }
 
     /**
+     * Get the environment associated with a codebase UUID.
+     *
+     * @throws \Acquia\Cli\Exception\AcquiaCliException
+     */
+    protected function getCloudEnvironmentByCodebase(string $codebaseUuid): EnvironmentResponse
+    {
+        $acquiaCloudClient = $this->cloudApiClientService->getClient();
+        $codebasesResource = new Codebases($acquiaCloudClient);
+        $codebase = $codebasesResource->get($codebaseUuid);
+        // Prepare environment response from codebase.
+        $environment = new stdClass();
+        $environment->id = $codebase->id;
+        $environment->name = $codebase->label;
+        $environment->label = $codebase->label;
+        $environment->application = new stdClass();
+        $environment->domains = [];
+        $environment->active_domain = "";
+        $environment->default_domain = "";
+        $environment->ips = [];
+        $environment->balancer = "";
+        $environment->platform = "";
+        $environment->status = "";
+        $environment->type = "";
+        $environment->flags = new stdClass();
+        $environment->_links = $codebase->links;
+        $environment->region = $codebase->region;
+        $environment->configuration =  new stdClass();
+        $environment->artifact  =  new stdClass();
+        $environment->image_url = "";
+        $environment->vcs = new stdClass();
+        $environment->vcs->path = $codebase->vcs_url;
+        $environment->vcs->url = $codebase->vcs_url;
+        $environmentResponse = new EnvironmentResponse($environment);
+        $environmentResponse->uuid = $codebase->id;
+        return $environmentResponse;
+    }
+
+    /**
      * @throws \Acquia\Cli\Exception\AcquiaCliException
      */
     protected function isLocalGitRepoDirty(): bool
     {
         $this->localMachineHelper->checkRequiredBinariesExist(['git']);
         $process = $this->localMachineHelper->executeFromCmd(
-        // Problem with this is that it stages changes for the user. They may
-        // not want that.
+            // Problem with this is that it stages changes for the user. They may
+            // not want that.
             'git add . && git diff-index --cached --quiet HEAD',
             null,
             $this->dir,
@@ -1287,8 +1331,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
     {
         if (
             $input->hasArgument('applicationUuid') && !$input->getArgument('applicationUuid') && $this->getDefinition()
-                ->getArgument('applicationUuid')
-                ->isRequired()
+            ->getArgument('applicationUuid')
+            ->isRequired()
         ) {
             $output->writeln('Inferring Cloud Application UUID for this command since none was provided...', OutputInterface::VERBOSITY_VERBOSE);
             if ($applicationUuid = $this->determineCloudApplication()) {

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -224,7 +224,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
         $this->formatter = $this->getHelper('formatter');
 
         $this->output->writeln('Acquia CLI version: ' . $this->getApplication()
-        ->getVersion(), OutputInterface::VERBOSITY_DEBUG);
+                ->getVersion(), OutputInterface::VERBOSITY_DEBUG);
         if (getenv('ACLI_NO_TELEMETRY') !== 'true') {
             $this->checkAndPromptTelemetryPreference();
             $this->telemetryHelper->initialize();

--- a/src/Command/Pull/PullCodeCommand.php
+++ b/src/Command/Pull/PullCodeCommand.php
@@ -23,6 +23,7 @@ final class PullCodeCommand extends PullCommandBase
         $this
             ->acceptEnvironmentId()
             ->addOption('dir', null, InputArgument::OPTIONAL, 'The directory containing the Drupal project to be refreshed')
+            ->addOption('codebase-uuid', null, InputArgument::OPTIONAL, 'The UUID of the codebase to be pulled')
             ->addOption(
                 'no-scripts',
                 null,


### PR DESCRIPTION
**Motivation**
[CLI-1540](https://acquia.atlassian.net/browse/CLI-1540)

**Proposed changes**
Enables acli:pull to accept a --codebase-uuid argument.

**Alternatives considered**
N/A

**Testing steps**

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: (add specific steps for this pr)
4. Check new functionality: 
./bin/acli pull --codebase-uuid=(uuid)
Expected behavior:
The command will first check whether the current or specified directory is a Git repository.
If it is, it will identify the Git remote and ensure it’s compatible.
It will then locate the matching repository for the provided codebase-uuid.
Based on the current Git branch, the CLI will attempt to pull the corresponding branch from the remote VCS URL associated with the codebase.

