### PR TITLE
CLI-1584: Deprecate MEO endpoints, fix environment command

### DIFF
--- a/assets/acquia-spec.json
+++ b/assets/acquia-spec.json
@@ -39278,7 +39278,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}/database": {
+    "/site-instances/{siteId}.{environmentId}/database": {
       "get": {
         "operationId": "site_instance_database",
         "x-cli-name": "site-instances:database",
@@ -39434,7 +39434,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -39632,7 +39632,7 @@
           },
           "required": false
         },
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -39640,7 +39640,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}/database/backups": {
+    "/site-instances/{siteId}.{environmentId}/database/backups": {
       "get": {
         "operationId": "get_database_backups",
         "x-cli-name": "site-instances:database:backups",
@@ -39933,7 +39933,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -40110,7 +40110,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -40118,7 +40118,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}/database/backups/{id}": {
+    "/site-instances/{siteId}.{environmentId}/database/backups/{id}": {
       "get": {
         "operationId": "get_database_backup",
         "x-cli-name": "site-instances:database:backups:get",
@@ -40284,7 +40284,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -40433,7 +40433,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -40441,7 +40441,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}/database/backups/{id}/actions/download": {
+    "/site-instances/{siteId}.{environmentId}/database/backups/{id}/actions/download": {
       "get": {
         "operationId": "api_site-instances_siteId._environmentIddatabasebackups_idactionsdownload_get",
         "x-cli-name": "site-instances:database:backups:download",
@@ -40604,7 +40604,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -40612,7 +40612,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}/database/backups/{id}/actions/restore": {
+    "/site-instances/{siteId}.{environmentId}/database/backups/{id}/actions/restore": {
       "post": {
         "operationId": "restore_database_backup",
         "x-cli-name": "site-instances:database:backups:restore",
@@ -40786,7 +40786,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -40794,7 +40794,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}/domains": {
+    "/site-instances/{siteId}.{environmentId}/domains": {
       "get": {
         "operationId": "site_instance_domains",
         "x-cli-name": "site-instances:domains",
@@ -41073,7 +41073,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -41081,7 +41081,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}/domains/{domainName}": {
+    "/site-instances/{siteId}.{environmentId}/domains/{domainName}": {
       "get": {
         "operationId": "site_instance_domain",
         "x-cli-name": "site-instances:domain",
@@ -41239,7 +41239,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -41422,7 +41422,7 @@
           },
           "required": false
         },
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -41571,7 +41571,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -41579,7 +41579,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}/domains/{domainName}/status": {
+    "/site-instances/{siteId}.{environmentId}/domains/{domainName}/status": {
       "get": {
         "operationId": "site_instance_domain_status",
         "x-cli-name": "site-instances:domain:status",
@@ -41773,7 +41773,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -41781,7 +41781,7 @@
         ]
       }
     },
-    "/api/codebases/{codebaseId}/environments": {
+    "/codebases/{codebaseId}/environments": {
       "get": {
         "operationId": "environments_by_codebase",
         "x-cli-name": "codebases:environments-list",
@@ -42153,7 +42153,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -42161,7 +42161,7 @@
         ]
       }
     },
-    "/api/codebases/{codebaseId}/environments/{environmentId}": {
+    "/codebases/{codebaseId}/environments/{environmentId}": {
       "get": {
         "operationId": "environment_by_codebase_id",
         "x-cli-name": "codebases:environments-find",
@@ -42386,7 +42386,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -42394,10 +42394,10 @@
         ]
       }
     },
-    "/api/environments/{environmentId}": {
+    "/v3/environments/{environmentId}": {
       "get": {
         "operationId": "environment_by_id",
-        "x-cli-name": "environments:find",
+        "x-cli-name": "environments-v3:find",
         "tags": [
           "Environment"
         ],
@@ -42605,7 +42605,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -42614,7 +42614,7 @@
       },
       "put": {
         "operationId": "update_environment",
-        "x-cli-name": "environments:update",
+        "x-cli-name": "environments-v3:update",
         "tags": [
           "Environment"
         ],
@@ -42806,7 +42806,7 @@
           },
           "required": false
         },
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -42814,10 +42814,10 @@
         ]
       }
     },
-    "/api/environments/{environmentId}/private-network": {
+    "/v3/environments/{environmentId}/private-network": {
       "get": {
         "operationId": "api_environments_environmentIdprivate-network_get",
-        "x-cli-name": "environments:private-network:get",
+        "x-cli-name": "environments-v3:private-network:get",
         "tags": [
           "Environment"
         ],
@@ -42949,7 +42949,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -42958,7 +42958,7 @@
       },
       "delete": {
         "operationId": "update_environment_private_network",
-        "x-cli-name": "environments:private-network:delete",
+        "x-cli-name": "environments-v3:private-network:delete",
         "tags": [
           "Environment"
         ],
@@ -43109,7 +43109,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -43117,7 +43117,7 @@
         ]
       }
     },
-    "/api/sites/{siteId}/environments": {
+    "/sites/{siteId}/environments": {
       "get": {
         "operationId": "environments_by_site",
         "x-cli-name": "sites:environments-list",
@@ -43487,7 +43487,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -43495,10 +43495,10 @@
         ]
       }
     },
-    "/api/environments/{environmentId}/site-instances": {
+    "/v3/environments/{environmentId}/site-instances": {
       "post": {
         "operationId": "api_environments_environmentIdsite-instances_post",
-        "x-cli-name": "environments:site-instances:create",
+        "x-cli-name": "environments-v3:site-instances:create",
         "tags": [
           "SiteInstance"
         ],
@@ -43669,7 +43669,7 @@
           },
           "required": false
         },
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -43677,7 +43677,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}": {
+    "/site-instances/{siteId}.{environmentId}": {
       "get": {
         "operationId": "site_instance",
         "x-cli-name": "site-instances:find",
@@ -43857,7 +43857,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -44007,7 +44007,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -44015,7 +44015,7 @@
         ]
       }
     },
