### PR TITLE
CLI-1579: API command that accepts an object has parameter wrapped in extra array.

### DIFF
--- a/tests/phpunit/src/Commands/Api/ApiBaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiBaseCommandTest.php
@@ -8,6 +8,7 @@ use Acquia\Cli\Command\Api\ApiBaseCommand;
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Tests\CommandTestBase;
+use ReflectionClass;
 
 class ApiBaseCommandTest extends CommandTestBase
 {
@@ -21,5 +22,125 @@ class ApiBaseCommandTest extends CommandTestBase
         $this->expectException(AcquiaCliException::class);
         $this->expectExceptionMessage('api:base is not a valid command');
         $this->executeCommand();
+    }
+
+    /**
+     * @dataProvider parseArrayValueProvider
+     */
+    public function testParseArrayValue(string|array $input, array $expected): void
+    {
+        $command = $this->createCommand();
+        $reflection = new ReflectionClass($command);
+        $method = $reflection->getMethod('parseArrayValue');
+
+        $result = $method->invoke($command, $input);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{string|array<mixed>, array<mixed>}>
+     */
+    public static function parseArrayValueProvider(): array
+    {
+        return [
+            'Comma-separated string' => [
+                'item1,item2,item3',
+                ['item1', 'item2', 'item3'],
+            ],
+            'Empty array input' => [
+                [],
+                [],
+            ],
+            'Empty string' => [
+                '',
+                [''],
+            ],
+            'Existing array input' => [
+                ['already', 'an', 'array'],
+                ['already', 'an', 'array'],
+            ],
+            'JSON array of objects' => [
+                '[{"environment_id":"164572-6ecd5987-5745-48b0-8cd3-397f5963aea2"},{"environment_id":"164548-97cc5820-b6b3-42f6-84b1-0cb81ac781d1"}]',
+                [
+                    ['environment_id' => '164572-6ecd5987-5745-48b0-8cd3-397f5963aea2'],
+                    ['environment_id' => '164548-97cc5820-b6b3-42f6-84b1-0cb81ac781d1'],
+                ],
+            ],
+            'JSON array of strings' => [
+                '["item1","item2","item3"]',
+                ['item1', 'item2', 'item3'],
+            ],
+            'JSON array with whitespace' => [
+                '  [ "item1" , "item2" ]  ',
+                ['item1', 'item2'],
+            ],
+            'JSON comma-separated objects' => [
+                '{"environment_id":"164572-6ecd5987-5745-48b0-8cd3-397f5963aea2"},{"environment_id":"164548-97cc5820-b6b3-42f6-84b1-0cb81ac781d1"}',
+                [
+                    ['environment_id' => '164572-6ecd5987-5745-48b0-8cd3-397f5963aea2'],
+                    ['environment_id' => '164548-97cc5820-b6b3-42f6-84b1-0cb81ac781d1'],
+                ],
+            ],
+            'Single item string' => [
+                'single-item',
+                ['single-item'],
+            ],
+            'Single JSON object' => [
+                '{"environment_id":"164572-6ecd5987-5745-48b0-8cd3-397f5963aea2"}',
+                ['environment_id' => '164572-6ecd5987-5745-48b0-8cd3-397f5963aea2'],
+            ],
+        ];
+    }
+
+    /**
+     * Test that doCastParamType handles object type correctly when value is already an array
+     */
+    public function testDoCastParamTypeWithObjectAndArrayValue(): void
+    {
+        $command = $this->createCommand();
+        $reflection = new ReflectionClass($command);
+        $method = $reflection->getMethod('doCastParamType');
+
+        // Test that passing an array to object type doesn't cause TypeError.
+        $result = $method->invoke($command, 'object', ['key' => 'value']);
+        $this->assertEquals(['key' => 'value'], $result);
+
+        // Test that passing a string to object type works as expected.
+        $result = $method->invoke($command, 'object', '{"key":"value"}');
+        $this->assertEquals((object)['key' => 'value'], $result);
+    }
+
+    /**
+     * @dataProvider shouldTreatAsArrayProvider
+     */
+    public function testShouldTreatAsArray(mixed $input, bool $expected): void
+    {
+        $command = $this->createCommand();
+        $reflection = new ReflectionClass($command);
+        $method = $reflection->getMethod('shouldTreatAsArray');
+
+        $result = $method->invoke($command, $input);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{mixed, bool}>
+     */
+    public static function shouldTreatAsArrayProvider(): array
+    {
+        return [
+            'Already an array' => [['item1', 'item2'], true],
+            'Comma-separated JSON objects' => ['{"environment_id":"ABC"},{"environment_id":"DEF"}', true],
+            'Comma-separated string' => ['item1,item2,item3', true],
+            'Empty string' => ['', false],
+            'JSON array' => ['[{"key":"value"}]', true],
+            'JSON array of objects' => ['[{"environment_id":"ABC"},{"environment_id":"DEF"}]', true],
+            'JSON object' => ['{"key":"value"}', true],
+            'JSON with whitespace' => ['  [{"key":"value"}]  ', true],
+            'Non-array non-string' => [123, false],
+            'Not an array value' => ['just-a-string', false],
+            'Object with whitespace' => ['  {"key":"value"}  ', true],
+            'String without commas' => ['single-item', false],
+        ];
     }
 }


### PR DESCRIPTION
**Motivation**
Fixes [#CLI-1579](https://acquia.atlassian.net/browse/CLI-1579)
The CLI command api:codebases:bulk-code-switch:start was producing malformed payloads when an object-type parameter (like targets) was passed as a JSON string. This led to a 500 Internal Server Error from the Cloud API because the payload structure wrapped the input in an unintended extra array.

**Proposed changes**
After this PR, both of the following command formats will work correctly:
`acli api:codebases:bulk-code-switch:start -vvv 479627e6-0e5e-4b1c-877d-ff060e5a509f tags/cms-2.12.1 '{"environment_id":"164572-6ecd5987-5745-48b0-8cd3-397f5963aea2"},{"environment_id":"164548-97cc5820-b6b3-42f6-84b1-0cb81ac781d1"}'`

and
`acli api:codebases:bulk-code-switch:start -vvv 479627e6-0e5e-4b1c-877d-ff060e5a509f tags/cms-2.12.1 '[{"environment_id":"164572-6ecd5987-5745-48b0-8cd3-397f5963aea2"},{"environment_id":"164548-97cc5820-b6b3-42f6-84b1-0cb81ac781d1"}]'`

**Alternatives considered**
N/A

**Testing steps**
1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: N/A
4. Check new functionality: Mentioned in proposed changes
