### PR TITLE
Remove Next ACMS from list of new applications

### DIFF
--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -59,15 +59,9 @@ final class NewCommand extends CommandBase
 
         $output->writeln('<info>Creating project. This may take a few minutes.</info>');
 
-        if ($project === 'acquia_next_acms') {
-            $successMessage = "<info>New Next.js project created in $dir. 🎉</info>";
-            $this->localMachineHelper->checkRequiredBinariesExist(['node']);
-            $this->createNextJsProject($dir);
-        } else {
-            $successMessage = "<info>New 💧 Drupal project created in $dir. 🎉</info>";
-            $this->localMachineHelper->checkRequiredBinariesExist(['composer']);
-            $this->createDrupalProject(self::$distros[$project], $dir);
-        }
+        $successMessage = "<info>New 💧 Drupal project created in $dir. 🎉</info>";
+        $this->localMachineHelper->checkRequiredBinariesExist(['composer']);
+        $this->createDrupalProject(self::$distros[$project], $dir);
 
         $this->initializeGitRepository($dir);
 
@@ -75,23 +69,6 @@ final class NewCommand extends CommandBase
         $output->writeln($successMessage);
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * @throws \Acquia\Cli\Exception\AcquiaCliException
-     */
-    private function createNextJsProject(string $dir): void
-    {
-        $process = $this->localMachineHelper->execute([
-            'npx',
-            'create-next-app',
-            '-e',
-            'https://github.com/acquia/next-acms/tree/main/starters/basic-starter',
-            $dir,
-        ]);
-        if (!$process->isSuccessful()) {
-            throw new AcquiaCliException("Unable to create new next-acms project.");
-        }
     }
 
     /**

--- a/src/Command/App/NewCommand.php
+++ b/src/Command/App/NewCommand.php
@@ -24,7 +24,6 @@ final class NewCommand extends CommandBase
     private static array $distros = [
         'acquia_drupal_cms' => 'acquia/drupal-cms-project',
         'acquia_drupal_recommended' => 'acquia/drupal-recommended-project',
-        'acquia_next_acms' => 'acquia/next-acms',
     ];
     protected function configure(): void
     {
@@ -41,7 +40,6 @@ final class NewCommand extends CommandBase
     {
         $this->output->writeln('Acquia recommends most customers use <options=bold>acquia/drupal-recommended-project</> to setup a Drupal project, which includes useful utilities such as Acquia Connector.');
         $this->output->writeln('<options=bold>acquia/drupal-cms-project</> is Drupal CMS scaffolded to work with Acquia hosting.');
-        $this->output->writeln('<options=bold>acquia/next-acms</> is a starter template for building a headless site powered by Acquia CMS and Next.js.');
 
         if ($input->hasOption('template') && $input->getOption('template')) {
             $project = $input->getOption('template');

--- a/tests/phpunit/src/Commands/App/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/App/NewCommandTest.php
@@ -92,6 +92,7 @@ class NewCommandTest extends CommandTestBase
         $output = $this->getDisplay();
         $this->assertStringContainsString('Acquia recommends most customers use acquia/drupal-recommended-project to setup a Drupal project', $output);
         $this->assertStringContainsString('acquia/drupal-cms-project is Drupal CMS scaffolded to work with Acquia hosting.', $output);
+        $this->assertStringNotContainsString('acquia/next-acms is a starter template for building a headless site powered by Acquia CMS and Next.js.', $output);
         $this->assertStringContainsString('Choose a starting project', $output);
         $this->assertStringContainsString($project, $output);
         $this->assertTrue($mockFileSystem->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');

--- a/tests/phpunit/src/Commands/App/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/App/NewCommandTest.php
@@ -81,6 +81,7 @@ class NewCommandTest extends CommandTestBase
         $output = $this->getDisplay();
         $this->assertStringContainsString('Acquia recommends most customers use acquia/drupal-recommended-project to setup a Drupal project', $output);
         $this->assertStringContainsString('acquia/drupal-cms-project is Drupal CMS scaffolded to work with Acquia hosting.', $output);
+        $this->assertStringNotContainsString('acquia/next-acms is a starter template for building a headless site powered by Acquia CMS and Next.js.', $output);
         $this->assertStringContainsString('Choose a starting project', $output);
         $this->assertStringContainsString($project, $output);
         $this->assertTrue($mockFileSystem->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');

--- a/tests/phpunit/src/Commands/App/NewCommandTest.php
+++ b/tests/phpunit/src/Commands/App/NewCommandTest.php
@@ -46,17 +46,6 @@ class NewCommandTest extends CommandTestBase
     }
 
     /**
-     * @return array<mixed>
-     */
-    public static function provideTestNewNextJsAppCommand(): array
-    {
-        return [
-            [['acquia_next_acms' => 'acquia/next-acms']],
-            [['acquia_next_acms' => 'acquia/next-acms'], 'test-dir'],
-        ];
-    }
-
-    /**
      * @dataProvider provideTestNewDrupalCommand
      */
     public function testNewDrupalCommand(array $package, string $directory = 'drupal'): void
@@ -92,86 +81,10 @@ class NewCommandTest extends CommandTestBase
         $output = $this->getDisplay();
         $this->assertStringContainsString('Acquia recommends most customers use acquia/drupal-recommended-project to setup a Drupal project', $output);
         $this->assertStringContainsString('acquia/drupal-cms-project is Drupal CMS scaffolded to work with Acquia hosting.', $output);
