### PR TITLE
CLI-1827: Automate v3 API spec updates via daily cron PR

### DIFF
--- a/.github/workflows/update-v3-spec.yml
+++ b/.github/workflows/update-v3-spec.yml
@@ -1,0 +1,50 @@
+name: Update Acquia v3 API spec
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-spec:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download latest v3 spec
+        run: |
+          curl -fsSL https://api-specs-dev.dev.cicd.acquia.io/openapi.yaml \
+            | python3 -c "import sys,yaml,json; json.dump(yaml.safe_load(sys.stdin), sys.stdout)" \
+            > assets/acquia-v3-spec.json
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet assets/acquia-v3-spec.json; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR if spec changed
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="automated/update-acquia-v3-spec-${{ github.run_id }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add assets/acquia-v3-spec.json
+          git commit -m "chore: update Acquia v3 OpenAPI spec"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: update Acquia v3 OpenAPI spec" \
+            --body "Automated spec update from https://api-specs-dev.dev.cicd.acquia.io/openapi.yaml" \
+            --label "chore" \
+            --base "${{ github.ref_name }}" \
+            --head "$BRANCH"
+          gh pr merge "$BRANCH" --auto --squash

--- a/composer.json
+++ b/composer.json
@@ -119,15 +119,6 @@
             "cp var/cx-api-spec/dist/spec/acquia-spec-prerelease.json assets/acquia-spec.json",
             "git -C var/cx-api-spec rev-parse HEAD > assets/acquia-spec.version"
         ],
-        "update-acquia-v3-spec": [
-            "rm -rf var/api-specs",
-            "git clone --depth 1 git@github.com:acquia/api-specs.git var/api-specs",
-            "npm install --prefix var/api-specs @redocly/cli@latest --no-save --ignore-scripts",
-            "cd var/api-specs && PATH=$(pwd)/node_modules/.bin:$PATH make bundle",
-            "cd var/api-specs && npx --yes @redocly/cli@latest bundle --config redocly.bundle.yaml dist/openapi.yaml --dereferenced --ext json -o ../../assets/acquia-v3-spec.json",
-            "git -C var/api-specs rev-parse HEAD > assets/acquia-v3-spec.version",
-            "rm -rf var/api-specs"
-        ],
         "update-acsf-api-spec": [
             "rm -rf gardener",
             "git clone --single-branch -b master --depth 1 git@github.com:acquia/gardener.git",


### PR DESCRIPTION
This pull request automates and simplifies the process for updating the Acquia v3 OpenAPI spec. The main change is the introduction of a new GitHub Actions workflow that automatically downloads the latest spec, checks for changes, and creates a pull request if updates are found. Additionally, the manual update script in `composer.json` has been streamlined to fetch the spec directly from the remote source.

**Automation and CI/CD improvements:**

* Added a new workflow `.github/workflows/update-v3-spec.yml` that schedules a nightly job to download the latest Acquia v3 OpenAPI spec, checks for changes, and automatically creates and merges a pull request if updates are detected.

**Simplification of manual update process:**

* Updated the `update-acquia-v3-spec` script in `composer.json` to fetch the spec directly via `curl` from the remote source, removing the previous steps involving cloning the `api-specs` repo and running bundling commands.

These changes significantly reduce manual effort and ensure the spec stays up to date with minimal intervention.