### PR TITLE
CLI-1853: Force-add docroot/autoload_runtime.php to push:artifact scaffold files

### DIFF
--- a/src/Command/Push/PushArtifactCommand.php
+++ b/src/Command/Push/PushArtifactCommand.php
@@ -457,6 +457,13 @@ final class PushArtifactCommand extends CommandBase
             }
         }
         $this->scaffoldFiles[] = 'docroot/autoload.php';
+        // autoload_runtime.php was introduced in Drupal 11.4 as the Symfony
+        // Runtime bootstrap entry point. It is not in core's file-mapping so
+        // it must be force-added like autoload.php, but only when present —
+        // Drupal < 11.4 does not generate this file.
+        if (file_exists(Path::join($artifactDir, 'docroot', 'autoload_runtime.php'))) {
+            $this->scaffoldFiles[] = 'docroot/autoload_runtime.php';
+        }
 
         return $this->scaffoldFiles;
     }

--- a/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
+++ b/tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php
@@ -195,6 +195,30 @@ EOF;
         $this->assertStringNotContainsString('Pushing changes to Acquia Git (site@svn-3.hosted.acquia-sites.com:site.git)', $output);
     }
 
+    public function testPushArtifactWithoutAutoloadRuntime(): void
+    {
+        $applications = $this->mockRequest('getApplications');
+        $this->mockRequest('getApplicationByUuid', $applications[0]->uuid);
+        $environments = $this->mockRequest('getApplicationEnvironments', $applications[0]->uuid);
+        $localMachineHelper = $this->mockLocalMachineHelper();
+        $this->setUpPushArtifact($localMachineHelper, $environments[0]->vcs->path, [$environments[0]->vcs->url], 'master:master', true, true, false, true, false);
+        $inputs = [
+            // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
+            'n',
+            // Select a Cloud Platform application:
+            0,
+            // Would you like to link the project at ... ?
+            'y',
+            // Choose an Acquia environment:
+            0,
+        ];
+        $this->executeCommand(['--no-push' => true], $inputs);
+
+        $output = $this->getDisplay();
+
+        $this->assertStringContainsString('Adding and committing changed files', $output);
+    }
+
     public function testPushArtifactNoCommit(): void
     {
         $applications = $this->mockRequest('getApplications');
@@ -243,7 +267,7 @@ EOF;
         $this->assertStringNotContainsString('Adding and committing changed files', $output);
         $this->assertStringNotContainsString('Pushing changes to Acquia Git (site@svn-3.hosted.acquia-sites.com:site.git)', $output);
     }
-    protected function setUpPushArtifact(ObjectProphecy $localMachineHelper, string $vcsPath, array $vcsUrls, string $destGitRef = 'master:master', bool $clone = true, bool $commit = true, bool $push = true, bool $printOutput = true): void
+    protected function setUpPushArtifact(ObjectProphecy $localMachineHelper, string $vcsPath, array $vcsUrls, string $destGitRef = 'master:master', bool $clone = true, bool $commit = true, bool $push = true, bool $printOutput = true, bool $hasAutoloadRuntime = true): void
     {
         touch(Path::join($this->projectDir, 'composer.json'));
         mkdir(Path::join($this->projectDir, 'docroot'));
@@ -267,7 +291,7 @@ EOF;
             $this->mockCloneShallow($localMachineHelper, $vcsPath, $vcsUrls[0], $artifactDir, $printOutput);
         }
         if ($commit) {
-            $this->mockGitAddCommit($localMachineHelper, $artifactDir, $commitHash, $printOutput);
+            $this->mockGitAddCommit($localMachineHelper, $artifactDir, $commitHash, $printOutput, $hasAutoloadRuntime);
         }
         if ($push) {
             $this->mockGitPush($vcsUrls, $localMachineHelper, $artifactDir, $destGitRef, $printOutput);
@@ -340,7 +364,7 @@ EOF;
             ->willReturn($process->reveal())->shouldBeCalled();
     }
 
-    protected function mockGitAddCommit(ObjectProphecy $localMachineHelper, string $artifactDir, string $commitHash, bool $printOutput): void
+    protected function mockGitAddCommit(ObjectProphecy $localMachineHelper, string $artifactDir, string $commitHash, bool $printOutput, bool $hasAutoloadRuntime = true): void
     {
         $process = $this->mockProcess();
         $localMachineHelper->execute([
@@ -363,6 +387,22 @@ EOF;
             'docroot/autoload.php',
         ], null, $artifactDir, false)
             ->willReturn($process->reveal())->shouldBeCalled();
+        $runtimeFile = Path::join($artifactDir, 'docroot', 'autoload_runtime.php');
+        if ($hasAutoloadRuntime) {
+            // Simulate Drupal 11.4+ where autoload_runtime.php is generated.
+            @mkdir(Path::join($artifactDir, 'docroot'), 0777, true);
+            touch($runtimeFile);
+            $localMachineHelper->execute([
+                'git',
+                'add',
+                '-f',
+                'docroot/autoload_runtime.php',
+            ], null, $artifactDir, false)
+                ->willReturn($process->reveal())->shouldBeCalled();
+        } else {
+            // Simulate Drupal < 11.4 where autoload_runtime.php is absent.
+            @unlink($runtimeFile);
+        }
         $localMachineHelper->execute([
             'git',
             'add',


### PR DESCRIPTION
## Summary

Drupal 11.4 introduced `docroot/autoload_runtime.php` as a Symfony Runtime bootstrap entry point, generated by `drupal/core-composer-scaffold`. Because this file is typically listed in `docroot/.gitignore`, `git add -A` does not pick it up during `push:artifact` builds. This causes HTTP 500 errors on deployed sites because the bootstrap file is missing from the artifact.

**Changes:**
- Add `docroot/autoload_runtime.php` to the `scaffoldFiles()` hardcoded list alongside `docroot/autoload.php`, using a `file_exists` guard so it is only force-added when present (backwards compatible with Drupal < 11.4).
- Update `mockGitAddCommit()` in `PushArtifactCommandTest` to accept a `$hasAutoloadRuntime` flag that creates the file on disk (triggering the `file_exists` check) and adds the corresponding mock expectation.
- Add `testPushArtifactWithoutAutoloadRuntime` to cover the Drupal < 11.4 case (file absent, `git add -f` not called).

## Root cause

`scaffoldFiles()` at `PushArtifactCommand.php` explicitly force-adds `docroot/autoload.php` (and other core scaffold files) because `git add -A` respects `.gitignore`. The same pattern is needed for `autoload_runtime.php`, which Drupal 11.4 added as a new scaffold file that is gitignored by default.

## Test plan

- [ ] `php vendor/bin/phpunit tests/phpunit/src/Commands/Push/PushArtifactCommandTest.php` — all 10 tests pass
- [ ] Manually run `acli push:artifact` against a Drupal 11.4 site — verify `autoload_runtime.php` is committed to the artifact branch
- [ ] Run against a Drupal < 11.4 site — verify no errors and the file is not force-added

Fixes: CLI-1853

🤖 Generated with [Claude Code](https://claude.com/claude-code)