### PR TITLE
Ensure all environments show when a branch or tag is deployed to multiple environments

### DIFF
--- a/src/Command/App/AppVcsInfo.php
+++ b/src/Command/App/AppVcsInfo.php
@@ -47,7 +47,9 @@ class AppVcsInfo extends CommandBase
         $deployedVcs = [];
         foreach ($environments as $environment) {
             if (isset($environment->vcs->path)) {
-                $deployedVcs[$environment->vcs->path] = $environment->label;
+                // Using paths as keys negates dev/stage/prod environments
+                // having the same branch/tag deployed.
+                $deployedVcs[$environment->label] = $environment->vcs->path;
             }
         }
 
@@ -81,12 +83,14 @@ class AppVcsInfo extends CommandBase
         $table->setHeaders($headers);
         $table->setHeaderTitle('Status of Branches and Tags of the Application');
         foreach ($allVcs as $vscPath => $env) {
+            // Flip the env and path if it is deployed.
+            $isDeployed = in_array($vscPath, array_keys($deployedVcs), true);
             $table->addRow([
-                $vscPath,
+                $isDeployed ? $env : $vscPath,
                 // If VCS and env name is not same, it means it is deployed.
                 $vscPath !== $env ? 'Yes' : 'No',
                 // If VCS and env name is same, it means it is deployed.
-                $vscPath !== $env ? $env : 'None',
+                $vscPath !== $env ? ($isDeployed ? $vscPath : $env) : 'None',
             ]);
         }
 


### PR DESCRIPTION
**Motivation**

When a branch or tag is deployed to multiple environments, not all are shown in the output:

```
acli app:vcs:info myproject --deployed
+------ Status of Branches and Tags of the Application -------+
| Branch / Tag Name         | Deployed | Deployed Environment |
+---------------------------+----------+----------------------+
| artifact-august-release-2 | Yes      | Stage                |
| tags/artifact-1.3.12      | Yes      | Prod                 |
+---------------------------+----------+----------------------+
```

Note that this problem exists with or without the `--deployed` flag. This PR fixes both cases.

**Proposed changes**

* Adds logic to ensure that keys are preserved when checking deployed status.

```
./bin/acli app:vcs:info centra2 --deployed
+------ Status of Branches and Tags of the Application -------+
| Branch / Tag Name         | Deployed | Deployed Environment |
+---------------------------+----------+----------------------+
| artifact-august-release-2 | Yes      | Dev                  |
| tags/artifact-1.3.12      | Yes      | Prod                 |
| artifact-august-release-2 | Yes      | Stage                |
+---------------------------+----------+----------------------+
```

**Alternatives considered**

* Alternately. we could flip the table output, but key juggling would still be an issue. 

**Testing steps**

1. Load a known project on Acquia
2. Deploy the same branch to DEV and STAGE
3. Run `./bin/acli app:vcs:info myproject --deployed` and note that DEV is not shown
4. Checkout this branch
5. Run `./bin/acli app:vcs:info myproject --deployed` and note that all environments are shown