### PR TITLE
CLI-1779: Restrict empty-body JSON fallback to POST only

### DIFF
--- a/src/Command/Api/ApiBaseCommand.php
+++ b/src/Command/Api/ApiBaseCommand.php
@@ -114,6 +114,16 @@ class ApiBaseCommand extends CommandBase
         $acquiaCloudClient->addOption('headers', [
             'Accept' => 'application/hal+json, version=2',
         ]);
+        // Some POST endpoints have no request body (e.g. schedule-delete). The
+        // Cloud Platform API requires both a Content-Type header and a body for
+        // all POST requests. Guzzle's `json` option satisfies both; passing an
+        // empty object sends `{}` with Content-Type: application/json.
+        // PUT/PATCH endpoints with no body (e.g. site-instances:domain:add) must
+        // not send `{}`: Guzzle creates a non-seekable stream which triggers
+        // `curl_setopt_array(): Stream does not support seeking`.
+        if (strtoupper($this->method) === 'POST' && empty($this->postParams)) {
+            $acquiaCloudClient->addOption('json', new \stdClass());
+        }
 
         try {
             if ($this->output->isVeryVerbose()) {

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -100,7 +100,7 @@ class ApiCommandTest extends CommandTestBase
         ]);
         $this->assertEquals(0, $this->getStatusCode());
     }
-  
+
     /**
      * oneOf entries that lack a 'type' key (e.g. unresolved $ref) must be
      * skipped silently rather than throwing an "Undefined array key" warning.

--- a/tests/phpunit/src/Commands/Api/ApiCommandTest.php
+++ b/tests/phpunit/src/Commands/Api/ApiCommandTest.php
@@ -59,6 +59,48 @@ class ApiCommandTest extends CommandTestBase
         $this->assertEquals(0, $this->getStatusCode());
     }
 
+    /**
+     * A body-less POST (no requestBody in the spec) must send an empty JSON
+     * object so the Cloud Platform API receives both a Content-Type header and
+     * a body, preventing HTTP 415 / HTTP 400 errors.
+     */
+    public function testBodylessPostSendsEmptyJsonBody(): void
+    {
+        $agreementUuid = 'da1c0a8e-ff69-45db-88fc-acd6d2affbb7';
+        $this->mockRequest('postAcceptAgreement', $agreementUuid);
+        $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
+            ->shouldBeCalled();
+        $this->clientProphecy->addOption('json', new \stdClass())
+            ->shouldBeCalled();
+        $this->command = $this->getApiCommandByName('api:agreements:accept');
+        $this->executeCommand(['agreementUuid' => $agreementUuid]);
+        $this->assertEquals(0, $this->getStatusCode());
+    }
+
+    /**
+     * A body-less PUT (requestBody with no properties, required: false) must
+     * NOT send `{}`. Guzzle creates a non-seekable stream for the empty object
+     * which triggers `curl_setopt_array(): Stream does not support seeking`.
+     */
+    public function testBodylessPutDoesNotSendEmptyJsonBody(): void
+    {
+        $siteId = '3e8ecbec-ea7c-4260-8414-ef2938c859bc';
+        $environmentId = 'd3f7270e-c45f-4801-9308-5e8afe84a323';
+        $domainName = 'example.com';
+        $this->mockRequest('add_domain_to_site', [$siteId, $environmentId, $domainName]);
+        $this->clientProphecy->addOption('headers', ['Accept' => 'application/hal+json, version=2'])
+            ->shouldBeCalled();
+        $this->clientProphecy->addOption('json', new \stdClass())
+            ->shouldNotBeCalled();
+        $this->command = $this->getApiCommandByName('api:site-instances:domain:add');
+        $this->executeCommand([
+            'domainName' => $domainName,
+            'environmentId' => $environmentId,
+            'siteId' => $siteId,
+        ]);
+        $this->assertEquals(0, $this->getStatusCode());
+    }
+
     public function testTaskWait(): void
     {
         $environmentId = '24-a47ac10b-58cc-4372-a567-0e02b2c3d470';


### PR DESCRIPTION
## Summary

- `ApiBaseCommand::execute` previously sent `{}` as a JSON body for any POST/PUT/PATCH with no post params
- For `PUT /site-instances/{siteId}.{environmentId}/domains/{domainName}` (`api:site-instances:domain:add`), this triggered `curl_setopt_array(): Stream does not support seeking` — PHP curl cannot seek on the non-seekable stream Guzzle creates for the empty `stdClass`
- Fix restricts the empty-body guard to POST only; PUT/PATCH endpoints without a body schema send no body at all

## Test plan

- [ ] `testBodylessPostSendsEmptyJsonBody` — POST with no body still sends `{}`
- [ ] `testPostWithBodyDoesNotSendEmptyFallback` — POST with body does not get the empty fallback
- [ ] `testBodylessPutDoesNotSendEmptyJsonBody` — PUT with no body does NOT send `{}` (regression test for CLI-1779)
- [ ] Run `acli api:site-instances:domain:add` against a real environment to confirm the PHP warning is gone

🤖 Generated with [Claude Code](https://claude.ai/claude-code)