### PR TITLE
CLI-1871: Add sync-skills GitHub Actions workflow.

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,0 +1,53 @@
+name: Sync ACLI skills
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force PR even if no skill files changed'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  sync-skills:
+    runs-on: ubuntu-24.04
+    name: Sync skills to acquia-skills repo
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v7
+
+      - name: Resolve version tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Read Acquia spec version
+        id: spec
+        run: echo "version=$(cat assets/acquia-spec.version)" >> $GITHUB_OUTPUT
+
+      - name: Download ACLI binary
+        run: |
+          curl -fsSL "https://github.com/acquia/cli/releases/download/${{ steps.version.outputs.tag }}/acli.phar" \
+            -o /usr/local/bin/acli
+          chmod +x /usr/local/bin/acli
+
+      - name: Generate commands JSON
+        run: acli list --format=json > /tmp/acli-commands.json
+
+      - name: Dispatch sync event to acquia-skills
+        env:
+          GH_TOKEN: ${{ secrets.ACQUIA_SKILLS_PAT }}
+        run: |
+          gh api repos/acquia/acquia-skills/dispatches \
+            --method POST \
+            --field event_type=sync-acli-skills \
+            --field "client_payload[acli_version]=${{ steps.version.outputs.tag }}" \
+            --field "client_payload[spec_version]=${{ steps.spec.outputs.version }}" \
+            --field "client_payload[force]=${{ inputs.force || false }}"

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      tag:
+        description: 'ACLI release tag to sync (defaults to latest release)'
+        required: false
+        type: string
       force:
         description: 'Force PR even if no skill files changed'
         required: false
@@ -19,6 +23,11 @@ jobs:
       - name: Checkout release commit
         uses: actions/checkout@v7
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
       - name: Resolve version tag
         id: version
         run: |
@@ -35,9 +44,9 @@ jobs:
       - name: Download ACLI binary
         run: |
           curl -fsSL "https://github.com/acquia/cli/releases/download/${{ steps.version.outputs.tag }}/acli.phar" \
-            -o /usr/local/bin/acli
-          chmod +x /usr/local/bin/acli
-
+            -o "$RUNNER_TEMP/acli"
+          chmod +x "$RUNNER_TEMP/acli"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
       - name: Generate commands JSON
         run: acli list --format=json > /tmp/acli-commands.json
 

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -20,17 +20,23 @@ jobs:
     runs-on: ubuntu-24.04
     name: Sync skills to acquia-skills repo
     steps:
-      - name: Checkout release commit
-        uses: actions/checkout@v7
-
       - name: Resolve version tag
         id: version
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
-          else
+          elif [ -n "${{ inputs.tag }}" ]; then
             echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$(gh release view --repo acquia/cli --json tagName --jq '.tagName')" >> $GITHUB_OUTPUT
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout release commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.version.outputs.tag }}
 
       - name: Dispatch sync event to acquia-skills
         env:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -23,32 +23,14 @@ jobs:
       - name: Checkout release commit
         uses: actions/checkout@v7
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          coverage: none
       - name: Resolve version tag
         id: version
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
           fi
-
-      - name: Read Acquia spec version
-        id: spec
-        run: echo "version=$(cat assets/acquia-spec.version)" >> $GITHUB_OUTPUT
-
-      - name: Download ACLI binary
-        run: |
-          curl -fsSL "https://github.com/acquia/cli/releases/download/${{ steps.version.outputs.tag }}/acli.phar" \
-            -o "$RUNNER_TEMP/acli"
-          chmod +x "$RUNNER_TEMP/acli"
-          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
-      - name: Generate commands JSON
-        run: acli list --format=json > /tmp/acli-commands.json
 
       - name: Dispatch sync event to acquia-skills
         env:
@@ -58,5 +40,5 @@ jobs:
             --method POST \
             --field event_type=sync-acli-skills \
             --field "client_payload[acli_version]=${{ steps.version.outputs.tag }}" \
-            --field "client_payload[spec_version]=${{ steps.spec.outputs.version }}" \
+            --field "client_payload[spec_version]=$(cat assets/acquia-spec.version)" \
             --field "client_payload[force]=${{ inputs.force || false }}"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow, `sync-skills.yml`, to automate syncing ACLI skills with the `acquia-skills` repository. The workflow is triggered on releases and manual dispatch, and it handles version resolution, downloads the ACLI binary, generates command data, and dispatches a sync event to the target repository.

Workflow automation:

* Added `.github/workflows/sync-skills.yml` to automate syncing ACLI skills to the `acquia-skills` repository on release or manual trigger, including options for forced syncs.
* The workflow resolves the correct version tag, reads the Acquia spec version, downloads the appropriate ACLI binary, generates a JSON list of commands, and triggers a repository dispatch event with relevant payload data.