-        $this->assertStringNotContainsString('acquia/next-acms is a starter template for building a headless site powered by Acquia CMS and Next.js.', $output);
         $this->assertStringContainsString('Choose a starting project', $output);
         $this->assertStringContainsString($project, $output);
         $this->assertTrue($mockFileSystem->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');
         $this->assertStringContainsString('New 💧 Drupal project created in ' . $this->newProjectDir, $output);
-    }
-
-    /**
-     * @dataProvider provideTestNewNextJsAppCommand
-     */
-    public function testNewNextJSAppCommand(array $package, string $directory = 'nextjs'): void
-    {
-        $this->newProjectDir = Path::makeAbsolute($directory, $this->projectDir);
-        $projectKey = array_keys($package)[0];
-        $project = $package[$projectKey];
-
-        $process = $this->prophet->prophesize(Process::class);
-        $process->isSuccessful()->willReturn(true);
-        $process->getExitCode()->willReturn(0);
-
-        $localMachineHelper = $this->mockLocalMachineHelper();
-
-        $mockFileSystem = $this->mockGetFilesystem($localMachineHelper);
-
-        $localMachineHelper->checkRequiredBinariesExist(["node"])
-            ->shouldBeCalled();
-        $this->mockExecuteNpxCreate($this->newProjectDir, $localMachineHelper, $process);
-        $localMachineHelper->checkRequiredBinariesExist(["git"])
-            ->shouldBeCalled();
-        $this->mockExecuteGitInit($localMachineHelper, $this->newProjectDir, $process);
-        $this->mockExecuteGitAdd($localMachineHelper, $this->newProjectDir, $process);
-        $this->mockExecuteGitCommit($localMachineHelper, $this->newProjectDir, $process);
-
-        $inputs = [
-            // Choose a starting project.
-            $project,
-        ];
-        $this->executeCommand([
-            'directory' => $directory,
-        ], $inputs);
-
-        $output = $this->getDisplay();
-        $this->assertStringContainsString('acquia/next-acms is a starter template for building a headless site', $output);
-        $this->assertStringContainsString('Choose a starting project', $output);
-        $this->assertStringContainsString($project, $output);
-        $this->assertTrue($mockFileSystem->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');
-        $this->assertStringContainsString('New Next.js project created in ' . $this->newProjectDir, $output);
-    }
-
-    public function testProjectTemplateOption(): void
-    {
-        $this->newProjectDir = Path::makeAbsolute('nextjs', $this->projectDir);
-
-        $process = $this->prophet->prophesize(Process::class);
-        $process->isSuccessful()->willReturn(true);
-        $process->getExitCode()->willReturn(0);
-
-        $localMachineHelper = $this->mockLocalMachineHelper();
-
-        $mockFileSystem = $this->mockGetFilesystem($localMachineHelper);
-
-        $localMachineHelper->checkRequiredBinariesExist(["node"])
-            ->shouldBeCalled();
-        $this->mockExecuteNpxCreate($this->newProjectDir, $localMachineHelper, $process);
-        $localMachineHelper->checkRequiredBinariesExist(["git"])
-            ->shouldBeCalled();
-        $this->mockExecuteGitInit($localMachineHelper, $this->newProjectDir, $process);
-        $this->mockExecuteGitAdd($localMachineHelper, $this->newProjectDir, $process);
-        $this->mockExecuteGitCommit($localMachineHelper, $this->newProjectDir, $process);
-
-        $this->executeCommand([
-            '--template' => 'acquia_next_acms',
-            'directory' => 'nextjs',
-        ]);
-
-        $output = $this->getDisplay();
-        $this->assertStringContainsString('Acquia recommends most customers use acquia/drupal-recommended-project to setup a Drupal project', $output);
-        $this->assertStringContainsString('acquia/next-acms', $output);
-        $this->assertTrue($mockFileSystem->isAbsolutePath($this->newProjectDir), 'Directory path is not absolute');
-        $this->assertStringContainsString('New Next.js project created in ' . $this->newProjectDir, $output);
     }
 
     protected function mockExecuteComposerCreate(
@@ -186,24 +99,6 @@ class NewCommandTest extends CommandTestBase
             $project,
             $projectDir,
             '--no-interaction',
-        ];
-        $localMachineHelper
-            ->execute($command)
-            ->willReturn($process->reveal())
-            ->shouldBeCalled();
-    }
-
-    protected function mockExecuteNpxCreate(
-        string $projectDir,
-        ObjectProphecy $localMachineHelper,
-        ObjectProphecy $process,
-    ): void {
-        $command = [
-            'npx',
-            'create-next-app',
-            '-e',
-            'https://github.com/acquia/next-acms/tree/main/starters/basic-starter',
-            $projectDir,
         ];
         $localMachineHelper
             ->execute($command)


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Next ACMS hasn't been maintained for over two years. I don't think we recommend this to customers anymore so we should remove it from the list of recommended installs.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Removed the Next ACMS options from the `app:new` command.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
We could choose to maintain the Next ACMS app, but that's would be a product decision. We should get someone from the Product org to approve this PR.

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Run the `app:new` command. You should see two options. Prior to the PR, there were three options. I also added an assertion to `testNewDrupalCommand` that asserts this option is not there.

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. Check for regressions: (add specific steps for this pr)
4. Check new functionality: (add specific steps for this pr)
