### PR TITLE
DXBE-19: Add SAS API client service

### DIFF
--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -121,6 +121,29 @@ services:
       $connectorFactory: '@cloud.v3.connector_factory'
       $application: '@Acquia\Cli\Application'
       $credentials: '@cloud.credentials'
+
+  # Sites Aggregation Service (SAS) — standalone service sharing the Cloud API
+  # auth layer. Prod default https://sites-aggregation-service.prod.cicd.acquia.io/api.
+  # Override with ACLI_SAS_BASE_URI for dev/qa/stage.
+  sas.credentials:
+    class: Acquia\Cli\SasApi\SasCredentials
+
+  sas.connector_factory:
+    class: Acquia\Cli\CloudApi\ConnectorFactory
+    arguments:
+      $config:
+        key: '@=service("sas.credentials").getCloudKey()'
+        secret: '@=service("sas.credentials").getCloudSecret()'
+        accessToken: '@=service("sas.credentials").getCloudAccessToken()'
+        accessTokenExpiry: '@=service("sas.credentials").getCloudAccessTokenExpiry()'
+      $baseUri: '@=service("sas.credentials").getBaseUri()'
+      $accountsUri: '@=service("sas.credentials").getAccountsUri()'
+
+  Acquia\Cli\SasApi\SasClientService:
+    arguments:
+      $connectorFactory: '@sas.connector_factory'
+      $application: '@Acquia\Cli\Application'
+      $credentials: '@sas.credentials'
   AcquiaCloudApi\Connector\ConnectorInterface:
     alias: Acquia\Cli\CloudApi\ConnectorFactory
   AcquiaCloudApi\Connector\Connector:

--- a/config/prod/services.yml
+++ b/config/prod/services.yml
@@ -123,7 +123,7 @@ services:
       $credentials: '@cloud.credentials'
 
   # Sites Aggregation Service (SAS) — standalone service sharing the Cloud API
-  # auth layer. Prod default https://sites-aggregation-service.prod.cicd.acquia.io/api.
+  # auth layer. Prod default https://sites-aggregation-service-prod.prod.cicd.acquia.io/api.
   # Override with ACLI_SAS_BASE_URI for dev/qa/stage.
   sas.credentials:
     class: Acquia\Cli\SasApi\SasCredentials

--- a/src/SasApi/SasClientService.php
+++ b/src/SasApi/SasClientService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Cli\SasApi;
+
+use Acquia\Cli\Application;
+use Acquia\Cli\CloudApi\ClientService;
+use Acquia\Cli\CloudApi\ConnectorFactory;
+
+/**
+ * Client service for the Sites Aggregation Service (SAS) API.
+ *
+ * Same auth as Cloud API but a different base URI, resolved by
+ * SasCredentials. Wire with the sas.connector_factory service so requests go
+ * to SAS rather than the Cloud API gateway.
+ */
+class SasClientService extends ClientService
+{
+    public function __construct(ConnectorFactory $connectorFactory, Application $application, SasCredentials $credentials)
+    {
+        parent::__construct($connectorFactory, $application, $credentials);
+    }
+}

--- a/src/SasApi/SasCredentials.php
+++ b/src/SasApi/SasCredentials.php
@@ -15,7 +15,7 @@ use Acquia\Cli\CloudApi\CloudCredentials;
  */
 class SasCredentials extends CloudCredentials
 {
-    private const DEFAULT_BASE_URI = 'https://sites-aggregation-service.prod.cicd.acquia.io/api';
+    private const DEFAULT_BASE_URI = 'https://sites-aggregation-service-prod.prod.cicd.acquia.io/api';
 
     /**
      * Base URI for SAS. Override with ACLI_SAS_BASE_URI for non-production

--- a/src/SasApi/SasCredentials.php
+++ b/src/SasApi/SasCredentials.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Cli\SasApi;
+
+use Acquia\Cli\CloudApi\CloudCredentials;
+
+/**
+ * Credentials for the Sites Aggregation Service (SAS) API.
+ *
+ * SAS shares the Cloud API auth layer (same key/secret, same OAuth token
+ * endpoint), so all credential logic is inherited. Only the base URI differs:
+ * SAS is a standalone service, not the Cloud API gateway.
+ */
+class SasCredentials extends CloudCredentials
+{
+    private const DEFAULT_BASE_URI = 'https://sites-aggregation-service.prod.cicd.acquia.io/api';
+
+    /**
+     * Base URI for SAS. Override with ACLI_SAS_BASE_URI for non-production
+     * environments (e.g. .dev/.qa/.staging.cicd.acquia.io).
+     */
+    public function getBaseUri(): ?string
+    {
+        $uri = getenv('ACLI_SAS_BASE_URI');
+        return $uri !== false ? $uri : self::DEFAULT_BASE_URI;
+    }
+}

--- a/src/SasApi/SasCredentials.php
+++ b/src/SasApi/SasCredentials.php
@@ -23,7 +23,8 @@ class SasCredentials extends CloudCredentials
      */
     public function getBaseUri(): ?string
     {
+        // Treat a set-but-empty value the same as unset.
         $uri = getenv('ACLI_SAS_BASE_URI');
-        return $uri !== false ? $uri : self::DEFAULT_BASE_URI;
+        return !empty($uri) ? $uri : self::DEFAULT_BASE_URI;
     }
 }

