### PR TITLE
CLI-1725: Remove embedded links from Megger MEO commands

### DIFF
--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -155,7 +155,6 @@ class ApiBaseCommand extends CommandBase
                 unset($value['_links']);
             }
         }
-        unset($value);
     }
 
     public function setMethod(string $method): void

--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -130,7 +130,7 @@ class ApiBaseCommand extends CommandBase
             $exitCode = 1;
         }
 
-        if (substr($this->path, 0, 12) === '/translation') {
+        if (substr($this->path, 0, 12) === '/translation' || $this->isMeoCommand()) {
             $this->mungeResponse($response);
         }
         if ($exitCode || !$this->getParamFromInput($input, 'task-wait')) {
@@ -501,5 +501,23 @@ class ApiBaseCommand extends CommandBase
             return $array;
         }
         return $this->doCastParamType('array', $originalValue);
+    }
+
+    /**
+     * Check if this command is one of the MEO commands that should have _links removed.
+     */
+    private function isMeoCommand(): bool
+    {
+        $commandName = $this->getName();
+        $meoCommands = [
+            'api:codebases:sites-list',
+            'api:environments:sites-list',
+            'api:site-instances:find',
+            'api:site-instances:database',
+            'api:site-instances:database:backups',
+            'api:site-instances:domains',
+            'api:site-instances:domain:add',
+        ];
+        return in_array($commandName, $meoCommands, true);
     }
 }

--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -148,11 +148,14 @@ class ApiBaseCommand extends CommandBase
         if (is_object($response) && property_exists($response, '_links')) {
             unset($response->_links);
         }
-        foreach ($response as $value) {
-            if (property_exists($value, '_links')) {
+        foreach ($response as &$value) {
+            if (is_object($value) && property_exists($value, '_links')) {
                 unset($value->_links);
+            } elseif (is_array($value) && array_key_exists('_links', $value)) {
+                unset($value['_links']);
             }
         }
+        unset($value);
     }
 
     public function setMethod(string $method): void

--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -143,7 +143,7 @@ class ApiBaseCommand extends CommandBase
         return $success ? Command::SUCCESS : Command::FAILURE;
     }
 
-    private function mungeResponse(mixed $response): void
+    private function mungeResponse(mixed &$response): void
     {
         if (is_object($response) && property_exists($response, '_links')) {
             unset($response->_links);


### PR DESCRIPTION
## Motivation
Fixes #CLI-1725

As a product owner for the MEO Sites APIs, we do not want embedded links exposed in API responses via ACLI, so that customers are not tempted to follow links that may point to unsupported endpoints.

## Proposed changes

- **Strip `_links` from MEO command responses** in `ApiBaseCommand`:
  - Added `isMeoCommand()` to detect the seven MEO commands that must not expose `_links`.
  - Added `mungeResponse()` to remove top-level `_links` and `_links` from each item in responses. The method handles both object properties (via `property_exists`) and array elements (via `array_key_exists`), since some MEO endpoints return nested arrays (e.g. `site_instances`) rather than objects.
  - After receiving the API response, MEO commands (and existing translation-path commands) call `mungeResponse()` before output so `_links` are not shown to the user.

- **Commands affected** (any top-level `_links` object is stripped before output):
  - `api:codebases:sites-list`
  - `api:environments:sites-list`
  - `api:site-instances:find`
  - `api:site-instances:database`
  - `api:site-instances:database:backups`
  - `api:site-instances:domains`
  - `api:site-instances:domain:add`

- **Tests**
  - Unit tests in `ApiCommandTest` to ensure MEO commands remove `_links` from array and object responses, and that non-MEO commands still return `_links`.
  - Mutation coverage for the new MEO/munge logic.

## Alternatives considered
N/A

## Testing steps

1. Follow the [contribution guide](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#building-and-testing) to set up your development environment or [download a pre-built acli.phar](https://github.com/acquia/cli/blob/HEAD/CONTRIBUTING.md#automatic-dev-builds) for this PR.
2. If running from source, clear the kernel cache to pick up new and changed commands: `./bin/acli ckc`
3. **Check for regressions**
   - Run a non-MEO API command that returns HAL (e.g. `acli api:accounts:ssh-keys-list`) and confirm the response still includes `_links` where the API provides them.
   - Run a few existing API commands and confirm behavior and output format are unchanged.
4. **Check new functionality**
   - Run each of the MEO commands above with valid arguments (e.g. `acli api:codebases:sites-list <codebaseId>`, `acli api:environments:sites-list <environmentId>`, etc.).
   - Confirm that the JSON output does **not** contain a top-level `_links` key and that list items do **not** contain `_links`.
   - Confirm that all other response fields (ids, names, data, etc.) are unchanged.
5. Run the test suite: `composer test` (or `./vendor/bin/phpunit`). Ensure the new MEO tests and existing API tests pass.
