### PR TITLE
CLI-1760: getSolrConfigSetId - MEO Support for Search Configuration Set.

### DIFF
--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -532,6 +532,6 @@ class ApiBaseCommand extends CommandBase
      */
     private function isRewrittenMeoPath(): bool
     {
-        return getenv('AH_CODEBASE_UUID') && str_starts_with($this->path, '/applications/');
+        return self::getCodebaseUuid() && str_starts_with($this->path, '/applications/');
     }
 }

--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -130,7 +130,7 @@ class ApiBaseCommand extends CommandBase
             $exitCode = 1;
         }
 
-        if (substr($this->path, 0, 12) === '/translation' || $this->isMeoCommand()) {
+        if (substr($this->path, 0, 12) === '/translation' || $this->isMeoCommand() || $this->isRewrittenMeoPath()) {
             $this->mungeResponse($response);
         }
         if ($exitCode || !$this->getParamFromInput($input, 'task-wait')) {
@@ -521,5 +521,17 @@ class ApiBaseCommand extends CommandBase
             'api:site-instances:domain:add',
         ];
         return in_array($commandName, $meoCommands, true);
+    }
+
+    /**
+     * Check if the command path will be rewritten by PathRewriteConnector for MEO.
+     *
+     * When AH_CODEBASE_UUID is set, PathRewriteConnector rewrites /applications/{uuid}/...
+     * to /translation/codebases/{codebaseUuid}/..., so response _links may contain
+     * translation API paths that should not be exposed to customers.
+     */
+    private function isRewrittenMeoPath(): bool
+    {
+        return getenv('AH_CODEBASE_UUID') && str_starts_with($this->path, '/applications/');
     }
 }

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -19,10 +19,23 @@ use Symfony\Component\Yaml\Yaml;
  */
 class ApiCommandTest extends CommandTestBase
 {
+    private string|false $originalCodebaseUuid;
+
     public function setUp(): void
     {
         parent::setUp();
         putenv('ACQUIA_CLI_USE_CLOUD_API_SPEC_CACHE=1');
+        $this->originalCodebaseUuid = getenv('AH_CODEBASE_UUID');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalCodebaseUuid === false) {
+            putenv('AH_CODEBASE_UUID');
+        } else {
+            putenv('AH_CODEBASE_UUID=' . $this->originalCodebaseUuid);
+        }
+        parent::tearDown();
     }
 
     protected function createCommand(): CommandBase
@@ -1205,8 +1218,6 @@ EOD;
         $this->assertArrayNotHasKey('_links', $decoded, 'Rewritten MEO path must remove _links from response');
         $this->assertEquals('shared-1234567891011-121', $decoded['id']);
         $this->assertEquals('example-0', $decoded['label']);
-
-        putenv('AH_CODEBASE_UUID');
     }
 
     /**

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -1165,4 +1165,85 @@ EOD;
         $this->assertEquals(1, $decoded[0]['id']);
         $this->assertEquals('site2', $decoded[1]['name']);
     }
+
+    /**
+     * When AH_CODEBASE_UUID is set, PathRewriteConnector rewrites /applications/{uuid}/...
+     * paths. Response _links must be stripped to avoid exposing translation API paths.
+     */
+    public function testRewrittenMeoPathRemovesLinksFromResponse(): void
+    {
+        putenv('AH_CODEBASE_UUID=test-codebase-uuid');
+
+        $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
+            ->shouldBeCalled();
+
+        $mockResponse = (object) [
+            'id' => 'shared-1234567891011-121',
+            'label' => 'example-0',
+            '_links' => (object) [
+                'self' => (object) ['href' => '/api/config-sets/shared-1234567891011-121'],
+            ],
+        ];
+
+        $this->command = $this->getApiCommandByName('api:applications:search:configuration-set-find');
+        $this->clientProphecy->request(
+            $this->command->getMethod(),
+            '/applications/da1c0a8e-ff69-45db-88fc-acd6d2affbb7/search/config-sets/test-config-set-id'
+        )
+            ->willReturn($mockResponse)
+            ->shouldBeCalled();
+
+        $this->executeCommand([
+            'applicationUuid' => 'da1c0a8e-ff69-45db-88fc-acd6d2affbb7',
+            'configurationSetId' => 'test-config-set-id',
+        ]);
+
+        $output = $this->getDisplay();
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertArrayNotHasKey('_links', $decoded, 'Rewritten MEO path must remove _links from response');
+        $this->assertEquals('shared-1234567891011-121', $decoded['id']);
+        $this->assertEquals('example-0', $decoded['label']);
+
+        putenv('AH_CODEBASE_UUID');
+    }
+
+    /**
+     * When AH_CODEBASE_UUID is NOT set, /applications/ commands must preserve _links.
+     */
+    public function testNonMeoApplicationCommandPreservesLinks(): void
+    {
+        putenv('AH_CODEBASE_UUID');
+
+        $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
+            ->shouldBeCalled();
+
+        $mockResponse = (object) [
+            'id' => 'shared-1234567891011-121',
+            'label' => 'example-0',
+            '_links' => (object) [
+                'self' => (object) ['href' => '/api/config-sets/shared-1234567891011-121'],
+            ],
+        ];
+
+        $this->command = $this->getApiCommandByName('api:applications:search:configuration-set-find');
+        $this->clientProphecy->request(
+            $this->command->getMethod(),
+            '/applications/da1c0a8e-ff69-45db-88fc-acd6d2affbb7/search/config-sets/test-config-set-id'
+        )
+            ->willReturn($mockResponse)
+            ->shouldBeCalled();
+
+        $this->executeCommand([
+            'applicationUuid' => 'da1c0a8e-ff69-45db-88fc-acd6d2affbb7',
+            'configurationSetId' => 'test-config-set-id',
+        ]);
+
+        $output = $this->getDisplay();
+        $decoded = json_decode($output, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('_links', $decoded, 'Non-MEO application command must preserve _links');
+    }
 }


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1760

**Proposed changes**
TBD
     
**Testing steps**
AH_CODEBASE_UUID='your-codebase-uuid' acli api:applications:search:configuration-set-find 'applicationUuid' 'configurationSetId' 