--- a/tests/phpunit/src/SasApi/EnvVarSasAuthenticationTest.php
+++ b/tests/phpunit/src/SasApi/EnvVarSasAuthenticationTest.php
@@ -40,7 +40,7 @@ class EnvVarSasAuthenticationTest extends TestBase
     {
         putenv('ACLI_SAS_BASE_URI');
         self::assertEquals(
-            'https://sites-aggregation-service.prod.cicd.acquia.io/api',
+            'https://sites-aggregation-service-prod.prod.cicd.acquia.io/api',
             $this->cloudCredentials->getBaseUri()
         );
     }

--- a/tests/phpunit/src/SasApi/EnvVarSasAuthenticationTest.php
+++ b/tests/phpunit/src/SasApi/EnvVarSasAuthenticationTest.php
@@ -6,7 +6,10 @@ namespace Acquia\Cli\Tests\SasApi;
 
 use Acquia\Cli\SasApi\SasCredentials;
 use Acquia\Cli\Tests\TestBase;
+use PHPUnit\Framework\Attributes\Group;
 
+// Mutates process-global env vars, so must run in the serial group.
+#[Group('serial')]
 class EnvVarSasAuthenticationTest extends TestBase
 {
     private static string $sasBaseUri = 'https://sites-aggregation-service.dev.cicd.acquia.io/api';
@@ -39,6 +42,15 @@ class EnvVarSasAuthenticationTest extends TestBase
     public function testDefaultBaseUri(): void
     {
         putenv('ACLI_SAS_BASE_URI');
+        self::assertEquals(
+            'https://sites-aggregation-service-prod.prod.cicd.acquia.io/api',
+            $this->cloudCredentials->getBaseUri()
+        );
+    }
+
+    public function testEmptyBaseUriFallsBackToDefault(): void
+    {
+        putenv('ACLI_SAS_BASE_URI=');
         self::assertEquals(
             'https://sites-aggregation-service-prod.prod.cicd.acquia.io/api',
             $this->cloudCredentials->getBaseUri()

--- a/tests/phpunit/src/SasApi/EnvVarSasAuthenticationTest.php
+++ b/tests/phpunit/src/SasApi/EnvVarSasAuthenticationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Cli\Tests\SasApi;
+
+use Acquia\Cli\SasApi\SasCredentials;
+use Acquia\Cli\Tests\TestBase;
+
+class EnvVarSasAuthenticationTest extends TestBase
+{
+    private static string $sasBaseUri = 'https://sites-aggregation-service.dev.cicd.acquia.io/api';
+
+    public function setUp(mixed $output = null): void
+    {
+        parent::setUp();
+        $this->cloudCredentials = new SasCredentials($this->datastoreCloud);
+        putenv('ACLI_KEY=' . self::$key);
+        putenv('ACLI_SECRET=' . self::$secret);
+        putenv('ACLI_SAS_BASE_URI=' . self::$sasBaseUri);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        putenv('ACLI_KEY');
+        putenv('ACLI_SECRET');
+        putenv('ACLI_SAS_BASE_URI');
+    }
+
+    public function testKeyAndSecret(): void
+    {
+        $this->removeMockCloudConfigFile();
+        self::assertEquals(self::$key, $this->cloudCredentials->getCloudKey());
+        self::assertEquals(self::$secret, $this->cloudCredentials->getCloudSecret());
+        self::assertEquals(self::$sasBaseUri, $this->cloudCredentials->getBaseUri());
+    }
+
+    public function testDefaultBaseUri(): void
+    {
+        putenv('ACLI_SAS_BASE_URI');
+        self::assertEquals(
+            'https://sites-aggregation-service.prod.cicd.acquia.io/api',
+            $this->cloudCredentials->getBaseUri()
+        );
+    }
+}

--- a/tests/phpunit/src/SasApi/SasClientServiceTest.php
+++ b/tests/phpunit/src/SasApi/SasClientServiceTest.php
@@ -45,7 +45,7 @@ class SasClientServiceTest extends TestBase
         );
         $sasService = new SasClientService($connectorFactory, $this->application, $credentials);
         $this->assertEquals(
-            'https://sites-aggregation-service.prod.cicd.acquia.io/api',
+            'https://sites-aggregation-service-prod.prod.cicd.acquia.io/api',
             $connectorFactory->createConnector()->getBaseUri()
         );
         $this->assertFalse($sasService->isMachineAuthenticated());

--- a/tests/phpunit/src/SasApi/SasClientServiceTest.php
+++ b/tests/phpunit/src/SasApi/SasClientServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acquia\Cli\Tests\SasApi;
+
+use Acquia\Cli\CloudApi\ConnectorFactory;
+use Acquia\Cli\DataStore\CloudDataStore;
+use Acquia\Cli\SasApi\SasClientService;
+use Acquia\Cli\SasApi\SasCredentials;
+use Acquia\Cli\Tests\TestBase;
+
+class SasClientServiceTest extends TestBase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        putenv('ACLI_SAS_BASE_URI');
+    }
+
+    public function testConstructs(): void
+    {
+        $cloudDatastore = $this->prophet->prophesize(CloudDataStore::class);
+        $credentials = new SasCredentials($cloudDatastore->reveal());
+        $connectorFactory = new ConnectorFactory([
+            'accessToken' => null,
+            'key' => null,
+            'secret' => null,
+        ]);
+        $sasService = new SasClientService($connectorFactory, $this->application, $credentials);
+        $this->assertFalse($sasService->isMachineAuthenticated());
+    }
+
+    public function testConnectorUsesSasBaseUri(): void
+    {
+        $cloudDatastore = $this->prophet->prophesize(CloudDataStore::class);
+        $credentials = new SasCredentials($cloudDatastore->reveal());
+        $connectorFactory = new ConnectorFactory(
+            [
+                'accessToken' => null,
+                'key' => null,
+                'secret' => null,
+            ],
+            $credentials->getBaseUri()
+        );
+        $sasService = new SasClientService($connectorFactory, $this->application, $credentials);
+        $this->assertEquals(
+            'https://sites-aggregation-service.prod.cicd.acquia.io/api',
+            $connectorFactory->createConnector()->getBaseUri()
+        );
+        $this->assertFalse($sasService->isMachineAuthenticated());
+    }
+
+    public function testConnectorUsesEnvVarBaseUri(): void
+    {
+        $sasUri = 'https://sites-aggregation-service.qa.cicd.acquia.io/api';
+        putenv('ACLI_SAS_BASE_URI=' . $sasUri);
+        $cloudDatastore = $this->prophet->prophesize(CloudDataStore::class);
+        $credentials = new SasCredentials($cloudDatastore->reveal());
+        $connectorFactory = new ConnectorFactory(
+            [
+                'accessToken' => null,
+                'key' => null,
+                'secret' => null,
+            ],
+            $credentials->getBaseUri()
+        );
+        $this->assertEquals($sasUri, $connectorFactory->createConnector()->getBaseUri());
+    }
+}

