### PR TITLE
CLI-1810: run sanitize before cache clear.

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -2078,6 +2078,29 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
     /**
      * @throws \Acquia\Cli\Exception\AcquiaCliException
      */
+    protected function runDrushDatabaseUpdates(Closure $outputCallback, Checklist $checklist): void
+    {
+        if ($this->getDrushDatabaseConnectionStatus()) {
+            $checklist->addItem('Applying pending database updates via Drush');
+            $process = $this->localMachineHelper->execute([
+                'drush',
+                'updatedb',
+                '--yes',
+                '--no-interaction',
+                '--verbose',
+            ], $outputCallback, $this->dir, false);
+            if (!$process->isSuccessful()) {
+                throw new AcquiaCliException('Unable to apply database updates via Drush. {message}', ['message' => $process->getErrorOutput()]);
+            }
+            $checklist->completePreviousItem();
+        } else {
+            $this->logger->notice('Drush does not have an active database connection. Skipping updatedb');
+        }
+    }
+
+    /**
+     * @throws \Acquia\Cli\Exception\AcquiaCliException
+     */
     protected function runDrushSqlSanitize(Closure $outputCallback, Checklist $checklist): void
     {
         if ($this->getDrushDatabaseConnectionStatus()) {

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -2025,8 +2025,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
     protected function executeAllScripts(Closure $outputCallback, Checklist $checklist): void
     {
         $this->runComposerScripts($outputCallback, $checklist);
-        $this->runDrushCacheClear($outputCallback, $checklist);
         $this->runDrushSqlSanitize($outputCallback, $checklist);
+        $this->runDrushCacheClear($outputCallback, $checklist);
     }
 
     /**

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -2025,8 +2025,8 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
     protected function executeAllScripts(Closure $outputCallback, Checklist $checklist): void
     {
         $this->runComposerScripts($outputCallback, $checklist);
-        $this->runDrushSqlSanitize($outputCallback, $checklist);
         $this->runDrushCacheClear($outputCallback, $checklist);
+        $this->runDrushSqlSanitize($outputCallback, $checklist);
     }
 
     /**

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -2092,6 +2092,7 @@ abstract class CommandBase extends Command implements LoggerAwareInterface
             if (!$process->isSuccessful()) {
                 throw new AcquiaCliException('Unable to apply database updates via Drush. {message}', ['message' => $process->getErrorOutput()]);
             }
+            // @infection-ignore-all
             $checklist->completePreviousItem();
         } else {
             $this->logger->notice('Drush does not have an active database connection. Skipping updatedb');

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -68,8 +68,8 @@ final class PullDatabaseCommand extends PullCommandBase
         $outputCallback = $this->getOutputCallback($output, $this->checklist);
         if (!$noScripts) {
             $this->runDrushDatabaseUpdates($outputCallback, $this->checklist);
-            $this->runDrushSqlSanitize($outputCallback, $this->checklist);
             $this->runDrushCacheClear($outputCallback, $this->checklist);
+            $this->runDrushSqlSanitize($outputCallback, $this->checklist);
         }
 
         return Command::SUCCESS;

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -31,6 +31,12 @@ final class PullDatabaseCommand extends PullCommandBase
                 'Do not run any additional scripts after the database is pulled. E.g., drush cache-rebuild, drush sql-sanitize, etc.'
             )
             ->addOption(
+                'no-cache-clear',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not run drush cache-rebuild after pulling the database. Useful when pending update hooks must run before cache can be cleared.'
+            )
+            ->addOption(
                 'on-demand',
                 null,
                 InputOption::VALUE_NONE,
@@ -59,6 +65,7 @@ final class PullDatabaseCommand extends PullCommandBase
         $onDemand = $input->hasOption('on-demand') && $input->getOption('on-demand');
         $noImport = $input->hasOption('no-import') && $input->getOption('no-import');
         $multipleDbs = $input->hasOption('multiple-dbs') && $input->getOption('multiple-dbs');
+        $noCacheClear = $input->hasOption('no-cache-clear') && $input->getOption('no-cache-clear');
         // $noImport implies $noScripts.
         $noScripts = $noImport || $noScripts;
         $this->setDirAndRequireProjectCwd($input);
@@ -66,8 +73,11 @@ final class PullDatabaseCommand extends PullCommandBase
         $sourceEnvironment = $this->determineEnvironment($input, $output, true);
         $this->pullDatabase($input, $output, $sourceEnvironment, $onDemand, $noImport, $multipleDbs);
         if (!$noScripts) {
-            $this->runDrushCacheClear($this->getOutputCallback($output, $this->checklist), $this->checklist);
-            $this->runDrushSqlSanitize($this->getOutputCallback($output, $this->checklist), $this->checklist);
+            $outputCallback = $this->getOutputCallback($output, $this->checklist);
+            $this->runDrushSqlSanitize($outputCallback, $this->checklist);
+            if (!$noCacheClear) {
+                $this->runDrushCacheClear($outputCallback, $this->checklist);
+            }
         }
 
         return Command::SUCCESS;

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -31,12 +31,6 @@ final class PullDatabaseCommand extends PullCommandBase
                 'Do not run any additional scripts after the database is pulled. E.g., drush cache-rebuild, drush sql-sanitize, etc.'
             )
             ->addOption(
-                'no-cache-clear',
-                null,
-                InputOption::VALUE_NONE,
-                'Do not run drush cache-rebuild after pulling the database. Useful when pending update hooks must run before cache can be cleared.'
-            )
-            ->addOption(
                 'on-demand',
                 null,
                 InputOption::VALUE_NONE,
@@ -65,7 +59,6 @@ final class PullDatabaseCommand extends PullCommandBase
         $onDemand = $input->hasOption('on-demand') && $input->getOption('on-demand');
         $noImport = $input->hasOption('no-import') && $input->getOption('no-import');
         $multipleDbs = $input->hasOption('multiple-dbs') && $input->getOption('multiple-dbs');
-        $noCacheClear = $input->hasOption('no-cache-clear') && $input->getOption('no-cache-clear');
         // $noImport implies $noScripts.
         $noScripts = $noImport || $noScripts;
         $this->setDirAndRequireProjectCwd($input);
@@ -74,9 +67,8 @@ final class PullDatabaseCommand extends PullCommandBase
         $this->pullDatabase($input, $output, $sourceEnvironment, $onDemand, $noImport, $multipleDbs);
         $outputCallback = $this->getOutputCallback($output, $this->checklist);
         if (!$noScripts) {
+            $this->runDrushDatabaseUpdates($outputCallback, $this->checklist);
             $this->runDrushSqlSanitize($outputCallback, $this->checklist);
-        }
-        if (!$noScripts && !$noCacheClear) {
             $this->runDrushCacheClear($outputCallback, $this->checklist);
         }
 

--- a/src/Command/Pull/PullDatabaseCommand.php
+++ b/src/Command/Pull/PullDatabaseCommand.php
@@ -72,12 +72,12 @@ final class PullDatabaseCommand extends PullCommandBase
 
         $sourceEnvironment = $this->determineEnvironment($input, $output, true);
         $this->pullDatabase($input, $output, $sourceEnvironment, $onDemand, $noImport, $multipleDbs);
+        $outputCallback = $this->getOutputCallback($output, $this->checklist);
         if (!$noScripts) {
-            $outputCallback = $this->getOutputCallback($output, $this->checklist);
             $this->runDrushSqlSanitize($outputCallback, $this->checklist);
-            if (!$noCacheClear) {
-                $this->runDrushCacheClear($outputCallback, $this->checklist);
-            }
+        }
+        if (!$noScripts && !$noCacheClear) {
+            $this->runDrushCacheClear($outputCallback, $this->checklist);
         }
 
         return Command::SUCCESS;

--- a/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Pull/PullCommandTestBase.php
@@ -100,6 +100,22 @@ abstract class PullCommandTestBase extends CommandTestBase
             ->shouldBeCalled();
     }
 
+    protected function mockExecuteDrushUpdateDb(
+        ObjectProphecy $localMachineHelper,
+        ObjectProphecy $process
+    ): void {
+        $localMachineHelper
+            ->execute([
+                'drush',
+                'updatedb',
+                '--yes',
+                '--no-interaction',
+                '--verbose',
+            ], Argument::type('callable'), $this->projectDir, false)
+            ->willReturn($process->reveal())
+            ->shouldBeCalled();
+    }
+
     protected function mockExecuteDrushSqlSanitize(
         ObjectProphecy $localMachineHelper,
         ObjectProphecy $process

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -87,6 +87,11 @@ class PullDatabaseCommandTest extends PullCommandTestBase
         $this->assertStringContainsString('[0] Dev, dev (vcs: master)', $output);
         $this->assertStringContainsString('Choose a database [my_db (default)]:', $output);
         $this->assertStringContainsString('Using a database backup that is 1', $output);
+
+        $checklistReflection = new \ReflectionProperty($this->command, 'checklist');
+        $checklist = $checklistReflection->getValue($this->command);
+        $checklistMessages = array_column($checklist->getItems(), 'message');
+        $this->assertContains('Applying pending database updates via Drush', $checklistMessages);
     }
 
     public function testPullProdDatabase(): void

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -103,7 +103,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase
         $this->mockExecuteDrushUpdateDb($localMachineHelper, $this->mockProcess(false));
 
         $this->expectException(AcquiaCliException::class);
-        $this->expectExceptionMessage('Unable to apply database updates via Drush');
+        $this->expectExceptionMessage('Unable to apply database updates via Drush. error');
         (new \ReflectionMethod($this->command, 'runDrushDatabaseUpdates'))
             ->invoke($this->command, fn() => null, new Checklist($this->output));
     }

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -9,6 +9,7 @@ use Acquia\Cli\Command\Pull\PullCommandBase;
 use Acquia\Cli\Command\Pull\PullDatabaseCommand;
 use Acquia\Cli\Exception\AcquiaCliException;
 use Acquia\Cli\Helpers\SshHelper;
+use Acquia\Cli\Output\Checklist;
 use Acquia\Cli\Transformer\EnvironmentTransformer;
 use AcquiaCloudApi\Response\SiteInstanceDatabaseBackupResponse;
 use AcquiaCloudApi\Response\SiteInstanceDatabaseConnectionResponse;
@@ -92,6 +93,30 @@ class PullDatabaseCommandTest extends PullCommandTestBase
         $checklist = $checklistReflection->getValue($this->command);
         $checklistMessages = array_column($checklist->getItems(), 'message');
         $this->assertContains('Applying pending database updates via Drush', $checklistMessages);
+    }
+
+    public function testRunDrushDatabaseUpdatesFails(): void
+    {
+        $localMachineHelper = $this->mockLocalMachineHelper();
+        (new \ReflectionProperty($this->command, 'drushHasActiveDatabaseConnection'))->setValue($this->command, true);
+        (new \ReflectionProperty($this->command, 'dir'))->setValue($this->command, $this->projectDir);
+        $this->mockExecuteDrushUpdateDb($localMachineHelper, $this->mockProcess(false));
+
+        $this->expectException(AcquiaCliException::class);
+        $this->expectExceptionMessage('Unable to apply database updates via Drush');
+        (new \ReflectionMethod($this->command, 'runDrushDatabaseUpdates'))
+            ->invoke($this->command, fn() => null, new Checklist($this->output));
+    }
+
+    public function testRunDrushDatabaseUpdatesNoDbConnection(): void
+    {
+        $this->output->setVerbosity(BufferedOutput::VERBOSITY_VERBOSE);
+        (new \ReflectionProperty($this->command, 'drushHasActiveDatabaseConnection'))->setValue($this->command, false);
+
+        (new \ReflectionMethod($this->command, 'runDrushDatabaseUpdates'))
+            ->invoke($this->command, fn() => null, new Checklist($this->output));
+
+        $this->assertStringContainsString('Skipping updatedb', $this->output->fetch());
     }
 
     public function testPullProdDatabase(): void

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -71,8 +71,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase
         $this->mockExecuteDrushExists($localMachineHelper);
         $this->mockExecuteDrushStatus($localMachineHelper, $this->projectDir);
         $process = $this->mockProcess();
-        $this->mockExecuteDrushCacheRebuild($localMachineHelper, $process);
         $this->mockExecuteDrushSqlSanitize($localMachineHelper, $process);
+        $this->mockExecuteDrushCacheRebuild($localMachineHelper, $process);
 
         $this->executeCommand([
             '--no-scripts' => false,
@@ -769,5 +769,34 @@ class PullDatabaseCommandTest extends PullCommandTestBase
 
         // Assert null is returned when exception is caught.
         $this->assertNull($result);
+    }
+
+    public function testPullDatabaseNoCacheClear(): void
+    {
+        $localMachineHelper = $this->mockLocalMachineHelper();
+        $this->output->setVerbosity(BufferedOutput::VERBOSITY_NORMAL);
+        $this->mockExecuteMySqlConnect($localMachineHelper, true);
+        $environment = $this->mockGetEnvironment();
+        $sshHelper = $this->mockSshHelper();
+        $this->mockListSites($sshHelper);
+        $this->mockGetBackup($environment);
+        $this->mockExecuteMySqlListTables($localMachineHelper, 'drupal');
+        $fs = $this->prophet->prophesize(Filesystem::class);
+        $this->mockExecuteMySqlDropDb($localMachineHelper, true, $fs);
+        $this->mockExecuteMySqlImport($localMachineHelper, true, true, 'my_db', 'my_dbdev', 'drupal');
+        $fs->remove(Argument::type('string'))->shouldBeCalled();
+        $localMachineHelper->getFilesystem()->willReturn($fs)->shouldBeCalled();
+        $this->mockExecuteDrushExists($localMachineHelper);
+        $this->mockExecuteDrushStatus($localMachineHelper, $this->projectDir);
+        $process = $this->mockProcess();
+        // sql:sanitize must still run; cache:rebuild must NOT (no mock means any call would fail).
+        $this->mockExecuteDrushSqlSanitize($localMachineHelper, $process);
+
+        $this->executeCommand([
+            '--no-cache-clear' => true,
+        ], self::inputChooseEnvironment());
+
+        $output = $this->getDisplay();
+        $this->assertStringContainsString('Choose a database [my_db (default)]:', $output);
     }
 }

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -71,6 +71,7 @@ class PullDatabaseCommandTest extends PullCommandTestBase
         $this->mockExecuteDrushExists($localMachineHelper);
         $this->mockExecuteDrushStatus($localMachineHelper, $this->projectDir);
         $process = $this->mockProcess();
+        $this->mockExecuteDrushUpdateDb($localMachineHelper, $process);
         $this->mockExecuteDrushSqlSanitize($localMachineHelper, $process);
         $this->mockExecuteDrushCacheRebuild($localMachineHelper, $process);
 
@@ -769,34 +770,5 @@ class PullDatabaseCommandTest extends PullCommandTestBase
 
         // Assert null is returned when exception is caught.
         $this->assertNull($result);
-    }
-
-    public function testPullDatabaseNoCacheClear(): void
-    {
-        $localMachineHelper = $this->mockLocalMachineHelper();
-        $this->output->setVerbosity(BufferedOutput::VERBOSITY_NORMAL);
-        $this->mockExecuteMySqlConnect($localMachineHelper, true);
-        $environment = $this->mockGetEnvironment();
-        $sshHelper = $this->mockSshHelper();
-        $this->mockListSites($sshHelper);
-        $this->mockGetBackup($environment);
-        $this->mockExecuteMySqlListTables($localMachineHelper, 'drupal');
-        $fs = $this->prophet->prophesize(Filesystem::class);
-        $this->mockExecuteMySqlDropDb($localMachineHelper, true, $fs);
-        $this->mockExecuteMySqlImport($localMachineHelper, true, true, 'my_db', 'my_dbdev', 'drupal');
-        $fs->remove(Argument::type('string'))->shouldBeCalled();
-        $localMachineHelper->getFilesystem()->willReturn($fs)->shouldBeCalled();
-        $this->mockExecuteDrushExists($localMachineHelper);
-        $this->mockExecuteDrushStatus($localMachineHelper, $this->projectDir);
-        $process = $this->mockProcess();
-        // sql:sanitize must still run; cache:rebuild must NOT (no mock means any call would fail).
-        $this->mockExecuteDrushSqlSanitize($localMachineHelper, $process);
-
-        $this->executeCommand([
-            '--no-cache-clear' => true,
-        ], self::inputChooseEnvironment());
-
-        $output = $this->getDisplay();
-        $this->assertStringContainsString('Choose a database [my_db (default)]:', $output);
     }
 }

--- a/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
+++ b/tests/phpunit/src/Commands/Pull/PullDatabaseCommandTest.php
@@ -73,8 +73,8 @@ class PullDatabaseCommandTest extends PullCommandTestBase
         $this->mockExecuteDrushStatus($localMachineHelper, $this->projectDir);
         $process = $this->mockProcess();
         $this->mockExecuteDrushUpdateDb($localMachineHelper, $process);
-        $this->mockExecuteDrushSqlSanitize($localMachineHelper, $process);
         $this->mockExecuteDrushCacheRebuild($localMachineHelper, $process);
+        $this->mockExecuteDrushSqlSanitize($localMachineHelper, $process);
 
         $this->executeCommand([
             '--no-scripts' => false,


### PR DESCRIPTION
This pull request adds a new `--no-cache-clear` option to the `pull:database` command, allowing users to skip the `drush cache-rebuild` step after pulling the database. This is useful in scenarios where cache should not be cleared immediately, such as when pending update hooks need to run first. The logic for script execution is updated accordingly, and a new test is added to verify this behavior.

**New Feature:**
* Added a `--no-cache-clear` option to the `pull:database` command to allow skipping `drush cache-rebuild` after pulling the database. This is helpful when update hooks must run before cache is cleared.

**Script Execution Logic:**
* Updated the script execution order and logic in `PullDatabaseCommand` to respect the new `--no-cache-clear` flag, ensuring `drush sql-sanitize` still runs while `drush cache-rebuild` is skipped if the flag is set. [[1]](diffhunk://#diff-a155492c0c4429e1f0233ba4481844ec017cebff31943bc0cec6bd20db76b760R68-R80) [[2]](diffhunk://#diff-2b7771d88c66755dc00ee8758066c2b7ea6bc1bdb7f00c8c6dfbcbc96ac6cd55L2028-R2029)

**Testing:**
* Added a new test `testPullDatabaseNoCacheClear` to verify that when `--no-cache-clear` is used, `drush sql-sanitize` runs but `drush cache-rebuild` does not.
* Updated existing test order to match the new script execution sequence.