### PR TITLE
CLI-0001: Update github token keyname.

### DIFF
--- a/.github/workflows/update-v3-spec.yml
+++ b/.github/workflows/update-v3-spec.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Create PR if spec changed
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="automated/update-acquia-v3-spec-${{ github.run_id }}"
           git config user.name "github-actions[bot]"
@@ -55,4 +55,4 @@ jobs:
             --label "chore" \
             --base "${{ github.ref_name }}" \
             --head "$BRANCH"
-          gh pr merge "$BRANCH" --auto --squash
+          # gh pr merge "$BRANCH" --auto --squash

--- a/.github/workflows/update-v3-spec.yml
+++ b/.github/workflows/update-v3-spec.yml
@@ -37,22 +37,27 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create PR if spec changed
+      - name: Create or update PR if spec changed
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="automated/update-acquia-v3-spec-${{ github.run_id }}"
+          BRANCH="automated/update-acquia-v3-spec"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add assets/acquia-v3-spec.json assets/acquia-v3-spec.version
           git commit -m "chore: update Acquia v3 OpenAPI spec"
-          git push origin "$BRANCH"
-          gh pr create \
-            --title "chore: update Acquia v3 OpenAPI spec" \
-            --body "Automated update of the Acquia v3 OpenAPI spec." \
-            --label "chore" \
-            --base "${{ github.ref_name }}" \
-            --head "$BRANCH"
+          git push origin "$BRANCH" --force
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Updating existing PR #$EXISTING_PR"
+          else
+            gh pr create \
+              --title "chore: update Acquia v3 OpenAPI spec" \
+              --body "Automated update of the Acquia v3 OpenAPI spec." \
+              --label "chore" \
+              --base "${{ github.ref_name }}" \
+              --head "$BRANCH"
+          fi
           # gh pr merge "$BRANCH" --auto --squash


### PR DESCRIPTION
This pull request makes minor updates to the GitHub Actions workflow for updating the v3 spec. The main changes involve adjusting authentication and modifying the pull request merging step.

- **Workflow Authentication:**
  - Switched from using the `GH_TOKEN` secret to the built-in `GITHUB_TOKEN` for authentication in the workflow, which is more standard and secure for GitHub Actions.

- **Pull Request Merging:**
  - Commented out the automatic pull request merge command (`gh pr merge`), so pull requests will no longer be merged automatically by the workflow.