### PR TITLE
CLI-1837: remote:ssh should accept environmentId

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7849,16 +7849,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.10.2",
+            "version": "2.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "8d4439f572a97670a9edc039eb3b093cc976b4bc"
+                "reference": "f0de0bf90226853b841672f086d8b58b02332504"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/8d4439f572a97670a9edc039eb3b093cc976b4bc",
-                "reference": "8d4439f572a97670a9edc039eb3b093cc976b4bc",
+                "url": "https://api.github.com/repos/composer/composer/zipball/f0de0bf90226853b841672f086d8b58b02332504",
+                "reference": "f0de0bf90226853b841672f086d8b58b02332504",
                 "shasum": ""
             },
             "require": {
@@ -7869,6 +7869,8 @@
                 "composer/semver": "^3.3",
                 "composer/spdx-licenses": "^1.5.7",
                 "composer/xdebug-handler": "^2.0.2 || ^3.0.3",
+                "ext-filter": "*",
+                "ext-hash": "*",
                 "ext-json": "*",
                 "justinrainbow/json-schema": "^6.5.1",
                 "php": "^7.2.5 || ^8.0",
@@ -7946,7 +7948,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.10.2"
+                "source": "https://github.com/composer/composer/tree/2.10.3"
             },
             "funding": [
                 {
@@ -7958,7 +7960,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-01T09:24:45+00:00"
+            "time": "2026-08-27T11:34:23+00:00"
         },
         {
             "name": "composer/metadata-minifier",

--- a/src/Command/Remote/SshCommand.php
+++ b/src/Command/Remote/SshCommand.php
@@ -21,18 +21,17 @@ final class SshCommand extends SshBaseCommand
     protected function configure(): void
     {
         $this
-            ->addArgument('alias', InputArgument::REQUIRED, 'Alias for application & environment in the format `app-name.env`')
+            ->acceptEnvironmentId()
             ->addArgument('ssh_command', InputArgument::IS_ARRAY, 'Command to run via SSH (if not provided, opens a shell in the site directory)')
             ->addUsage("myapp.dev # open a shell in the myapp.dev environment")
-            ->addUsage("myapp.dev -- ls -al # list files in the myapp.dev environment and return");
+            ->addUsage("myapp.dev -- ls -al # list files in the myapp.dev environment and return")
+            ->addUsage("12345-abcd1234-1111-2222-3333-0e02b2c3d470 -- ls -al");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
-        $alias = $input->getArgument('alias');
-        $alias = $this->normalizeAlias($alias);
-        $alias = self::validateEnvironmentAlias($alias);
-        $environment = $this->getEnvironmentFromAliasArg($alias);
+        $environment = $this->determineEnvironment($input, $output, true);
+        $alias = self::getEnvironmentAlias($environment);
         if (!isset($environment->sshUrl)) {
             throw new AcquiaCliException('Cannot determine environment SSH URL. Check that you have SSH permissions on this environment.');
         }

--- a/tests/phpunit/src/Commands/Remote/SshCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTest.php
@@ -6,9 +6,7 @@ namespace Acquia\Cli\Tests\Commands\Remote;
 
 use Acquia\Cli\Command\CommandBase;
 use Acquia\Cli\Command\Remote\SshCommand;
-use Acquia\Cli\Command\Self\ClearCacheCommand;
 use Acquia\Cli\Helpers\SshHelper;
-use PHPUnit\Framework\Attributes\Group;
 use Prophecy\Argument;
 
 /**
@@ -21,11 +19,9 @@ class SshCommandTest extends SshCommandTestBase
         return $this->injectCommand(SshCommand::class);
     }
 
-    #[Group('serial')]
-    public function testRemoteAliasesDownloadCommand(): void
+    public function testRemoteSshCommand(): void
     {
-        ClearCacheCommand::clearCaches();
-        $this->mockForGetEnvironmentFromAliasArg();
+        $this->mockGetEnvironment();
         [$process, $localMachineHelper] = $this->mockForExecuteCommand();
         $localMachineHelper->checkRequiredBinariesExist(['ssh'])
             ->shouldBeCalled();
@@ -36,7 +32,7 @@ class SshCommandTest extends SshCommandTestBase
             '-o StrictHostKeyChecking=accept-new',
             '-o AddressFamily inet',
             '-o LogLevel=ERROR',
-            'cd /var/www/html/devcloud2.dev; exec $SHELL -l',
+            'cd /var/www/html/site.dev; exec $SHELL -l',
         ];
         $localMachineHelper
             ->execute($sshCommand, Argument::type('callable'), null, true, null, null)
@@ -44,13 +40,34 @@ class SshCommandTest extends SshCommandTestBase
             ->shouldBeCalled();
 
         $this->command->sshHelper = new SshHelper($this->output, $localMachineHelper->reveal(), $this->logger);
+        $this->executeCommand(['ssh_command' => []], self::inputChooseEnvironment());
 
-        $args = [
-            'alias' => 'devcloud2.dev',
+        $this->getDisplay();
+    }
+
+    public function testRemoteSshCommandWithEnvUuid(): void
+    {
+        $this->mockRequest('getEnvironment', '24-a47ac10b-58cc-4372-a567-0e02b2c3d470');
+        [$process, $localMachineHelper] = $this->mockForExecuteCommand();
+        $localMachineHelper->checkRequiredBinariesExist(['ssh'])
+            ->shouldBeCalled();
+        $sshCommand = [
+            'ssh',
+            'site.dev@sitedev.ssh.hosted.acquia-sites.com',
+            '-t',
+            '-o StrictHostKeyChecking=accept-new',
+            '-o AddressFamily inet',
+            '-o LogLevel=ERROR',
+            'cd /var/www/html/site.dev; exec $SHELL -l',
         ];
-        $this->executeCommand($args);
+        $localMachineHelper
+            ->execute($sshCommand, Argument::type('callable'), null, true, null, null)
+            ->willReturn($process->reveal())
+            ->shouldBeCalled();
 
-        // Assert.
-        $output = $this->getDisplay();
+        $this->command->sshHelper = new SshHelper($this->output, $localMachineHelper->reveal(), $this->logger);
+        $this->executeCommand(['environmentId' => '24-a47ac10b-58cc-4372-a567-0e02b2c3d470']);
+
+        $this->getDisplay();
     }
 }

--- a/tests/phpunit/src/Commands/Remote/SshCommandTest.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTest.php
@@ -45,6 +45,41 @@ class SshCommandTest extends SshCommandTestBase
         $this->getDisplay();
     }
 
+    public function testRemoteSshCommandAllowsProductionEnvironment(): void
+    {
+        $this->mockGetEnvironment();
+        [$process, $localMachineHelper] = $this->mockForExecuteCommand();
+        $localMachineHelper->checkRequiredBinariesExist(['ssh'])
+            ->shouldBeCalled();
+        $sshCommand = [
+            'ssh',
+            'site.prod@siteprod.ssh.hosted.acquia-sites.com',
+            '-t',
+            '-o StrictHostKeyChecking=accept-new',
+            '-o AddressFamily inet',
+            '-o LogLevel=ERROR',
+            'cd /var/www/html/site.prod; exec $SHELL -l',
+        ];
+        $localMachineHelper
+            ->execute($sshCommand, Argument::type('callable'), null, true, null, null)
+            ->willReturn($process->reveal())
+            ->shouldBeCalled();
+
+        $this->command->sshHelper = new SshHelper($this->output, $localMachineHelper->reveal(), $this->logger);
+        $this->executeCommand(['ssh_command' => []], [
+            // Would you like Acquia CLI to search for a Cloud application that matches your local git config?
+            'n',
+            // Select a Cloud Platform application:
+            self::$INPUT_DEFAULT_CHOICE,
+            // Would you like to link the project at ... ?
+            'n',
+            // Choose a Cloud Platform environment (index 1 = prod):
+            1,
+        ]);
+
+        $this->getDisplay();
+    }
+
     public function testRemoteSshCommandWithEnvUuid(): void
     {
         $this->mockRequest('getEnvironment', '24-a47ac10b-58cc-4372-a567-0e02b2c3d470');

--- a/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
+++ b/tests/phpunit/src/Commands/Remote/SshCommandTestBase.php
@@ -10,15 +10,6 @@ use Symfony\Component\Process\Process;
 
 abstract class SshCommandTestBase extends CommandTestBase
 {
-    protected function mockForGetEnvironmentFromAliasArg(): void
-    {
-        $applicationsResponse = $this->mockApplicationsRequest(1);
-        $this->mockEnvironmentsRequest($applicationsResponse);
-        $this->clientProphecy->addQuery('filter', 'hosting=@*:devcloud2')
-            ->shouldBeCalled();
-        $this->mockRequest('getAccount');
-    }
-
     /**
      * @return array<mixed>
      */


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes CLI-1837

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
- Accept standard environmentID
- Improve test coverage for this command (renames alias download command)