### PR TITLE
CLI-1596: Let the user choose the Environment and site interactive input.

### DIFF
--- a/assets/acquia-spec.json
+++ b/assets/acquia-spec.json
@@ -42884,7 +42884,7 @@
                                     "properties": {
                                       "id": {
                                         "type": "string",
-                                        "example": "1111-1111-1111"
+                                        "example": "11111111-041c-44c7-a486-7972ed2cafc8"
                                       },
                                       "_links": {
                                         "type": "object",
@@ -42895,7 +42895,7 @@
                                               "href": {
                                                 "type": "string",
                                                 "format": "uri",
-                                                "example": "https://codebase-service.acquia.com/api/codebases/1111-1111-1111"
+                                                "example": "https://codebase-service.acquia.com/api/codebases/11111111-041c-44c7-a486-7972ed2cafc8"
                                               }
                                             }
                                           }
@@ -43035,10 +43035,10 @@
                         "reference": "tag/v3.1",
                         "_embedded": {
                           "codebase": {
-                            "id": "1111-1111-1111",
+                            "id": "11111111-041c-44c7-a486-7972ed2cafc8",
                             "_links": {
                               "self": {
-                                "href": "https://codebase-service.acquia.com/api/codebases/1111-1111-1111"
+                                "href": "https://codebase-service.acquia.com/api/codebases/11111111-041c-44c7-a486-7972ed2cafc8"
                               }
                             }
                           }
@@ -44504,7 +44504,7 @@
                                     "properties": {
                                       "id": {
                                         "type": "string",
-                                        "example": "1111-1111-1111"
+                                        "example": "11111111-041c-44c7-a486-7972ed2cafc8"
                                       },
                                       "_links": {
                                         "type": "object",
@@ -44515,7 +44515,7 @@
                                               "href": {
                                                 "type": "string",
                                                 "format": "uri",
-                                                "example": "https://cloud.acquia.com/api/codebases/1111-1111-1111"
+                                                "example": "https://cloud.acquia.com/api/codebases/11111111-041c-44c7-a486-7972ed2cafc8"
                                               }
                                             }
                                           }
@@ -44658,10 +44658,10 @@
                         "reference": "tag/v3.1",
                         "_embedded": {
                           "codebase": {
-                            "id": "1111-1111-1111",
+                            "id": "11111111-041c-44c7-a486-7972ed2cafc8",
                             "_links": {
                               "self": {
-                                "href": "https://cloud.acquia.com/api/codebases/1111-1111-1111"
+                                "href": "https://cloud.acquia.com/api/codebases/11111111-041c-44c7-a486-7972ed2cafc8"
                               }
                             }
                           }

--- a/src/Transformer/EnvironmentTransformer.php
+++ b/src/Transformer/EnvironmentTransformer.php
@@ -14,7 +14,6 @@ class EnvironmentTransformer
     public static function transform(mixed $codebaseEnv): EnvironmentResponse
     {
         $env = new \stdClass();
-
         // Core fields.
         $env->id = $codebaseEnv->id;
         $env->uuid = $codebaseEnv->id;
@@ -22,6 +21,9 @@ class EnvironmentTransformer
         $env->label = $codebaseEnv->label;
         $env->status = $codebaseEnv->status;
 
+        if (isset($codebaseEnv->properties) && is_object($codebaseEnv->properties)) {
+            $codebaseEnv->properties = (array)$codebaseEnv->properties;
+        }
         // Domains, network, etc.
         $env->active_domain = $codebaseEnv->properties['active_domain'] ?? '';
         $env->default_domain = $codebaseEnv->properties['default_domain'] ?? '';
@@ -48,6 +50,7 @@ class EnvironmentTransformer
         ) {
             $vcsUrl = $codebaseEnv->codebase->vcs_url;
         }
+        $env->ssh_url = $env->ssh_url ?? $vcsUrl;
         $env->vcs = (object) [
             'branch' => $branch,
             'path' => $branch,
@@ -60,9 +63,7 @@ class EnvironmentTransformer
         // Cast for mutation safety.
         $env->flags = (object) ($codebaseEnv->flags ?? []);
         $env->_links = (object) ($codebaseEnv->links ?? []);
-
         $env->type = $codebaseEnv->properties['type'] ?? '';
-
         // Now instantiate EnvironmentResponse.
         return new EnvironmentResponse($env);
     }

--- a/tests/phpunit/src/CommandTestBase.php
+++ b/tests/phpunit/src/CommandTestBase.php
@@ -271,14 +271,32 @@ abstract class CommandTestBase extends TestBase
         $environment->codebase = (object)$codebase;
         return $environment;
     }
-    public function mockGetCodebase(): mixed
+    public function mockGetCodebaseEnvironments(): mixed
     {
         $sites = $this->mockRequest('get_sites');
         $site = $sites[self::$INPUT_DEFAULT_CHOICE];
         $environments = $this->mockRequest('environments_by_site', $site->id);
-        $environment = $environments[self::$INPUT_DEFAULT_CHOICE];
-        $codebase = $this->mockRequest('get_codebase_by_id', $environment->_embedded->codebase->id);
+        foreach ($environments as $environment) {
+            $codebase = $this->mockRequest('get_codebase_by_id', $environment->_embedded->codebase->id);
+            $environment->codebase = (object)$codebase;
+        }
+        return $environments;
+    }
+    public function mockGetCodebaseSites(): mixed
+    {
+        $sites = $this->mockRequest('get_sites');
+        return $sites;
+    }
+    public function mockGetCodebase(): mixed
+    {
+        $codebases = $this->mockRequest('api_codebases_get_collection');
+        $codebase = $codebases[self::$INPUT_DEFAULT_CHOICE];
         return $codebase;
+    }
+    public function mockGetCodebases(): mixed
+    {
+        $codebases = $this->mockRequest('api_codebases_get_collection');
+        return $codebases;
     }
 
     protected function mockLocalMachineHelper(): LocalMachineHelper|ObjectProphecy

--- a/tests/phpunit/src/Commands/CommandBaseTest.php
+++ b/tests/phpunit/src/Commands/CommandBaseTest.php
@@ -428,6 +428,40 @@ class CommandBaseTest extends CommandTestBase
      * Test that determineVcsUrl method exists and is accessible for testing purposes.
      * This test validates the method signature and basic invocation.
      */
+    public function testDetermineEnvironmentFromIdeContextMethodAccessibility(): void
+    {
+        $reflection = new \ReflectionClass($this->command);
+        $method = $reflection->getMethod('determineEnvironmentFromIdeContext');
+        $this->assertTrue($method->isProtected());
+        $method->setAccessible(true);
+
+        // The method should exist and be callable.
+        $this->assertTrue($method->isUserDefined());
+        $this->assertEquals('determineEnvironmentFromIdeContext', $method->getName());
+    }
+
+    /**
+     * Test determineVcsUrl method existence and accessibility.
+     * This creates basic test coverage for mutation testing.
+     */
+    public function testDetermineEnvironmentFromIdeContextMethodExists(): void
+    {
+        $reflection = new \ReflectionClass($this->command);
+        $method = $reflection->getMethod('determineEnvironmentFromIdeContext');
+        $this->assertTrue($method->isProtected());
+        $this->assertEquals('determineEnvironmentFromIdeContext', $method->getName());
+
+        // Test the method signature by checking parameter count.
+        $this->assertEquals(2, $method->getNumberOfParameters());
+        $parameters = $method->getParameters();
+        $this->assertEquals('input', $parameters[0]->getName());
+        $this->assertEquals('output', $parameters[1]->getName());
+    }
+
+    /**
+     * Test that determineSiteInstance method exists and is accessible for testing purposes.
+     * This test validates the method signature and basic invocation.
+     */
     public function testDetermineSiteInstanceMethodAccessibility(): void
     {
         $reflection = new \ReflectionClass($this->command);

--- a/tests/phpunit/src/TestBase.php
+++ b/tests/phpunit/src/TestBase.php
@@ -652,7 +652,7 @@ abstract class TestBase extends TestCase
     protected function getMockCodeBaseEnvironment(string $method = 'get', string $httpCode = '200'): object
     {
         return self::getMockResponseFromSpec(
-            '/api/environments/{environmentId}',
+            '/v3/environments/{environmentId}',
             $method,
             $httpCode
         );


### PR DESCRIPTION
**Motivation**
Fixes [#CLI-1596](https://acquia.atlassian.net/browse/CLI-1596)

**Proposed changes**
Currently, the acli pull command requires users to manually input the site_instance_id, which is inefficient—especially when working within an IDE.

- This enhancement will improve the developer experience by:
- Automatically detecting the IDE context via an environment variable.
- Using AH_CODEBASE_UUID (if available) to infer context.
- Falling back to AH_APPLICATION_UUID if AH_CODEBASE_UUID is unavailable.
- Automatically retrieving associated environments and site instances.
- Prompting users to interactively select from available options.



**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: (add specific steps for this pr)
4. Check new functionality: (add specific steps for this pr)