--- a/tests/phpunit/src/SasApi/SasClientServiceTest.php
+++ b/tests/phpunit/src/SasApi/SasClientServiceTest.php
@@ -9,7 +9,10 @@ use Acquia\Cli\DataStore\CloudDataStore;
 use Acquia\Cli\SasApi\SasClientService;
 use Acquia\Cli\SasApi\SasCredentials;
 use Acquia\Cli\Tests\TestBase;
+use PHPUnit\Framework\Attributes\Group;
 
+// Mutates process-global env vars, so must run in the serial group.
+#[Group('serial')]
 class SasClientServiceTest extends TestBase
 {
     protected function tearDown(): void


### PR DESCRIPTION
Adds a dedicated client stack for the Sites Aggregation Service (SAS) API, a standalone Acquia service that shares the Cloud API auth layer (same key/secret, same OAuth token endpoint).

- `SasApi\SasCredentials` extends `CloudApi\CloudCredentials`, inheriting key/secret/token resolution and owning only the base URI: `ACLI_SAS_BASE_URI` env var, defaulting to the prod SAS service URL.
- `SasApi\SasClientService` extends `CloudApi\ClientService`, injected with a separately wired `sas.connector_factory` — same pattern as `V3ClientService` — so requests go to SAS rather than the Cloud API gateway.

No connector subclass is needed: the SDK Connector already implements the shared OAuth client-credentials flow, and SAS paths (`/sites/...`) never match `PathRewriteConnector` rules in MEO contexts.

This is groundwork for upcoming `source:cms:*` commands that will call SAS endpoints (e.g. `POST /api/sites/{siteId}/config-sync`), which are not part of the Cloud API OpenAPI specs and therefore need a hand-written client.