### PR TITLE
IDE-4565: acli pull-files not showing the Prod environment option on Cloud IDE | bca.prod | 01204920.

### DIFF
--- a/src/Command/Pull/PullFilesCommand.php
+++ b/src/Command/Pull/PullFilesCommand.php
@@ -26,7 +26,7 @@ final class PullFilesCommand extends PullCommandBase
     {
         $this->setDirAndRequireProjectCwd($input);
 
-        $sourceEnvironment = $this->determineEnvironment($input, $output);
+        $sourceEnvironment = $this->determineEnvironment($input, $output, false);
 
         $this->pullFiles($input, $output, $sourceEnvironment);
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: (add specific steps for this pr)
4. Check new functionality: (add specific steps for this pr)