-    "/api/site-instances/{siteId}.{environmentId}/files": {
+    "/site-instances/{siteId}.{environmentId}/files": {
       "post": {
         "operationId": "api_site-instances_siteId._environmentIdfiles_post",
         "x-cli-name": "site-instances:files:copy",
@@ -44203,7 +44203,7 @@
           },
           "required": false
         },
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Environment_Service_JWT": []
@@ -44211,7 +44211,7 @@
         ]
       }
     },
-    "/api/codebases/{codebaseId}/sites": {
+    "/codebases/{codebaseId}/sites": {
       "get": {
         "operationId": "api_codebases_codebaseIdsites_get_collection",
         "x-cli-name": "codebases:sites-list",
@@ -44439,7 +44439,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Site_Service_JWT": []
@@ -44447,7 +44447,7 @@
         ]
       }
     },
-    "/api/environments/{environmentId}/sites": {
+    "/environments/{environmentId}/sites": {
       "get": {
         "operationId": "api_environments_environmentIdsites_get_collection",
         "x-cli-name": "environments:sites-list",
@@ -44684,7 +44684,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Site_Service_JWT": []
@@ -44692,7 +44692,7 @@
         ]
       }
     },
-    "/api/organizations/{organizationId}/sites": {
+    "/organizations/{organizationId}/sites": {
       "get": {
         "operationId": "api_organizations_organizationIdsites_get_collection",
         "x-cli-name": "organizations:sites-list",
@@ -44917,7 +44917,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Site_Service_JWT": []
@@ -44925,7 +44925,7 @@
         ]
       }
     },
-    "/api/sites": {
+    "/sites": {
       "get": {
         "operationId": "get_sites",
         "x-cli-name": "sites:list",
@@ -45139,7 +45139,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Site_Service_JWT": []
@@ -45254,7 +45254,7 @@
           },
           "required": false
         },
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Site_Service_JWT": []
@@ -45262,7 +45262,7 @@
         ]
       }
     },
-    "/api/sites/{siteId}": {
+    "/sites/{siteId}": {
       "get": {
         "operationId": "get_site_by_id",
         "x-cli-name": "sites:find",
@@ -45358,7 +45358,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Site_Service_JWT": []
@@ -45467,7 +45467,7 @@
           },
           "required": false
         },
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Site_Service_JWT": []
@@ -45553,7 +45553,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Site_Service_JWT": []
@@ -45561,7 +45561,7 @@
         ]
       }
     },
-    "/api/teams/{teamId}/sites": {
+    "/teams/{teamId}/sites": {
       "get": {
         "operationId": "api_teams_teamIdsites_get_collection",
         "x-cli-name": "teams:sites-list",
@@ -45786,7 +45786,7 @@
             "allowReserved": false
           }
         ],
-        "deprecated": false,
+        "deprecated": true,
         "security": [
           {
             "Site_Service_JWT": []

--- a/src/Command/Acsf/AcsfListCommandBase.php
+++ b/src/Command/Acsf/AcsfListCommandBase.php
@@ -20,21 +20,6 @@ class AcsfListCommandBase extends CommandBase
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $commands = $this->getApplication()->all();
-        foreach ($commands as $command) {
-            if (
-                $command->getName() !== $this->namespace
-                // E.g., if the namespace is acsf:api, show all acsf:api:* commands.
-                && str_contains($command->getName(), $this->namespace . ':')
-                // This is a lazy way to exclude api:base and acsf:base.
-                && $command->getDescription()
-            ) {
-                $command->setHidden(false);
-            } else {
-                $command->setHidden();
-            }
-        }
-
         $command = $this->getApplication()->find('list');
         $arguments = [
             'command' => 'list',

--- a/src/Command/Api/ApiCommandHelper.php
+++ b/src/Command/Api/ApiCommandHelper.php
@@ -364,19 +364,13 @@ class ApiCommandHelper
                     continue;
                 }
 
-                // Skip deprecated endpoints.
-                // @infection-ignore-all
-                if (array_key_exists('deprecated', $schema) && $schema['deprecated']) {
-                    continue;
-                }
-
                 $commandName = $commandPrefix . ':' . $schema['x-cli-name'];
                 $command = $commandFactory->createCommand();
                 $command->setName($commandName);
                 $command->setDescription($schema['summary']);
                 $command->setMethod($method);
                 $command->setResponses($schema['responses']);
-                $command->setHidden(false);
+                $command->setHidden(array_key_exists('deprecated', $schema) && $schema['deprecated']);
                 if (array_key_exists('servers', $acquiaCloudSpec)) {
                     $command->setServers($acquiaCloudSpec['servers']);
                 }

--- a/src/Command/Api/ApiListCommandBase.php
+++ b/src/Command/Api/ApiListCommandBase.php
@@ -18,22 +18,11 @@ class ApiListCommandBase extends CommandBase
         $this->namespace = $namespace;
     }
 
+    /**
+     * @throws \Symfony\Component\Console\Exception\ExceptionInterface
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $commands = $this->getApplication()->all();
-        foreach ($commands as $command) {
-            if (
-                $command->getName() !== $this->namespace
-                && str_contains($command->getName(), $this->namespace . ':')
-                // This is a lazy way to exclude api:base and acsf:base.
-                && $command->getDescription()
-            ) {
-                $command->setHidden(false);
-            } else {
-                $command->setHidden();
-            }
-        }
-
         $command = $this->getApplication()->find('list');
         $arguments = [
             'command' => 'list',

--- a/tests/phpunit/src/Commands/Acsf/AcsfListCommandTest.php
+++ b/tests/phpunit/src/Commands/Acsf/AcsfListCommandTest.php
@@ -49,7 +49,6 @@ class AcsfListCommandTest extends AcsfCommandTestBase
         $this->executeCommand();
         $output = $this->getDisplay();
         $this->assertStringContainsString('acsf:api:ping', $output);
-        $this->assertStringNotContainsString('acsf:groups', $output);
     }
 
     /**

--- a/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiListCommandTest.php
@@ -43,7 +43,6 @@ class ApiListCommandTest extends CommandTestBase
         $output = $this->getDisplay();
         $this->assertStringContainsString('api:accounts:', $output);
         $this->assertStringContainsString('api:accounts:ssh-keys-list', $output);
-        $this->assertStringNotContainsString('api:subscriptions', $output);
     }
 
     public function testListCommand(): void


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1584

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

This isn't perfect, it still prints the namespaces for the hidden commands due to a bug in the Symfony ApplicationDescription Descriptor, but it's better than what we have now.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: (add specific steps for this pr)
4. Check new functionality: (add specific steps for this pr)
